### PR TITLE
Cleanup the snapshots in E2E test app

### DIFF
--- a/packages/e2e-test-app-fabric/test/__snapshots__/ActivityIndicatorComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/ActivityIndicatorComponentTest.test.ts.snap
@@ -4,402 +4,206 @@ exports[`ActivityIndicator Tests An ActivityIndicator can have custom colors 1`]
 {
   "Automation Tree": {
     "AutomationId": "activity-color",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "activity-color",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              20,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          111,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              20,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          336,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              20,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          561,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              20,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          786,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "activity-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      36,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 36",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "111, 8, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "20, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "336, 8, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "20, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "561, 8, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "20, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "786, 8, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "20, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -408,402 +212,206 @@ exports[`ActivityIndicator Tests An ActivityIndicator can have custom colors and
 {
   "Automation Tree": {
     "AutomationId": "activity-large-color",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50012,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "progress bar",
-        "Name": "",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "activity-large-color",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              36,
-              36,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          103,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          36,
-          36,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              36,
-              36,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          328,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          36,
-          36,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              36,
-              36,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          553,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          36,
-          36,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              36,
-              36,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      80,
-                      80,
-                    ],
-                    "Visual Type": "Visual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "Visual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          778,
-          8,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          36,
-          36,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "activity-large-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      52,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 52",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "103, 8, 0",
+        "Size": "36, 36",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "36, 36",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "328, 8, 0",
+        "Size": "36, 36",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "36, 36",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "553, 8, 0",
+        "Size": "36, 36",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "36, 36",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "778, 8, 0",
+        "Size": "36, 36",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "36, 36",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "Visual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "80, 80",
+                    "Visual Type": "Visual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -813,24 +421,18 @@ exports[`ActivityIndicator Tests An ActivityIndicator can have custom sizing 1`]
   "Automation Tree": {
     "AutomationId": "activity-size",
     "ControlType": 50012,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "progress bar",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+    "_Props": {
+      "TestId": "activity-size",
+    },
   },
   "Visual Tree": {
     "Comment": "activity-size",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      36,
-      36,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "36, 36",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -841,24 +443,18 @@ exports[`ActivityIndicator Tests An ActivityIndicator can have large sizing 1`] 
   "Automation Tree": {
     "AutomationId": "activity-large",
     "ControlType": 50012,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "progress bar",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+    "_Props": {
+      "TestId": "activity-large",
+    },
   },
   "Visual Tree": {
     "Comment": "activity-large",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      36,
-      36,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "36, 36",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -869,24 +465,18 @@ exports[`ActivityIndicator Tests An ActivityIndicator can have styling 1`] = `
   "Automation Tree": {
     "AutomationId": "activity-gray",
     "ControlType": 50012,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "progress bar",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+    "_Props": {
+      "TestId": "activity-gray",
+    },
   },
   "Visual Tree": {
     "Comment": "activity-gray",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      20,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "20, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -897,24 +487,18 @@ exports[`ActivityIndicator Tests An ActivityIndicator can have toggle animation 
   "Automation Tree": {
     "AutomationId": "activity-toggle",
     "ControlType": 50012,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "progress bar",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+    "_Props": {
+      "TestId": "activity-toggle",
+    },
   },
   "Visual Tree": {
     "Comment": "activity-toggle",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      36,
-      36,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "36, 36",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -925,24 +509,20 @@ exports[`ActivityIndicator Tests An ActivityIndicator can render 1`] = `
   "Automation Tree": {
     "AutomationId": "default_activity_indicator",
     "ControlType": 50012,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "progress bar",
     "Name": "Wait for content to load!",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ActivityIndicatorComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Wait for content to load!",
+      "TestId": "default_activity_indicator",
+    },
+  },
   "Visual Tree": {
     "Comment": "default_activity_indicator",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      20,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "20, 20",
     "Visual Type": "SpriteVisual",
   },
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/ButtonComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/ButtonComponentTest.test.ts.snap
@@ -4,259 +4,153 @@ exports[`Button Tests Buttons can be disabled 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "disabled_button",
-    "Children": [
-      {
-        "AutomationId": "",
-        "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": false,
-        "IsKeyboardFocusable": false,
-        "LocalizedControlType": "text",
-        "Name": "Submit Application",
-      },
-    ],
     "ControlType": 50000,
-    "HelpText": "",
     "IsEnabled": false,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "button",
     "Name": "Press to submit your application!",
+    "__Children": [
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "IsEnabled": false,
+        "LocalizedControlType": "text",
+        "Name": "Submit Application",
+      },
+    ],
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "disabled_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  -2,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              37,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "disabled_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 37",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, 0, 0",
+                "Size": "908, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, -2, 0",
+                "Size": "908, 2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -265,263 +159,155 @@ exports[`Button Tests Buttons can have accessibility labels 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "accessibilityLabel_button",
-    "Children": [
+    "ControlType": 50000,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "Press to submit your application!",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Submit Application",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "Press to submit your application!",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "accessibilityLabel_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "accessibilityLabel_button",
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
+        "Offset": "0, 0, 0",
+        "Size": "916, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(0, 122, 255, 255)",
             },
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  -2,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              37,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "916, 37",
             "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, 0, 0",
+                "Size": "908, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, -2, 0",
+                "Size": "908, 2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "accessibilityLabel_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -530,216 +316,129 @@ exports[`Button Tests Buttons can have accessibility props 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "accessibility_props",
-    "Children": [
+    "ControlType": 50000,
+    "HelpText": "Submit Button",
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "Press to submit your application!",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Submit Application",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "Submit Button",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "Press to submit your application!",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "accessibility_props",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -1,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          -2,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "accessibility_props",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, 0, 0",
+        "Size": "908, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-1, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, -2, 0",
+        "Size": "908, 2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -748,259 +447,153 @@ exports[`Button Tests Buttons can have accessibility states 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "accessibilityState_button",
-    "Children": [
-      {
-        "AutomationId": "",
-        "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": false,
-        "IsKeyboardFocusable": false,
-        "LocalizedControlType": "text",
-        "Name": "Submit Application",
-      },
-    ],
     "ControlType": 50000,
-    "HelpText": "",
     "IsEnabled": false,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "button",
     "Name": "Press to submit your application!",
+    "__Children": [
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "IsEnabled": false,
+        "LocalizedControlType": "text",
+        "Name": "Submit Application",
+      },
+    ],
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "accessibilityState_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  -2,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              37,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "accessibilityState_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 37",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, 0, 0",
+                "Size": "908, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, -2, 0",
+                "Size": "908, 2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1009,263 +602,155 @@ exports[`Button Tests Buttons can have custom colors 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "cancel_button",
-    "Children": [
+    "ControlType": 50000,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "Press to cancel your application!",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Cancel Application",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "Press to cancel your application!",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to cancel your application!",
+      "TestId": "cancel_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "cancel_button",
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
+        "Offset": "0, 0, 0",
+        "Size": "916, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(255, 59, 48, 255)",
             },
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  -2,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  908,
-                  2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              37,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "916, 37",
             "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, 0, 0",
+                "Size": "908, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-4, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "4, -2, 0",
+                "Size": "908, 2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -5, 0",
+                "Size": "4, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 4, 0",
+                "Size": "1, 28",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "cancel_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1273,198 +758,115 @@ exports[`Button Tests Buttons can have custom colors 1`] = `
 exports[`Button Tests Buttons can have custom focusable and accessible props 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "accessible_false_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
+  },
   "Visual Tree": {
-    "Children": [
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -1,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          -2,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "accessible_false_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, 0, 0",
+        "Size": "908, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-1, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, -2, 0",
+        "Size": "908, 2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1473,216 +875,128 @@ exports[`Button Tests Buttons can have custom focusable and accessible props 2`]
 {
   "Automation Tree": {
     "AutomationId": "focusable_false_button",
-    "Children": [
+    "ControlType": 50000,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "Press to submit your application!",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Button with focusable=false",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "Press to submit your application!",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "focusable_false_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -1,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          -2,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "focusable_false_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, 0, 0",
+        "Size": "908, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-1, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, -2, 0",
+        "Size": "908, 2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1690,198 +1004,115 @@ exports[`Button Tests Buttons can have custom focusable and accessible props 2`]
 exports[`Button Tests Buttons can have custom focusable and accessible props 3`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "accessible_focusable_false_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
+  },
   "Visual Tree": {
-    "Children": [
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -1,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          -2,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "accessible_focusable_false_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, 0, 0",
+        "Size": "908, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-1, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, -2, 0",
+        "Size": "908, 2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1890,606 +1121,354 @@ exports[`Button Tests Buttons can have flexbox styling 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "two_button_container",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "two_cancel_button",
-        "Children": [
+        "ControlType": 50000,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "button",
+        "Name": "Press to cancel your application!",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Cancel",
           },
         ],
-        "ControlType": 50000,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "button",
-        "Name": "Press to cancel your application!",
       },
       {
         "AutomationId": "two_submit_button",
-        "Children": [
+        "ControlType": 50000,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "button",
+        "Name": "Press to submit your application!",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Submit",
           },
         ],
-        "ControlType": 50000,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "button",
-        "Name": "Press to submit your application!",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "two_button_container",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "AccessibilityLabel": "Press to cancel your application!",
+          "TestId": "two_cancel_button",
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+            "_Props": {},
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "AccessibilityLabel": "Press to submit your application!",
+          "TestId": "two_submit_button",
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+            "_Props": {},
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "two_button_container",
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
+        "Offset": "0, 0, 0",
+        "Size": "59, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
-            "Children": [
+            "Comment": "two_cancel_button",
+            "Offset": "0, 0, 0",
+            "Size": "59, 37",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
+                "Offset": "0, 0, 0",
+                "Size": "59, 37",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
                   {
                     "Brush": {
                       "Brush Type": "ColorBrush",
                       "Color": "rgba(255, 59, 48, 255)",
                     },
-                    "Children": [
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          51,
-                          1,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -1,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          -2,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          51,
-                          2,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                    ],
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      59,
-                      37,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "59, 37",
                     "Visual Type": "SpriteVisual",
+                    "__Children": [
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, 0, 0",
+                        "Size": "51, 1",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-1, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, -2, 0",
+                        "Size": "51, 2",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                    ],
                   },
                   {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
                     "Visual Type": "SpriteVisual",
                   },
                 ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  59,
-                  37,
-                ],
-                "Visual Type": "SpriteVisual",
               },
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      41,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  9,
-                  9,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  41,
-                  20,
-                ],
+                "Offset": "9, 9, 0",
+                "Size": "41, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "41, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Comment": "two_cancel_button",
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              59,
-              37,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          59,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
+        "Offset": "854, 0, 0",
+        "Size": "62, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
-            "Children": [
+            "Comment": "two_submit_button",
+            "Offset": "0, 0, 0",
+            "Size": "62, 37",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
+                "Offset": "0, 0, 0",
+                "Size": "62, 37",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
                   {
                     "Brush": {
                       "Brush Type": "ColorBrush",
                       "Color": "rgba(52, 199, 89, 255)",
                     },
-                    "Children": [
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          54,
-                          1,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -1,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          -2,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          54,
-                          2,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                    ],
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      62,
-                      37,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "62, 37",
                     "Visual Type": "SpriteVisual",
+                    "__Children": [
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, 0, 0",
+                        "Size": "54, 1",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-1, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, -2, 0",
+                        "Size": "54, 2",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                    ],
                   },
                   {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
                     "Visual Type": "SpriteVisual",
                   },
                 ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  62,
-                  37,
-                ],
-                "Visual Type": "SpriteVisual",
               },
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      44,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  9,
-                  9,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  20,
-                ],
+                "Offset": "9, 9, 0",
+                "Size": "44, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "44, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Comment": "two_submit_button",
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              62,
-              37,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          854,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          62,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "two_button_container",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -2498,894 +1477,518 @@ exports[`Button Tests Buttons can have flexbox styling with three buttons 1`] = 
 {
   "Automation Tree": {
     "AutomationId": "three_button_container",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "three_cancel_button",
-        "Children": [
+        "ControlType": 50000,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "button",
+        "Name": "Press to cancel your application!",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Cancel",
           },
         ],
-        "ControlType": 50000,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "button",
-        "Name": "Press to cancel your application!",
       },
       {
         "AutomationId": "three_save_button",
-        "Children": [
+        "ControlType": 50000,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "button",
+        "Name": "Press to save your application!",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Save For Later",
           },
         ],
-        "ControlType": 50000,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "button",
-        "Name": "Press to save your application!",
       },
       {
         "AutomationId": "three_submit_button",
-        "Children": [
+        "ControlType": 50000,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "button",
+        "Name": "Press to submit your application!",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Submit",
           },
         ],
-        "ControlType": 50000,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "button",
-        "Name": "Press to submit your application!",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "three_button_container",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "AccessibilityLabel": "Press to cancel your application!",
+          "TestId": "three_cancel_button",
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+            "_Props": {},
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "AccessibilityLabel": "Press to save your application!",
+          "TestId": "three_save_button",
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+            "_Props": {},
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "AccessibilityLabel": "Press to submit your application!",
+          "TestId": "three_submit_button",
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+            "_Props": {},
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "three_button_container",
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
+        "Offset": "0, 0, 0",
+        "Size": "59, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
-            "Children": [
+            "Comment": "three_cancel_button",
+            "Offset": "0, 0, 0",
+            "Size": "59, 37",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
+                "Offset": "0, 0, 0",
+                "Size": "59, 37",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
                   {
                     "Brush": {
                       "Brush Type": "ColorBrush",
                       "Color": "rgba(255, 59, 48, 255)",
                     },
-                    "Children": [
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          51,
-                          1,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -1,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          -2,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          51,
-                          2,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                    ],
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      59,
-                      37,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "59, 37",
                     "Visual Type": "SpriteVisual",
+                    "__Children": [
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, 0, 0",
+                        "Size": "51, 1",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-1, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, -2, 0",
+                        "Size": "51, 2",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                    ],
                   },
                   {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
                     "Visual Type": "SpriteVisual",
                   },
                 ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  59,
-                  37,
-                ],
-                "Visual Type": "SpriteVisual",
               },
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      41,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  9,
-                  9,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  41,
-                  20,
-                ],
+                "Offset": "9, 9, 0",
+                "Size": "41, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "41, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Comment": "three_cancel_button",
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              59,
-              37,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          59,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
+        "Offset": "404, 0, 0",
+        "Size": "105, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
-            "Children": [
+            "Comment": "three_save_button",
+            "Offset": "0, 0, 0",
+            "Size": "105, 37",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
+                "Offset": "0, 0, 0",
+                "Size": "105, 37",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
                   {
                     "Brush": {
                       "Brush Type": "ColorBrush",
                       "Color": "rgba(0, 122, 255, 255)",
                     },
-                    "Children": [
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          97,
-                          1,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -1,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          -2,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          97,
-                          2,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                    ],
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      105,
-                      37,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "105, 37",
                     "Visual Type": "SpriteVisual",
+                    "__Children": [
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, 0, 0",
+                        "Size": "97, 1",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-1, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, -2, 0",
+                        "Size": "97, 2",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                    ],
                   },
                   {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
                     "Visual Type": "SpriteVisual",
                   },
                 ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  105,
-                  37,
-                ],
-                "Visual Type": "SpriteVisual",
               },
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      87,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  9,
-                  9,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  87,
-                  20,
-                ],
+                "Offset": "9, 9, 0",
+                "Size": "87, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "87, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Comment": "three_save_button",
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              105,
-              37,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          404,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          105,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
+        "Offset": "854, 0, 0",
+        "Size": "62, 37",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
-            "Children": [
+            "Comment": "three_submit_button",
+            "Offset": "0, 0, 0",
+            "Size": "62, 37",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
+                "Offset": "0, 0, 0",
+                "Size": "62, 37",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
                   {
                     "Brush": {
                       "Brush Type": "ColorBrush",
                       "Color": "rgba(52, 199, 89, 255)",
                     },
-                    "Children": [
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          54,
-                          1,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          0,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          4,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -1,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          -4,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          4,
-                          -2,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          54,
-                          2,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          -5,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          4,
-                          5,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                      {
-                        "Brush": {
-                          "Brush Type": "ColorBrush",
-                          "Color": "rgba(0, 0, 0, 255)",
-                        },
-                        "Offset": [
-                          0,
-                          4,
-                          0,
-                        ],
-                        "Opacity": 1,
-                        "Size": [
-                          1,
-                          28,
-                        ],
-                        "Visual Type": "SpriteVisual",
-                      },
-                    ],
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      62,
-                      37,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "62, 37",
                     "Visual Type": "SpriteVisual",
+                    "__Children": [
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, 0, 0",
+                        "Size": "54, 1",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, 0, 0",
+                        "Size": "4, 4",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-1, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "-4, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "4, -2, 0",
+                        "Size": "54, 2",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, -5, 0",
+                        "Size": "4, 5",
+                        "Visual Type": "SpriteVisual",
+                      },
+                      {
+                        "Brush": {
+                          "Brush Type": "ColorBrush",
+                          "Color": "rgba(0, 0, 0, 255)",
+                        },
+                        "Offset": "0, 4, 0",
+                        "Size": "1, 28",
+                        "Visual Type": "SpriteVisual",
+                      },
+                    ],
                   },
                   {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
                     "Visual Type": "SpriteVisual",
                   },
                 ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  62,
-                  37,
-                ],
-                "Visual Type": "SpriteVisual",
               },
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      44,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  9,
-                  9,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  20,
-                ],
+                "Offset": "9, 9, 0",
+                "Size": "44, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "44, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Comment": "three_submit_button",
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              62,
-              37,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          854,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          62,
-          37,
-        ],
-        "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "three_button_container",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3394,216 +1997,128 @@ exports[`Button Tests Buttons have default styling 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "button_default_styling",
-    "Children": [
+    "ControlType": 50000,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "Press to submit your application!",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Submit Application",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "Press to submit your application!",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Press to submit your application!",
+      "TestId": "button_default_styling",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          4,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -1,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          -4,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          4,
-          -2,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          908,
-          2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          4,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
-        },
-        "Offset": [
-          0,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              898,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          9,
-          9,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          898,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "button_default_styling",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      37,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 37",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, 0, 0",
+        "Size": "908, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, 0, 0",
+        "Size": "4, 4",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-1, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "-4, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "4, -2, 0",
+        "Size": "908, 2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, -5, 0",
+        "Size": "4, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "0, 4, 0",
+        "Size": "1, 28",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "9, 9, 0",
+        "Size": "898, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "898, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
@@ -4,168 +4,112 @@ exports[`Home UIA Tree Dump APIs Tab 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "apis-tab",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "APIs",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "apis-tab",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+            "_Props": {
+              "Sources": [
+                {
+                  "Size": "111, 72",
+                  "Type": "Local",
+                  "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/bottom-nav-apis-icon-light.png?platform=windows&hash=875572ed8afafed87f73c4c597b11835",
+                },
+              ],
+            },
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(243, 248, 255, 255)",
     },
-    "Children": [
+    "Comment": "apis-tab",
+    "Offset": "0, 0, 0",
+    "Size": "499, 65",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      30,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  235,
-                  13,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  30,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      27,
-                      19,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  236,
-                  33,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  27,
-                  19,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              499,
-              65,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          499,
-          65,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "499, 65",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "499, 65",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "235, 13, 0",
+                "Size": "30, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "30, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+              {
+                "Offset": "236, 33, 0",
+                "Size": "27, 19",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "27, 19",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "apis-tab",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      499,
-      65,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -174,284 +118,168 @@ exports[`Home UIA Tree Dump Accessibility 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Accessibility",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Accessibility Examples of using Accessibility APIs.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Accessibility",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Examples of using Accessibility APIs.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Accessibility Examples of using Accessibility APIs.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Accessibility Examples of using Accessibility APIs.",
+      "TestId": "Accessibility",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              107,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          107,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Accessibility",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "107, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "107, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -460,284 +288,168 @@ exports[`Home UIA Tree Dump Accessibility Windows 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Accessibility Windows",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Accessibility Windows Usage of accessibility properties.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Accessibility Windows",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Usage of accessibility properties.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Accessibility Windows Usage of accessibility properties.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Accessibility Windows Usage of accessibility properties.",
+      "TestId": "Accessibility Windows",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              194,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          194,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Accessibility Windows",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "194, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "194, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -746,284 +458,168 @@ exports[`Home UIA Tree Dump AccessibilityInfo 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "AccessibilityInfo",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "AccessibilityInfo Examples of using AccessibilityInfo APIs.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "AccessibilityInfo",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Examples of using AccessibilityInfo APIs.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "AccessibilityInfo Examples of using AccessibilityInfo APIs.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "AccessibilityInfo Examples of using AccessibilityInfo APIs.",
+      "TestId": "AccessibilityInfo",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              142,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          142,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "AccessibilityInfo",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "142, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "142, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1032,284 +628,168 @@ exports[`Home UIA Tree Dump ActivityIndicator 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "ActivityIndicator",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "ActivityIndicator Animated loading indicators.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ActivityIndicator",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Animated loading indicators.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "ActivityIndicator Animated loading indicators.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "ActivityIndicator Animated loading indicators.",
+      "TestId": "ActivityIndicator",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              143,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          143,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "ActivityIndicator",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "143, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "143, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1318,284 +798,168 @@ exports[`Home UIA Tree Dump Alerts 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Alerts",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Alerts Alerts display a concise and informative message and prompt the user to make a decision.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Alerts",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Alerts display a concise and informative message and prompt the user to make a decision.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Alerts Alerts display a concise and informative message and prompt the user to make a decision.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Alerts Alerts display a concise and informative message and prompt the user to make a decision.",
+      "TestId": "Alerts",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              51,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          51,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Alerts",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "51, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "51, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1604,284 +968,168 @@ exports[`Home UIA Tree Dump Animated - Gratuitous App 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Animated - Gratuitous App",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Animated - Gratuitous App Bunch of Animations - tap a circle to open a view with more animations, or longPress and drag to reorder circles.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Animated - Gratuitous App",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Bunch of Animations - tap a circle to open a view with more animations, or longPress and drag to reorder circles.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Animated - Gratuitous App Bunch of Animations - tap a circle to open a view with more animations, or longPress and drag to reorder circles.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Animated - Gratuitous App Bunch of Animations - tap a circle to open a view with more animations, or longPress and drag to reorder circles.",
+      "TestId": "Animated - Gratuitous App",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              239,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          239,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Animated - Gratuitous App",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "239, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "239, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1890,284 +1138,168 @@ exports[`Home UIA Tree Dump Animated 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Animated",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Animated Library designed to make animations fluid, powerful, and painless to build and maintain.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Animated",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Library designed to make animations fluid, powerful, and painless to build and maintain.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Animated Library designed to make animations fluid, powerful, and painless to build and maintain.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Animated Library designed to make animations fluid, powerful, and painless to build and maintain.",
+      "TestId": "Animated",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              86,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          86,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Animated",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "86, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "86, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2176,284 +1308,168 @@ exports[`Home UIA Tree Dump AppState 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "AppState",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "AppState app background status",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "AppState",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "app background status",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "AppState app background status",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "AppState app background status",
+      "TestId": "AppState",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              81,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          81,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "AppState",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "81, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "81, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2462,284 +1478,168 @@ exports[`Home UIA Tree Dump Appearance 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Appearance",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Appearance Light and dark user interface examples.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Appearance",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Light and dark user interface examples.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Appearance Light and dark user interface examples.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Appearance Light and dark user interface examples.",
+      "TestId": "Appearance",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              106,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          106,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Appearance",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "106, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "106, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2748,284 +1648,168 @@ exports[`Home UIA Tree Dump Border 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Border",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Border Demonstrates some of the border styles available to Views.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Border",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Demonstrates some of the border styles available to Views.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Border Demonstrates some of the border styles available to Views.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Border Demonstrates some of the border styles available to Views.",
+      "TestId": "Border",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Border",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "60, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "60, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -3034,284 +1818,168 @@ exports[`Home UIA Tree Dump Button 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Button Simple React Native button component.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Button",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Simple React Native button component.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Button Simple React Native button component.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Button Simple React Native button component.",
+      "TestId": "Button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "60, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "60, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -3320,272 +1988,152 @@ exports[`Home UIA Tree Dump Components Tab 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "components-tab",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Components",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "components-tab",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+            "_Props": {
+              "Sources": [
+                {
+                  "Size": "66, 72",
+                  "Type": "Local",
+                  "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/bottom-nav-components-icon-dark.png?platform=windows&hash=40b81f6ff9fc225d33fa501761a0cccd",
+                },
+              ],
+            },
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(243, 248, 255, 255)",
     },
-    "Children": [
+    "Comment": "components-tab",
+    "Offset": "0, 0, 0",
+    "Size": "499, 65",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -0,
-                  2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -0,
-                  2,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  2,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      20,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  240,
-                  14,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  20,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      81,
-                      19,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  209,
-                  34,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  81,
-                  19,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              499,
-              65,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          499,
-          65,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "499, 65",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "499, 65",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "0, 2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 0, 0",
+                "Size": "-0, 2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-0, 0, 0",
+                "Size": "0, 2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-0, 2, 0",
+                "Size": "0, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-0, -0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -0, 0",
+                "Size": "-0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 2, 0",
+                "Size": "0, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "240, 14, 0",
+                "Size": "20, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "20, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+              {
+                "Offset": "209, 34, 0",
+                "Size": "81, 19",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "81, 19",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "components-tab",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      499,
-      65,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3594,284 +2142,168 @@ exports[`Home UIA Tree Dump Composition Bugs Example 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Composition Bugs Example",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Composition Bugs Example See bugs in UI.Composition driven native animations",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Composition Bugs Example",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "See bugs in UI.Composition driven native animations",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Composition Bugs Example See bugs in UI.Composition driven native animations",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Composition Bugs Example See bugs in UI.Composition driven native animations",
+      "TestId": "Composition Bugs Example",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              241,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          241,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Composition Bugs Example",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "241, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "241, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -3880,284 +2312,168 @@ exports[`Home UIA Tree Dump Crash 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Crash",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Crash Crash examples.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Crash",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Crash examples.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Crash Crash examples.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Crash Crash examples.",
+      "TestId": "Crash",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Crash",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "50, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -4166,284 +2482,168 @@ exports[`Home UIA Tree Dump Cxx TurboModule 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Cxx TurboModule",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Cxx TurboModule Usage of Cxx TurboModule",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Cxx TurboModule",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Usage of Cxx TurboModule",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Cxx TurboModule Usage of Cxx TurboModule",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Cxx TurboModule Usage of Cxx TurboModule",
+      "TestId": "Cxx TurboModule",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              157,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          157,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Cxx TurboModule",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "157, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "157, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -4452,284 +2652,168 @@ exports[`Home UIA Tree Dump DevSettings 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "DevSettings",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "DevSettings Customize the development settings",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "DevSettings",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Customize the development settings",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "DevSettings Customize the development settings",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "DevSettings Customize the development settings",
+      "TestId": "DevSettings",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              106,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          106,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "DevSettings",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "106, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "106, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -4738,284 +2822,168 @@ exports[`Home UIA Tree Dump Dimensions 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Dimensions",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Dimensions Dimensions of the viewport",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Dimensions",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Dimensions of the viewport",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Dimensions Dimensions of the viewport",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Dimensions Dimensions of the viewport",
+      "TestId": "Dimensions",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              103,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          103,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Dimensions",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "103, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "103, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -5024,284 +2992,168 @@ exports[`Home UIA Tree Dump Display:none Style 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Display:none Style",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Display:none Style Style prop which will collapse the element in XAML tree.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Display:none Style",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Style prop which will collapse the element in XAML tree.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Display:none Style Style prop which will collapse the element in XAML tree.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Display:none Style Style prop which will collapse the element in XAML tree.",
+      "TestId": "Display:none Style",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              161,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          161,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Display:none Style",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "161, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "161, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -5310,284 +3162,168 @@ exports[`Home UIA Tree Dump Fabric Native Component 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Fabric Native Component",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Fabric Native Component Sample Fabric Native Component that sizes based on max desired size of native XAML contained within",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Fabric Native Component",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Sample Fabric Native Component that sizes based on max desired size of native XAML contained within",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Fabric Native Component Sample Fabric Native Component that sizes based on max desired size of native XAML contained within",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Fabric Native Component Sample Fabric Native Component that sizes based on max desired size of native XAML contained within",
+      "TestId": "Fabric Native Component",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              225,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          225,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Fabric Native Component",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "225, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "225, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -5596,284 +3332,168 @@ exports[`Home UIA Tree Dump Fabric Native Component Yoga 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Fabric Native Component Yoga",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Fabric Native Component Yoga Sample Fabric Native Component that places native XAML inside a container sized by yoga",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Fabric Native Component Yoga",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Sample Fabric Native Component that places native XAML inside a container sized by yoga",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Fabric Native Component Yoga Sample Fabric Native Component that places native XAML inside a container sized by yoga",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Fabric Native Component Yoga Sample Fabric Native Component that places native XAML inside a container sized by yoga",
+      "TestId": "Fabric Native Component Yoga",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              273,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          273,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Fabric Native Component Yoga",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "273, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "273, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -5882,284 +3502,168 @@ exports[`Home UIA Tree Dump Fast Path Texts 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Fast Path Texts",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Fast Path Texts Examples of performant fast path texts, turn on IsTextPerformanceVisualizationEnabled to visualize examples",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Fast Path Texts",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Examples of performant fast path texts, turn on IsTextPerformanceVisualizationEnabled to visualize examples",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Fast Path Texts Examples of performant fast path texts, turn on IsTextPerformanceVisualizationEnabled to visualize examples",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Fast Path Texts Examples of performant fast path texts, turn on IsTextPerformanceVisualizationEnabled to visualize examples",
+      "TestId": "Fast Path Texts",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              128,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          128,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Fast Path Texts",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "128, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "128, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -6168,284 +3672,168 @@ exports[`Home UIA Tree Dump FlatList 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "FlatList",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "FlatList Performant, scrollable list of data.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "FlatList",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Performant, scrollable list of data.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ListView",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "FlatList Performant, scrollable list of data.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "FlatList Performant, scrollable list of data.",
+      "TestId": "FlatList",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              62,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          62,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "FlatList",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "62, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "62, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -6454,284 +3842,168 @@ exports[`Home UIA Tree Dump Flyout 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Flyout",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Flyout Displays content on top of existing content, within the bounds of the application window.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Flyout",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Displays content on top of existing content, within the bounds of the application window.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Flyout Displays content on top of existing content, within the bounds of the application window.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Flyout Displays content on top of existing content, within the bounds of the application window.",
+      "TestId": "Flyout",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              55,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          55,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Flyout",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "55, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "55, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -6740,284 +4012,168 @@ exports[`Home UIA Tree Dump Glyph UWP 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Glyph UWP",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Glyph UWP Usage of Glyph control.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Glyph UWP",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Usage of Glyph control.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Glyph UWP Usage of Glyph control.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Glyph UWP Usage of Glyph control.",
+      "TestId": "Glyph UWP",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              101,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          101,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Glyph UWP",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "101, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "101, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -7026,284 +4182,168 @@ exports[`Home UIA Tree Dump Image 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Image",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Image Base component for displaying different types of images.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Image",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Base component for displaying different types of images.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Image Base component for displaying different types of images.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Image Base component for displaying different types of images.",
+      "TestId": "Image",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              55,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          55,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Image",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "55, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "55, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -7312,284 +4352,168 @@ exports[`Home UIA Tree Dump Keyboard 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Keyboard",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Keyboard Demonstrates usage of the "Keyboard" static API",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Keyboard",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Demonstrates usage of the "Keyboard" static API",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Keyboard Demonstrates usage of the "Keyboard" static API",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Keyboard Demonstrates usage of the "Keyboard" static API",
+      "TestId": "Keyboard",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              84,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          84,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Keyboard",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "84, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "84, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -7598,284 +4522,168 @@ exports[`Home UIA Tree Dump Keyboard 2`] = `
 {
   "Automation Tree": {
     "AutomationId": "Keyboard",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Keyboard Demonstrates usage of the "Keyboard" static API",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Keyboard",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Demonstrates usage of the "Keyboard" static API",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Keyboard Demonstrates usage of the "Keyboard" static API",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Keyboard Demonstrates usage of the "Keyboard" static API",
+      "TestId": "Keyboard",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              84,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          84,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Keyboard",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "84, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "84, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -7884,284 +4692,168 @@ exports[`Home UIA Tree Dump Keyboard Focus Example 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Keyboard Focus Example",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Keyboard Focus Example Demo of keyboard focus.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Keyboard Focus Example",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Demo of keyboard focus.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Keyboard Focus Example Demo of keyboard focus.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Keyboard Focus Example Demo of keyboard focus.",
+      "TestId": "Keyboard Focus Example",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              220,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          220,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Keyboard Focus Example",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "220, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "220, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -8170,284 +4862,168 @@ exports[`Home UIA Tree Dump Keyboard extension Example 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Keyboard extension Example",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Keyboard extension Example Demo of keyboard properties.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Keyboard extension Example",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Demo of keyboard properties.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Keyboard extension Example Demo of keyboard properties.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Keyboard extension Example Demo of keyboard properties.",
+      "TestId": "Keyboard extension Example",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              254,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          254,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Keyboard extension Example",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "254, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "254, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -8456,284 +5032,168 @@ exports[`Home UIA Tree Dump Layout - Flexbox 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Layout - Flexbox",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Layout - Flexbox Examples of using the flexbox API to layout views.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Layout - Flexbox",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Examples of using the flexbox API to layout views.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Layout - Flexbox Examples of using the flexbox API to layout views.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Layout - Flexbox Examples of using the flexbox API to layout views.",
+      "TestId": "Layout - Flexbox",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              145,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          145,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Layout - Flexbox",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "145, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "145, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -8742,284 +5202,168 @@ exports[`Home UIA Tree Dump Layout Events 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Layout Events",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Layout Events Examples that show how Layout events can be used to measure view size and position.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Layout Events",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Examples that show how Layout events can be used to measure view size and position.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Layout Events Examples that show how Layout events can be used to measure view size and position.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Layout Events Examples that show how Layout events can be used to measure view size and position.",
+      "TestId": "Layout Events",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              122,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          122,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Layout Events",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "122, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "122, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -9028,284 +5372,168 @@ exports[`Home UIA Tree Dump Legacy Native Module 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Legacy Native Module",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Legacy Native Module Usage of legacy Native Module",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Legacy Native Module",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Usage of legacy Native Module",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Legacy Native Module Usage of legacy Native Module",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Legacy Native Module Usage of legacy Native Module",
+      "TestId": "Legacy Native Module",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              197,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          197,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Legacy Native Module",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "197, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "197, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -9314,284 +5542,168 @@ exports[`Home UIA Tree Dump LegacyControlStyleTest 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "LegacyControlStyleTest",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "LegacyControlStyleTest Legacy e2e test for Control Styles",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "LegacyControlStyleTest",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Legacy e2e test for Control Styles",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "LegacyControlStyleTest Legacy e2e test for Control Styles",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "LegacyControlStyleTest Legacy e2e test for Control Styles",
+      "TestId": "LegacyControlStyleTest",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              203,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          203,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "LegacyControlStyleTest",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "203, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "203, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -9600,284 +5712,168 @@ exports[`Home UIA Tree Dump LegacyImageTest 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "LegacyImageTest",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "LegacyImageTest Legacy e2e test for Image",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "LegacyImageTest",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Legacy e2e test for Image",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "LegacyImageTest Legacy e2e test for Image",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "LegacyImageTest Legacy e2e test for Image",
+      "TestId": "LegacyImageTest",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              150,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          150,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "LegacyImageTest",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "150, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "150, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -9886,284 +5882,168 @@ exports[`Home UIA Tree Dump LegacyLoginTest 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "LegacyLoginTest",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "LegacyLoginTest Legacy e2e test for TextInput with password",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "LegacyLoginTest",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Legacy e2e test for TextInput with password",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "LegacyLoginTest Legacy e2e test for TextInput with password",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "LegacyLoginTest Legacy e2e test for TextInput with password",
+      "TestId": "LegacyLoginTest",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              145,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          145,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "LegacyLoginTest",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "145, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "145, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -10172,284 +6052,168 @@ exports[`Home UIA Tree Dump LegacySelectableTextTest 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "LegacySelectableTextTest",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "LegacySelectableTextTest Legacy e2e test for selectable Text hit testing",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "LegacySelectableTextTest",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Legacy e2e test for selectable Text hit testing",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "LegacySelectableTextTest Legacy e2e test for selectable Text hit testing",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "LegacySelectableTextTest Legacy e2e test for selectable Text hit testing",
+      "TestId": "LegacySelectableTextTest",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              220,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          220,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "LegacySelectableTextTest",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "220, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "220, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -10458,284 +6222,168 @@ exports[`Home UIA Tree Dump LegacyTextHitTestTest 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "LegacyTextHitTestTest",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "LegacyTextHitTestTest Legacy e2e test for Text hit testing",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "LegacyTextHitTestTest",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Legacy e2e test for Text hit testing",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "LegacyTextHitTestTest Legacy e2e test for Text hit testing",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "LegacyTextHitTestTest Legacy e2e test for Text hit testing",
+      "TestId": "LegacyTextHitTestTest",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              190,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          190,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "LegacyTextHitTestTest",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "190, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "190, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -10744,284 +6392,168 @@ exports[`Home UIA Tree Dump LegacyTextInputTest 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "LegacyTextInputTest",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "LegacyTextInputTest Legacy e2e test for TextInput",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "LegacyTextInputTest",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Legacy e2e test for TextInput",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "LegacyTextInputTest Legacy e2e test for TextInput",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "LegacyTextInputTest Legacy e2e test for TextInput",
+      "TestId": "LegacyTextInputTest",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              177,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          177,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "LegacyTextInputTest",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "177, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "177, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -11030,284 +6562,168 @@ exports[`Home UIA Tree Dump Linking 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Linking",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Linking Shows how to use Linking to open URLs.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Linking",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Shows how to use Linking to open URLs.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Linking Shows how to use Linking to open URLs.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Linking Shows how to use Linking to open URLs.",
+      "TestId": "Linking",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Linking",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "64, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -11316,284 +6732,168 @@ exports[`Home UIA Tree Dump Mouse Click Events 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Mouse Click Events",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Mouse Click Events Tests that mouse click events work on intended components",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Mouse Click Events",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Tests that mouse click events work on intended components",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Mouse Click Events Tests that mouse click events work on intended components",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Mouse Click Events Tests that mouse click events work on intended components",
+      "TestId": "Mouse Click Events",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              169,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          169,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Mouse Click Events",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "169, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "169, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -11602,284 +6902,168 @@ exports[`Home UIA Tree Dump Mouse Events 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Mouse Events",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Mouse Events Tests that mouse events can be observed",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Mouse Events",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Tests that mouse events can be observed",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Mouse Events Tests that mouse events can be observed",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Mouse Events Tests that mouse events can be observed",
+      "TestId": "Mouse Events",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              123,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          123,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Mouse Events",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "123, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "123, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -11888,284 +7072,168 @@ exports[`Home UIA Tree Dump Native Animated Example 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Native Animated Example",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Native Animated Example Test out Native Animations",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Native Animated Example",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Test out Native Animations",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Native Animated Example Test out Native Animations",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Native Animated Example Test out Native Animations",
+      "TestId": "Native Animated Example",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              227,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          227,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Native Animated Example",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "227, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "227, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -12174,284 +7242,168 @@ exports[`Home UIA Tree Dump New App Screen 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "New App Screen",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "New App Screen Displays the content of the new app screen",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "New App Screen",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Displays the content of the new app screen",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "New App Screen Displays the content of the new app screen",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "New App Screen Displays the content of the new app screen",
+      "TestId": "New App Screen",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              147,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          147,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "New App Screen",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "147, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "147, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -12460,284 +7412,168 @@ exports[`Home UIA Tree Dump PanResponder Sample 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "PanResponder Sample",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "PanResponder Sample Shows the Use of PanResponder to provide basic gesture handling",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "PanResponder Sample",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Shows the Use of PanResponder to provide basic gesture handling",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "PanResponder Sample Shows the Use of PanResponder to provide basic gesture handling",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "PanResponder Sample Shows the Use of PanResponder to provide basic gesture handling",
+      "TestId": "PanResponder Sample",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              197,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          197,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "PanResponder Sample",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "197, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "197, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -12746,284 +7582,168 @@ exports[`Home UIA Tree Dump Performance API Examples 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Performance API Examples",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Performance API Examples Shows the performance API provided in React Native",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Performance API Examples",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Shows the performance API provided in React Native",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Performance API Examples Shows the performance API provided in React Native",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Performance API Examples Shows the performance API provided in React Native",
+      "TestId": "Performance API Examples",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              234,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          234,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Performance API Examples",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "234, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "234, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -13032,284 +7752,168 @@ exports[`Home UIA Tree Dump Performance Comparison Examples 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Performance Comparison Examples",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Performance Comparison Examples Compare performance with bad and good examples. Use React DevTools to highlight re-renders is recommended.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Performance Comparison Examples",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Compare performance with bad and good examples. Use React DevTools to highlight re-renders is recommended.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Performance Comparison Examples Compare performance with bad and good examples. Use React DevTools to highlight re-renders is recommended.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Performance Comparison Examples Compare performance with bad and good examples. Use React DevTools to highlight re-renders is recommended.",
+      "TestId": "Performance Comparison Examples",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              312,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          312,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Performance Comparison Examples",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "312, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "312, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -13318,284 +7922,168 @@ exports[`Home UIA Tree Dump PlatformColor 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "PlatformColor",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "PlatformColor Examples that show how PlatformColors may be used in an app.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "PlatformColor",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Examples that show how PlatformColors may be used in an app.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "PlatformColor Examples that show how PlatformColors may be used in an app.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "PlatformColor Examples that show how PlatformColors may be used in an app.",
+      "TestId": "PlatformColor",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              123,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          123,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "PlatformColor",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "123, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "123, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -13604,284 +8092,168 @@ exports[`Home UIA Tree Dump Pointer Events 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Pointer Events",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Pointer Events Demonstrates the use of the pointerEvents prop of a View to control how touches should be handled.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Pointer Events",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Demonstrates the use of the pointerEvents prop of a View to control how touches should be handled.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Pointer Events Demonstrates the use of the pointerEvents prop of a View to control how touches should be handled.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Pointer Events Demonstrates the use of the pointerEvents prop of a View to control how touches should be handled.",
+      "TestId": "Pointer Events",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              125,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          125,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Pointer Events",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "125, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "125, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -13890,284 +8262,168 @@ exports[`Home UIA Tree Dump Popup 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Popup",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Popup Displays content on top of existing content, within the bounds of the application window.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Popup",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Displays content on top of existing content, within the bounds of the application window.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Popup Displays content on top of existing content, within the bounds of the application window.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Popup Displays content on top of existing content, within the bounds of the application window.",
+      "TestId": "Popup",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              58,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          58,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Popup",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "58, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "58, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -14176,284 +8432,168 @@ exports[`Home UIA Tree Dump Pressable 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Pressable",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Pressable Component for making views pressable.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Pressable",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Component for making views pressable.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Pressable Component for making views pressable.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Pressable Component for making views pressable.",
+      "TestId": "Pressable",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              83,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          83,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Pressable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "83, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "83, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -14462,284 +8602,168 @@ exports[`Home UIA Tree Dump RTLExample 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "RTLExample",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "RTLExample Examples to show how to apply components to RTL layout.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "RTLExample",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Examples to show how to apply components to RTL layout.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "RTLExample Examples to show how to apply components to RTL layout.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "RTLExample Examples to show how to apply components to RTL layout.",
+      "TestId": "RTLExample",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              105,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          105,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "RTLExample",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "105, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "105, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -14748,284 +8772,168 @@ exports[`Home UIA Tree Dump ScrollView 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "ScrollView",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "ScrollView Component that enables scrolling through child components",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ScrollView",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Component that enables scrolling through child components",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "ScrollView Component that enables scrolling through child components",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "ScrollView Component that enables scrolling through child components",
+      "TestId": "ScrollView",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              91,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          91,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "ScrollView",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "91, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "91, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -15034,284 +8942,168 @@ exports[`Home UIA Tree Dump ScrollViewAnimated 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "ScrollViewAnimated",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "ScrollViewAnimated Component that is animated when ScrollView is offset.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ScrollViewAnimated",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Component that is animated when ScrollView is offset.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "ScrollViewAnimated Component that is animated when ScrollView is offset.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "ScrollViewAnimated Component that is animated when ScrollView is offset.",
+      "TestId": "ScrollViewAnimated",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              176,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          176,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "ScrollViewAnimated",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "176, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "176, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -15320,284 +9112,168 @@ exports[`Home UIA Tree Dump ScrollViewSimpleExample 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "ScrollViewSimpleExample",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "ScrollViewSimpleExample Component that enables scrolling through child components.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ScrollViewSimpleExample",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Component that enables scrolling through child components.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "ScrollViewSimpleExample Component that enables scrolling through child components.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "ScrollViewSimpleExample Component that enables scrolling through child components.",
+      "TestId": "ScrollViewSimpleExample",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              224,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          224,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "ScrollViewSimpleExample",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "224, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "224, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -15608,28 +9284,29 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
     "AutomationId": "explorer_search",
     "ControlType": 50004,
     "HelpText": "Search...",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Search...",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "explorer_search",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "explorer_search",
+    "Offset": "0, 0, 0",
+    "Size": "938, 35",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
         "Brush": {
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          7,
-          7,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "7, 7",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15637,16 +9314,8 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          7,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          924,
-          1,
-        ],
+        "Offset": "7, 0, 0",
+        "Size": "924, 1",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15654,16 +9323,8 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          -7,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          7,
-          7,
-        ],
+        "Offset": "-7, 0, 0",
+        "Size": "7, 7",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15671,16 +9332,8 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          -1,
-          7,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          21,
-        ],
+        "Offset": "-1, 7, 0",
+        "Size": "1, 21",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15688,16 +9341,8 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          -7,
-          -7,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          7,
-          7,
-        ],
+        "Offset": "-7, -7, 0",
+        "Size": "7, 7",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15705,16 +9350,8 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          7,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          924,
-          1,
-        ],
+        "Offset": "7, -1, 0",
+        "Size": "924, 1",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15722,16 +9359,8 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          0,
-          -7,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          7,
-          7,
-        ],
+        "Offset": "0, -7, 0",
+        "Size": "7, 7",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15739,16 +9368,8 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(60, 60, 67, 45)",
         },
-        "Offset": [
-          0,
-          7,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          21,
-        ],
+        "Offset": "0, 7, 0",
+        "Size": "1, 21",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -15756,31 +9377,12 @@ exports[`Home UIA Tree Dump Search Bar 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "explorer_search",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      938,
-      35,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -15789,284 +9391,168 @@ exports[`Home UIA Tree Dump SectionList 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "SectionList",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "SectionList Performant, scrollable list of data.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "SectionList",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Performant, scrollable list of data.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ListView",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "SectionList Performant, scrollable list of data.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "SectionList Performant, scrollable list of data.",
+      "TestId": "SectionList",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              95,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          95,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "SectionList",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "95, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "95, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -16075,284 +9561,168 @@ exports[`Home UIA Tree Dump Share 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Share",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Share Share data with other Apps.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Share",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Share data with other Apps.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Share Share data with other Apps.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Share Share data with other Apps.",
+      "TestId": "Share",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Share",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "50, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -16361,284 +9731,168 @@ exports[`Home UIA Tree Dump SwipeableCard 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "SwipeableCard",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "SwipeableCard Example of a swipeable card with scrollable content to test PanResponder and JSResponderHandler interaction.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "SwipeableCard",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Example of a swipeable card with scrollable content to test PanResponder and JSResponderHandler interaction.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "SwipeableCard Example of a swipeable card with scrollable content to test PanResponder and JSResponderHandler interaction.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "SwipeableCard Example of a swipeable card with scrollable content to test PanResponder and JSResponderHandler interaction.",
+      "TestId": "SwipeableCard",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              131,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          131,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "SwipeableCard",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "131, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "131, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -16647,284 +9901,168 @@ exports[`Home UIA Tree Dump Switch 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Switch",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Switch Native boolean input",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Switch",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Native boolean input",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Switch Native boolean input",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Switch Native boolean input",
+      "TestId": "Switch",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              57,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          57,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Switch",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "57, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "57, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -16933,284 +10071,168 @@ exports[`Home UIA Tree Dump Text 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Text",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Text Base component for rendering styled text.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Text",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Base component for rendering styled text.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Text Base component for rendering styled text.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Text Base component for rendering styled text.",
+      "TestId": "Text",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              35,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          35,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Text",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "35, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "35, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -17219,284 +10241,168 @@ exports[`Home UIA Tree Dump TextInput 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "TextInput",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "TextInput Single and multi-line text inputs.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "TextInput",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Single and multi-line text inputs.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "TextInput Single and multi-line text inputs.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "TextInput Single and multi-line text inputs.",
+      "TestId": "TextInput",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              82,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          82,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "TextInput",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "82, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "82, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -17505,284 +10411,168 @@ exports[`Home UIA Tree Dump TextInputs with key prop 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "TextInputs with key prop",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "TextInputs with key prop Periodically render large number of TextInputs with key prop without a Runtime Error",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "TextInputs with key prop",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Periodically render large number of TextInputs with key prop without a Runtime Error",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Other",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "TextInputs with key prop Periodically render large number of TextInputs with key prop without a Runtime Error",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "TextInputs with key prop Periodically render large number of TextInputs with key prop without a Runtime Error",
+      "TestId": "TextInputs with key prop",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              217,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          217,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "TextInputs with key prop",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "217, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "217, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -17791,284 +10581,168 @@ exports[`Home UIA Tree Dump Timers 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Timers",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Timers A demonstration of Timers in React Native.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Timers",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "A demonstration of Timers in React Native.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Timers A demonstration of Timers in React Native.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Timers A demonstration of Timers in React Native.",
+      "TestId": "Timers",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              59,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          59,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Timers",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "59, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "59, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -18077,284 +10751,168 @@ exports[`Home UIA Tree Dump Touchable* and onPress 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Touchable* and onPress",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Touchable* and onPress Touchable and onPress examples.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Touchable* and onPress",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Touchable and onPress examples.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Touchable* and onPress Touchable and onPress examples.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Touchable* and onPress Touchable and onPress examples.",
+      "TestId": "Touchable* and onPress",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              211,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          211,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Touchable* and onPress",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "211, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "211, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -18363,284 +10921,168 @@ exports[`Home UIA Tree Dump TransferProperties 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "TransferProperties",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "TransferProperties Some tests that change the backing XAML element to see if transfer properties is working.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "TransferProperties",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Some tests that change the backing XAML element to see if transfer properties is working.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "TransferProperties Some tests that change the backing XAML element to see if transfer properties is working.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "TransferProperties Some tests that change the backing XAML element to see if transfer properties is working.",
+      "TestId": "TransferProperties",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              159,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          159,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "TransferProperties",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "159, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "159, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -18649,284 +11091,168 @@ exports[`Home UIA Tree Dump Transforms 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "Transforms",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Transforms View transforms",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Transforms",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "View transforms",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "Transforms View transforms",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Transforms View transforms",
+      "TestId": "Transforms",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              97,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          97,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "Transforms",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "97, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "97, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -18935,284 +11261,168 @@ exports[`Home UIA Tree Dump TransparentHitTestExample 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "TransparentHitTestExample",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "TransparentHitTestExample Transparent view receiving touch events",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "TransparentHitTestExample",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Transparent view receiving touch events",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "TransparentHitTestExample Transparent view receiving touch events",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "TransparentHitTestExample Transparent view receiving touch events",
+      "TestId": "TransparentHitTestExample",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              237,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          237,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "TransparentHitTestExample",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "237, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "237, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -19221,284 +11431,168 @@ exports[`Home UIA Tree Dump TurboModule 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "TurboModule",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "TurboModule Usage of TurboModule",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "TurboModule",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Usage of TurboModule",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "TurboModule Usage of TurboModule",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "TurboModule Usage of TurboModule",
+      "TestId": "TurboModule",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              121,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          121,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "TurboModule",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      100,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 100",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "121, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "121, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -19507,284 +11601,168 @@ exports[`Home UIA Tree Dump View 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "View",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "View Basic building block of all UI, examples that demonstrate some of the many styles available.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "View",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic building block of all UI, examples that demonstrate some of the many styles available.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "View Basic building block of all UI, examples that demonstrate some of the many styles available.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "View Basic building block of all UI, examples that demonstrate some of the many styles available.",
+      "TestId": "View",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              43,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          43,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "View",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "43, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "43, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -19793,284 +11771,168 @@ exports[`Home UIA Tree Dump WebSocket 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "WebSocket",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "WebSocket WebSocket API",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "WebSocket",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "WebSocket API",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "WebSocket WebSocket API",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "WebSocket WebSocket API",
+      "TestId": "WebSocket",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              99,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          99,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "WebSocket",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "99, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "99, 27",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -20079,284 +11941,168 @@ exports[`Home UIA Tree Dump XAML 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "XAML",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "XAML Usage of react-native-xaml controls",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "XAML",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Usage of react-native-xaml controls",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "UI",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "XAML Usage of react-native-xaml controls",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "XAML Usage of react-native-xaml controls",
+      "TestId": "XAML",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              53,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          53,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "XAML",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "53, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "53, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -20365,284 +12111,168 @@ exports[`Home UIA Tree Dump XMLHttpRequest 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "XMLHttpRequest",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "XMLHttpRequest Example that demonstrates upload and download requests using XMLHttpRequest.",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "XMLHttpRequest",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Example that demonstrates upload and download requests using XMLHttpRequest.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Basic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "iOS",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Android",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "XMLHttpRequest Example that demonstrates upload and download requests using XMLHttpRequest.",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "XMLHttpRequest Example that demonstrates upload and download requests using XMLHttpRequest.",
+      "TestId": "XMLHttpRequest",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              150,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          12,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          150,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              938,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          43,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          938,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              65,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          65,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              22,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          853,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          22,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          901,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "XMLHttpRequest",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      968,
-      99,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "968, 99",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "15, 12, 0",
+        "Size": "150, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "150, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 43, 0",
+        "Size": "938, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "938, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "15, 69, 0",
+        "Size": "65, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "65, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "853, 69, 0",
+        "Size": "22, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "22, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "901, 69, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/test/__snapshots__/ImageComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/ImageComponentTest.test.ts.snap
@@ -5,24 +5,25 @@ exports[`Image Tests A legacy local image can still render 1`] = `
   "Automation Tree": {
     "AutomationId": "image-legacy",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Size": "120, 120",
+          "Type": "Remote",
+          "Uri": "legacy_image",
+        },
+      ],
+      "TestId": "image-legacy",
+    },
   },
   "Visual Tree": {
     "Comment": "image-legacy",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      120,
-      120,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "120, 120",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -33,24 +34,24 @@ exports[`Image Tests A network Image example 1`] = `
   "Automation Tree": {
     "AutomationId": "image-network",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon_TYPO.ico",
+        },
+      ],
+      "TestId": "image-network",
+    },
   },
   "Visual Tree": {
     "Comment": "image-network",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -61,866 +62,515 @@ exports[`Image Tests An Image can a border radius 1`] = `
   "Automation Tree": {
     "AutomationId": "image-border-radius",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-border-radius",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          76,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          148,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  14,
-                  14,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  14,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  46,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  36,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  -24,
-                  -24,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  4,
-                  -4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  36,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  14,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  46,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          220,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  14,
-                  14,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  14,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  52,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -24,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  24,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -34,
-                  -34,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  34,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  44,
-                  -4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  12,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -44,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  14,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          292,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  14,
-                  14,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  14,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  52,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -24,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  24,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -34,
-                  -34,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  34,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  44,
-                  -4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  12,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -44,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  14,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          390,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  14,
-                  14,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  14,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  52,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -24,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -4,
-                  24,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  -34,
-                  -34,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  34,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  44,
-                  -4,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  12,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -44,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(255, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  14,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  4,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          488,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-border-radius",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      72,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 72",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "4, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "76, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "148, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "220, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "14, 14",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "14, 0, 0",
+                "Size": "46, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "-4, 0, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "-4, 4, 0",
+                "Size": "4, 36",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "-24, -24, 0",
+                "Size": "24, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "4, -4, 0",
+                "Size": "36, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "0, -4, 0",
+                "Size": "4, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "0, 14, 0",
+                "Size": "4, 46",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "292, 4, 0",
+        "Size": "90, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 64",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "14, 14",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "14, 0, 0",
+                "Size": "52, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-24, 0, 0",
+                "Size": "24, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-4, 24, 0",
+                "Size": "4, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-34, -34, 0",
+                "Size": "34, 34",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "44, -4, 0",
+                "Size": "12, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, -44, 0",
+                "Size": "44, 44",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, 14, 0",
+                "Size": "4, 6",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "390, 4, 0",
+        "Size": "90, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 64",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "14, 14",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "14, 0, 0",
+                "Size": "52, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-24, 0, 0",
+                "Size": "24, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-4, 24, 0",
+                "Size": "4, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-34, -34, 0",
+                "Size": "34, 34",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "44, -4, 0",
+                "Size": "12, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, -44, 0",
+                "Size": "44, 44",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, 14, 0",
+                "Size": "4, 6",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "488, 4, 0",
+        "Size": "90, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 64",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "14, 14",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "14, 0, 0",
+                "Size": "52, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-24, 0, 0",
+                "Size": "24, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-4, 24, 0",
+                "Size": "4, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "-34, -34, 0",
+                "Size": "34, 34",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "44, -4, 0",
+                "Size": "12, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, -44, 0",
+                "Size": "44, 44",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(255, 0, 0, 255)",
+                },
+                "Offset": "0, 14, 0",
+                "Size": "4, 6",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -930,24 +580,24 @@ exports[`Image Tests An Image can be added to the accessibility tree 1`] = `
   "Automation Tree": {
     "AutomationId": "image-accessible",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-accessible",
+    },
   },
   "Visual Tree": {
     "Comment": "image-accessible",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -957,121 +607,81 @@ exports[`Image Tests An Image can be nested inside of a component 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "image-nested",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "React",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-nested",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              52,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          12,
-          20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          52,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-nested",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "12, 20, 0",
+        "Size": "52, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "52, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1081,24 +691,24 @@ exports[`Image Tests An Image can be rendered at a different size 1`] = `
   "Automation Tree": {
     "AutomationId": "image-size",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-size",
+    },
   },
   "Visual Tree": {
     "Comment": "image-size",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      60,
-      60,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "60, 60",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -1109,131 +719,67 @@ exports[`Image Tests An Image can borders 1`] = `
   "Automation Tree": {
     "AutomationId": "image-border",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon.ico",
+        },
+      ],
+      "TestId": "image-border",
+    },
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          5,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -10,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -5,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -5,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          -10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -5,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          5,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -10,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          -10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-border",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "5, 0, 0",
+        "Size": "-10, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-5, 0, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-5, 5, 0",
+        "Size": "5, -10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-5, -5, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "5, -5, 0",
+        "Size": "-10, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -5, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 5, 0",
+        "Size": "5, -10",
+        "Visual Type": "SpriteVisual",
+      },
+    ],
   },
 }
 `;
@@ -1243,329 +789,209 @@ exports[`Image Tests An Image can have a background color 1`] = `
   "Automation Tree": {
     "AutomationId": "image-background-color",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-background-color",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          76,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          148,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  28,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  28,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  8,
-                  3,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  -28,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  28,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  -3,
-                  28,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  3,
-                  8,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  -28,
-                  -28,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  28,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  28,
-                  -3,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  8,
-                  3,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -28,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  28,
-                  28,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 128, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  28,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  3,
-                  8,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          220,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-background-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      72,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 72",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "4, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "76, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "148, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "220, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "28, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "28, 0, 0",
+                "Size": "8, 3",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "-28, 0, 0",
+                "Size": "28, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "-3, 28, 0",
+                "Size": "3, 8",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "-28, -28, 0",
+                "Size": "28, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "28, -3, 0",
+                "Size": "8, 3",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "0, -28, 0",
+                "Size": "28, 28",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 128, 0, 255)",
+                },
+                "Offset": "0, 28, 0",
+                "Size": "3, 8",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1575,24 +1001,26 @@ exports[`Image Tests An Image can have a can have alt text 1`] = `
   "Automation Tree": {
     "AutomationId": "image-alt",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
     "Name": "Picture of people standing around a table",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Picture of people standing around a table",
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-alt",
+    },
+  },
   "Visual Tree": {
     "Comment": "image-alt",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -1603,273 +1031,191 @@ exports[`Image Tests An Image can have a custom blur radius 1`] = `
   "Automation Tree": {
     "AutomationId": "image-blur-radius",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-blur-radius",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          76,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          148,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          220,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          292,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          364,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-blur-radius",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      72,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 72",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "4, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "76, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "148, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "220, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "292, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "364, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1879,24 +1225,24 @@ exports[`Image Tests An Image can have a loading indicator visual 1`] = `
   "Automation Tree": {
     "AutomationId": "image-loading-indicator",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png?hash=1715623796856",
+        },
+      ],
+      "TestId": "image-loading-indicator",
+    },
   },
   "Visual Tree": {
     "Comment": "image-loading-indicator",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -1906,836 +1252,579 @@ exports[`Image Tests An Image can have a tint color 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "image-tint-color",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "It also works using the \`tintColor\` style prop",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "The \`tintColor\` prop has precedence over the \`tintColor\` style prop",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "It also works with downloaded images:",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-tint-color",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          27,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          50,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          73,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          58,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          27,
-          58,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          50,
-          58,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          73,
-          58,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          82,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          111,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          27,
-          111,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          50,
-          111,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          73,
-          111,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          136,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          165,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          76,
-          165,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          148,
-          165,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          220,
-          165,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-tint-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      233,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 233",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "4, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "27, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "50, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "73, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 29, 0",
+        "Size": "916, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "4, 58, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "27, 58, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "50, 58, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "73, 58, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 82, 0",
+        "Size": "916, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "4, 111, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "27, 111, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "50, 111, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "73, 111, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 136, 0",
+        "Size": "916, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "4, 165, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "76, 165, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "148, 165, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "220, 165, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2745,24 +1834,26 @@ exports[`Image Tests An Image can have an accessibilityLabel 1`] = `
   "Automation Tree": {
     "AutomationId": "image-accessibilitylabel",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
     "Name": "Picture of people standing around a table",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Picture of people standing around a table",
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-accessibilitylabel",
+    },
+  },
   "Visual Tree": {
     "Comment": "image-accessibilitylabel",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -2773,273 +1864,201 @@ exports[`Image Tests An Image can have custom opacity 1`] = `
   "Automation Tree": {
     "AutomationId": "image-opacity",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-opacity",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Opacity": 0.800000011920929,
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Opacity": 0.6000000238418579,
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Opacity": 0.4000000059604645,
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Opacity": 0.20000000298023224,
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Opacity": 0,
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.800000011920929,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          76,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.6000000238418579,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          148,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.4000000059604645,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          220,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.20000000298023224,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          292,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0,
-            "Size": [
-              64,
-              64,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          364,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          64,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-opacity",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      72,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 72",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "4, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "76, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.800000011920929,
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "148, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.6000000238418579,
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "220, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.4000000059604645,
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "292, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.20000000298023224,
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "364, 4, 0",
+        "Size": "64, 64",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0,
+            "Size": "64, 64",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -3049,24 +2068,30 @@ exports[`Image Tests An Image can have multiple sources 1`] = `
   "Automation Tree": {
     "AutomationId": "image-multiple-sources",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Size": "38, 38",
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon.ico",
+        },
+        {
+          "Size": "100, 100",
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-multiple-sources",
+    },
   },
   "Visual Tree": {
     "Comment": "image-multiple-sources",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      30,
-      30,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "30, 30",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3077,24 +2102,32 @@ exports[`Image Tests An Image can have multiple sources through the srcSet prop 
   "Automation Tree": {
     "AutomationId": "image-srcset",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Scale": 4,
+          "Size": "64, 64",
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+        {
+          "Scale": 2,
+          "Size": "64, 64",
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon.ico",
+        },
+      ],
+      "TestId": "image-srcset",
+    },
   },
   "Visual Tree": {
     "Comment": "image-srcset",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3105,24 +2138,35 @@ exports[`Image Tests An Image can have onLayout behavior 1`] = `
   "Automation Tree": {
     "AutomationId": "image-onlayout",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Size": "38, 38",
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon.ico",
+        },
+        {
+          "Size": "76, 76",
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon.ico",
+        },
+        {
+          "Size": "400, 400",
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-onlayout",
+    },
   },
   "Visual Tree": {
     "Comment": "image-onlayout",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      30,
-      30,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "30, 30",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3133,191 +2177,143 @@ exports[`Image Tests An Image can load a static image 1`] = `
   "Automation Tree": {
     "AutomationId": "image-static",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-static",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_normal@2x.png?platform=windows&hash=c6f5aec4d9e0aa47c0887e4266796224",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_thumb_selected@2x.png?platform=windows&hash=4b7088ca5499061913e736668940c5bf",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_comment_normal@2x.png?platform=windows&hash=a271ab3a3933f61465b85e76ed8e4852",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Scale": 2,
+              "Size": "17, 40",
+              "Type": "Local",
+              "Uri": "http://localhost:8081/assets/@@/@react-native-windows/tester/js/assets/uie_comment_highlighted@2x.png?platform=windows&hash=99e642a0f019ca4695e8d172530b3c58",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          4,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          27,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          50,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              15,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          73,
-          4,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          15,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-static",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      23,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 23",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "4, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "27, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "50, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "73, 4, 0",
+        "Size": "15, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "15, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -3327,24 +2323,24 @@ exports[`Image Tests An Image can load an image through its source prop 1`] = `
   "Automation Tree": {
     "AutomationId": "image-plain-source",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-plain-source",
+    },
   },
   "Visual Tree": {
     "Comment": "image-plain-source",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3355,24 +2351,24 @@ exports[`Image Tests An Image can load an image through its src prop 1`] = `
   "Automation Tree": {
     "AutomationId": "image-plain-src",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+        },
+      ],
+      "TestId": "image-plain-src",
+    },
   },
   "Visual Tree": {
     "Comment": "image-plain-src",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3383,24 +2379,24 @@ exports[`Image Tests An Image component can have a network callback 1`] = `
   "Automation Tree": {
     "AutomationId": "image-network-callback",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon.ico?r=1&t=1715623796709",
+        },
+      ],
+      "TestId": "image-network-callback",
+    },
   },
   "Visual Tree": {
     "Comment": "image-network-callback",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3411,24 +2407,24 @@ exports[`Image Tests An Image component can hve a network callback 2 1`] = `
   "Automation Tree": {
     "AutomationId": "image-network-callback-2",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "https://www.facebook.com/favicon.ico?r=1&t=1715623795000",
+        },
+      ],
+      "TestId": "image-network-callback-2",
+    },
   },
   "Visual Tree": {
     "Comment": "image-network-callback-2",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3439,24 +2435,24 @@ exports[`Image Tests An Image component can render a blob image 1`] = `
   "Automation Tree": {
     "AutomationId": "image-blob",
     "ControlType": 50006,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "image",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+    "_Props": {
+      "Sources": [
+        {
+          "Type": "Remote",
+          "Uri": "blob:6b4e0e49-1e1a-4ce1-9042-bbf4b230f3f0?offset=0&size=5430",
+        },
+      ],
+      "TestId": "image-blob",
+    },
   },
   "Visual Tree": {
     "Comment": "image-blob",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      64,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 64",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -3466,1606 +2462,802 @@ exports[`Image Tests An Image customized how it is rendered within the frame usi
 {
   "Automation Tree": {
     "AutomationId": "image-object-fit",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Contain",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Cover",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Fill",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Scale Down",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Contain",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Cover",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Fill",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Scale Down",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-object-fit",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          18,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          18,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          78,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          96,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          78,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          96,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          155,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          173,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          155,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          173,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          233,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          251,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          233,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          251,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-object-fit",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      311,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 310",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 18, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 0, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 18, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 78, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 96, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 78, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 96, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 155, 0",
+        "Size": "90, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 173, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 155, 0",
+        "Size": "90, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 173, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 233, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 251, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 233, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 251, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -5074,2000 +3266,996 @@ exports[`Image Tests Images have multiple resize modes 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "image-resize-mode",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Contain",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Cover",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Stretch",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Repeat",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Center",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Contain",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Cover",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Stretch",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Repeat",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Center",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-resize-mode",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/ads/pics/successstories.png",
+            },
+          ],
+        },
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          18,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          18,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          78,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          96,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          78,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          96,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          200,
-          78,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          200,
-          96,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          155,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          173,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          155,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          173,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          233,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          251,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          233,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          100,
-          251,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          200,
-          233,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          200,
-          251,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-resize-mode",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      310,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 311",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "90, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 18, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 0, 0",
+        "Size": "90, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 18, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 78, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 96, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 78, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 96, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "200, 78, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "200, 96, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 155, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 173, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 155, 0",
+        "Size": "90, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 173, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 233, 0",
+        "Size": "90, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 251, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 233, 0",
+        "Size": "90, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "100, 251, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "200, 233, 0",
+        "Size": "90, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "200, 251, 0",
+        "Size": "90, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "90, 60",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/test/__snapshots__/LegacyControlStyleTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/LegacyControlStyleTest.test.ts.snap
@@ -3,18 +3,16 @@
 exports[`LegacyControlStyleTest ControlStyleTestWithRegularBorder #2 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "control-style-switch-view",
+    },
+  },
   "Visual Tree": {
     "Comment": "control-style-switch-view",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      180,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 180",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -23,18 +21,16 @@ exports[`LegacyControlStyleTest ControlStyleTestWithRegularBorder #2 1`] = `
 exports[`LegacyControlStyleTest ControlStyleTestWithRegularBorder 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "control-style-switch-view",
+    },
+  },
   "Visual Tree": {
     "Comment": "control-style-switch-view",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      180,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 180",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -43,18 +39,16 @@ exports[`LegacyControlStyleTest ControlStyleTestWithRegularBorder 1`] = `
 exports[`LegacyControlStyleTest ControlStyleTestWithRoundBorder 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "control-style-switch-view",
+    },
+  },
   "Visual Tree": {
     "Comment": "control-style-switch-view",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      180,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 180",
     "Visual Type": "SpriteVisual",
   },
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/LegacyImageTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/LegacyImageTest.test.ts.snap
@@ -3,129 +3,63 @@
 exports[`LegacyImageTest ImageRTLTest 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-container",
+    },
+  },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 0, 255)",
     },
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          20,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          460,
-          10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -20,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -10,
-          20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          10,
-          260,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -20,
-          -20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          20,
-          -10,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          460,
-          10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          10,
-          260,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-container",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      500,
-      300,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "500, 300",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "20, 0, 0",
+        "Size": "460, 10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-20, 0, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-10, 20, 0",
+        "Size": "10, 260",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-20, -20, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "20, -10, 0",
+        "Size": "460, 10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -20, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 20, 0",
+        "Size": "10, 260",
+        "Visual Type": "SpriteVisual",
+      },
+    ],
   },
 }
 `;
@@ -133,161 +67,95 @@ exports[`LegacyImageTest ImageRTLTest 1`] = `
 exports[`LegacyImageTest ImageWithBorderTest 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-container",
+    },
+  },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 0, 255)",
     },
-    "Children": [
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          20,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          460,
-          10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          -20,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          -10,
-          20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          10,
-          260,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          -20,
-          -20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          20,
-          -10,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          460,
-          10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          0,
-          -20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Brush": {
-          "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 255, 0, 85)",
-        },
-        "Offset": [
-          0,
-          20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          10,
-          260,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-container",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      500,
-      300,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "500, 300",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "0, 0, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "20, 0, 0",
+        "Size": "460, 10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "-20, 0, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "-10, 20, 0",
+        "Size": "10, 260",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "-20, -20, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "20, -10, 0",
+        "Size": "460, 10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "0, -20, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 255, 0, 85)",
+        },
+        "Offset": "0, 20, 0",
+        "Size": "10, 260",
+        "Visual Type": "SpriteVisual",
+      },
+    ],
   },
 }
 `;
@@ -295,22 +163,20 @@ exports[`LegacyImageTest ImageWithBorderTest 1`] = `
 exports[`LegacyImageTest ImageWithoutBorderTest 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-container",
+    },
+  },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 0, 255)",
     },
     "Comment": "image-container",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      500,
-      300,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "500, 300",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -319,129 +185,63 @@ exports[`LegacyImageTest ImageWithoutBorderTest 1`] = `
 exports[`LegacyImageTest ImageWithoutBorderTestOneMoreClick 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "image-container",
+    },
+  },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 0, 255)",
     },
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          20,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          460,
-          10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -20,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -10,
-          20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          10,
-          260,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -20,
-          -20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          20,
-          -10,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          460,
-          10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          20,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          20,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          10,
-          260,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "image-container",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      500,
-      300,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "500, 300",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "20, 0, 0",
+        "Size": "460, 10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-20, 0, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-10, 20, 0",
+        "Size": "10, 260",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-20, -20, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "20, -10, 0",
+        "Size": "460, 10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -20, 0",
+        "Size": "20, 20",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 20, 0",
+        "Size": "10, 260",
+        "Visual Type": "SpriteVisual",
+      },
+    ],
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/test/__snapshots__/LegacySelectableTextTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/LegacySelectableTextTest.test.ts.snap
@@ -5,24 +5,19 @@ exports[`LegacySelectableTextTest DoubleClickWhenNotSelectable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 2 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -33,24 +28,19 @@ exports[`LegacySelectableTextTest DoubleClickWhenSelectable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 2 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -61,24 +51,19 @@ exports[`LegacySelectableTextTest PressableWhenNotSelectable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -89,24 +74,19 @@ exports[`LegacySelectableTextTest PressableWhenSelectable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/LegacyTextHitTestTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/LegacyTextHitTestTest.test.ts.snap
@@ -5,24 +5,19 @@ exports[`LegacyTextHitTestTest BidirectionalTextPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 2 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -33,24 +28,19 @@ exports[`LegacyTextHitTestTest BidirectionalTextPressableEdgeCaseNotPressable 1`
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -61,24 +51,19 @@ exports[`LegacyTextHitTestTest BidirectionalTextSeparateRunsEdgeCasePressable 1`
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -89,24 +74,19 @@ exports[`LegacyTextHitTestTest BidirectionalTextSeparateRunsPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 2 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -117,24 +97,19 @@ exports[`LegacyTextHitTestTest InsertedVirtualTextPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -145,24 +120,19 @@ exports[`LegacyTextHitTestTest LTRTextInRTLFlowPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -173,24 +143,19 @@ exports[`LegacyTextHitTestTest MultilineRTLTextEdgeCaseNotPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -201,24 +166,19 @@ exports[`LegacyTextHitTestTest MultilineRTLTextPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 2 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -229,24 +189,19 @@ exports[`LegacyTextHitTestTest MultilineTextPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -257,24 +212,19 @@ exports[`LegacyTextHitTestTest RTLTextInRTLFlowPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -285,24 +235,19 @@ exports[`LegacyTextHitTestTest RTLTextPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -313,24 +258,19 @@ exports[`LegacyTextHitTestTest TextPressableWithVirtualText 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -341,24 +281,19 @@ exports[`LegacyTextHitTestTest ToggleVirtualTextPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -369,24 +304,19 @@ exports[`LegacyTextHitTestTest VirtualTextPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -397,24 +327,19 @@ exports[`LegacyTextHitTestTest WrappedLTRInRTLFlowEdgeCaseNotPressable 1`] = `
   "Automation Tree": {
     "AutomationId": "pressed-state",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Pressed: 1 times.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressed-state",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressed-state",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      103,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "103, 20",
     "Visual Type": "SpriteVisual",
   },
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/LegacyTextInputTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/LegacyTextInputTest.test.ts.snap
@@ -5,25 +5,20 @@ exports[`LegacyTextInputTest Click on TextInput to focus 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-log",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "onFocus
 <Log Start>",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "textinput-log",
+    },
+  },
   "Visual Tree": {
     "Comment": "textinput-log",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      38,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 38",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -34,26 +29,21 @@ exports[`LegacyTextInputTest Click on multiline TextInput to move focus away fro
   "Automation Tree": {
     "AutomationId": "textinput-log",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "onBlur
 onFocus
 <Log Start>",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "textinput-log",
+    },
+  },
   "Visual Tree": {
     "Comment": "textinput-log",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      57,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 57",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -64,9 +54,6 @@ exports[`LegacyTextInputTest TextInput onChange before onSelectionChange 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-log",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "onChange text: a
 onSelectionChange range: 1,1
@@ -113,18 +100,16 @@ onBlur
 onFocus
 <Log Start>",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "textinput-log",
+    },
+  },
   "Visual Tree": {
     "Comment": "textinput-log",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      820,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 820",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -135,9 +120,6 @@ exports[`LegacyTextInputTest Type abc on TextInput 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-log",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "onChange text: abc
 onSelectionChange range: 3,3
@@ -154,18 +136,16 @@ onBlur
 onFocus
 <Log Start>",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "textinput-log",
+    },
+  },
   "Visual Tree": {
     "Comment": "textinput-log",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      262,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 262",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -176,9 +156,6 @@ exports[`LegacyTextInputTest Type abc on multiline TextInput then press Enter ke
   "Automation Tree": {
     "AutomationId": "textinput-log",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "onSubmitEditing text: abc
 onChange text: abc
@@ -218,18 +195,16 @@ onBlur
 onFocus
 <Log Start>",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "textinput-log",
+    },
+  },
   "Visual Tree": {
     "Comment": "textinput-log",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      998,
-      690,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "998, 690",
     "Visual Type": "SpriteVisual",
   },
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/PressableComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/PressableComponentTest.test.ts.snap
@@ -4,80 +4,54 @@ exports[`Pressable Tests Pressables can be disabled, disabled = {false} 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_disabled_false",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Enabled Pressable",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_disabled_false",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              112,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          402,
-          10,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          112,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "pressable_disabled_false",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      39,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 39",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "402, 10, 0",
+        "Size": "112, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "112, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -86,80 +60,58 @@ exports[`Pressable Tests Pressables can be disabled, disabled = {true} 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_disabled_true",
-    "Children": [
+    "ControlType": 50026,
+    "IsEnabled": false,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Disabled Pressable",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": false,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_disabled_true",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.5,
-            "Size": [
-              116,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          400,
-          10,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          116,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {
+          "Opacity": 0.5,
+        },
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "pressable_disabled_true",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      38,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 38",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "400, 10, 0",
+        "Size": "116, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.5,
+            "Size": "116, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -168,84 +120,58 @@ exports[`Pressable Tests Pressables can change style when pressed 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "style-change-pressable",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Me",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "style-change-pressable",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 255, 255, 255)",
     },
-    "Children": [
+    "Comment": "style-change-pressable",
+    "Offset": "0, 0, 0",
+    "Size": "76, 34",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              64,
-              22,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          6,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          64,
-          22,
-        ],
+        "Offset": "6, 6, 0",
+        "Size": "64, 22",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "64, 22",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "style-change-pressable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      76,
-      34,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -255,24 +181,19 @@ exports[`Pressable Tests Pressables can change text on press/rest, state rest 1`
   "Automation Tree": {
     "AutomationId": "one_press_me_button",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Press Me",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "one_press_me_button",
+    },
+  },
   "Visual Tree": {
     "Comment": "one_press_me_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      64,
-      22,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "64, 22",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -283,24 +204,19 @@ exports[`Pressable Tests Pressables can change text on press/rest, state rest 2`
   "Automation Tree": {
     "AutomationId": "pressable_press_console",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "onPress",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "pressable_press_console",
+    },
+  },
   "Visual Tree": {
     "Comment": "pressable_press_console",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      854,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "854, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -310,84 +226,58 @@ exports[`Pressable Tests Pressables can have advanced borders 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_hit_slop_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Outside This View",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_hit_slop_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 0, 0, 255)",
     },
-    "Children": [
+    "Comment": "pressable_hit_slop_button",
+    "Offset": "0, 0, 0",
+    "Size": "146, 18",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              146,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          146,
-          20,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "146, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "146, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "pressable_hit_slop_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      146,
-      18,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -396,80 +286,54 @@ exports[`Pressable Tests Pressables can have delayed event handlers 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_delay_events_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Me",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_delay_events_button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              56,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          56,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "pressable_delay_events_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      56,
-      18,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "56, 18",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "56, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "56, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -478,238 +342,124 @@ exports[`Pressable Tests Pressables can have delayed event handlers 2`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_delay_events_console",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "pressOut",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "pressIn",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_delay_events_console",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(249, 249, 249, 255)",
     },
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              874,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          11,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          874,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              874,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          874,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "pressable_delay_events_console",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      896,
-      120,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "896, 120",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "11, 11, 0",
+        "Size": "874, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "874, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 29, 0",
+        "Size": "874, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "874, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -718,80 +468,56 @@ exports[`Pressable Tests Pressables can have event handlers 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_feedback_events_button",
-    "Children": [
+    "ControlType": 50000,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "pressable feedback events",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Me",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "pressable feedback events",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "pressable feedback events",
+      "TestId": "pressable_feedback_events_button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              56,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          56,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "pressable_feedback_events_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      56,
-      18,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "56, 18",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "56, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "56, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -800,338 +526,178 @@ exports[`Pressable Tests Pressables can have event handlers 2`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_feedback_events_console",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "pressOut",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "press",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "pressIn",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "hover in",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_feedback_events_console",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(249, 249, 249, 255)",
     },
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              874,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          11,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          874,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              874,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          874,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              874,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          48,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          874,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              874,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          66,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          874,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "pressable_feedback_events_console",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      896,
-      120,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "896, 120",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "11, 11, 0",
+        "Size": "874, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "874, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 29, 0",
+        "Size": "874, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "874, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 48, 0",
+        "Size": "874, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "874, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 66, 0",
+        "Size": "874, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "874, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1140,84 +706,58 @@ exports[`Pressable Tests Pressables can have hit slop functionality 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_hit_slop_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Outside This View",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_hit_slop_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 0, 0, 255)",
     },
-    "Children": [
+    "Comment": "pressable_hit_slop_button",
+    "Offset": "0, 0, 0",
+    "Size": "146, 18",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              146,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          146,
-          20,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "146, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "146, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "pressable_hit_slop_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      146,
-      18,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1226,624 +766,397 @@ exports[`Pressable Tests Pressables can have ranging opacity 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "opacity_pressable",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
         "IsKeyboardFocusable": true,
         "LocalizedControlType": "group",
-        "Name": "",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "opacity_pressable",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.10000000149011612,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.20000000298023224,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.30000001192092896,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.4000000059604645,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.5,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.6000000238418579,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.699999988079071,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.800000011920929,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.8999999761581421,
+        },
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.10000000149011612,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          50,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.20000000298023224,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          100,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.30000001192092896,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          150,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.4000000059604645,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          200,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.5,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          250,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.6000000238418579,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          300,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.699999988079071,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          350,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.800000011920929,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          400,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.8999999761581421,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          450,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          500,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "opacity_pressable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      550,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 550",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 50, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.10000000149011612,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 100, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.20000000298023224,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 150, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.30000001192092896,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 200, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.4000000059604645,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 250, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.5,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 300, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.6000000238418579,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 350, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.699999988079071,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 400, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.800000011920929,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 450, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Opacity": 0.8999999761581421,
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 500, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1852,424 +1165,249 @@ exports[`Pressable Tests Pressables can have their accessibility and keyboard fo
 {
   "Automation Tree": {
     "AutomationId": "accessible_pressable",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
-        "Children": [
+        "ControlType": 50026,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "group",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Pressable with accessible=true and focusable=true",
           },
         ],
-        "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Pressable with accessible=false",
       },
       {
         "AutomationId": "",
-        "Children": [
+        "ControlType": 50026,
+        "LocalizedControlType": "group",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Pressable with focusable=false",
           },
         ],
-        "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
-        "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Pressable with accessible=false and focusable=false",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "accessible_pressable",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          50,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          100,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          150,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "accessible_pressable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      180,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 180",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 50, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 100, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 150, 0",
+        "Size": "916, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 30",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2278,80 +1416,54 @@ exports[`Pressable Tests Pressables can have tooltips 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "tooltip_pressable",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Pressable with ToolTip "Pressable"",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "tooltip_pressable",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "tooltip_pressable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      18,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 18",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2360,562 +1472,336 @@ exports[`Pressable Tests Pressables can hide their backface 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "backface_pressable",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "View #1, front is visible, back is hidden.",
       },
       {
         "AutomationId": "",
-        "Children": [
+        "ControlType": 50026,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "group",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Front",
           },
         ],
-        "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
-        "Children": [
+        "ControlType": 50026,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "group",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Back (You should not see this)",
           },
         ],
-        "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "View #2, front is hidden, back is visible.",
       },
       {
         "AutomationId": "",
-        "Children": [
+        "ControlType": 50026,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "group",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Front (You should not see this)",
           },
         ],
-        "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "group",
-        "Name": "",
       },
       {
         "AutomationId": "",
-        "Children": [
+        "ControlType": 50026,
+        "IsKeyboardFocusable": true,
+        "LocalizedControlType": "group",
+        "__Children": [
           {
             "AutomationId": "",
             "ControlType": 50020,
-            "HelpText": "",
-            "IsEnabled": true,
-            "IsKeyboardFocusable": false,
             "LocalizedControlType": "text",
             "Name": "Back",
           },
         ],
-        "ControlType": 50026,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": true,
-        "LocalizedControlType": "group",
-        "Name": "",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "backface_pressable",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 255, 255)",
-            },
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      34,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  83,
-                  90,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              200,
-              200,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          358,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          200,
-          200,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 0, 0, 255)",
-            },
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      184,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  8,
-                  90,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  184,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              200,
-              200,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          358,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          200,
-          200,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              39,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          228,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          39,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 255, 255)",
-            },
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      188,
-                      19,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  6,
-                  90,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  188,
-                  19,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              200,
-              200,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          358,
-          267,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          200,
-          200,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 0, 0, 255)",
-            },
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      30,
-                      19,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  85,
-                  90,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  30,
-                  19,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              200,
-              200,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          358,
-          267,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          200,
-          200,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "backface_pressable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      468,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 468",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "358, 29, 0",
+        "Size": "200, 200",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 255, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "200, 200",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "83, 90, 0",
+                "Size": "34, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "34, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "358, 29, 0",
+        "Size": "200, 200",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "200, 200",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "8, 90, 0",
+                "Size": "184, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "184, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 228, 0",
+        "Size": "916, 39",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 39",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "358, 267, 0",
+        "Size": "200, 200",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 255, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "200, 200",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "6, 90, 0",
+                "Size": "188, 19",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "188, 19",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "358, 267, 0",
+        "Size": "200, 200",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "200, 200",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "85, 90, 0",
+                "Size": "30, 19",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "30, 19",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2925,24 +1811,19 @@ exports[`Pressable Tests Text can have pressable behavior 1`] = `
   "Automation Tree": {
     "AutomationId": "tappable_text",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Text has built-in onPress handling",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "tappable_text",
+    },
+  },
   "Visual Tree": {
     "Comment": "tappable_text",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -2953,24 +1834,19 @@ exports[`Pressable Tests Text can have pressable behavior 2`] = `
   "Automation Tree": {
     "AutomationId": "tappable_text_console",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "2x text onPress",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "tappable_text_console",
+    },
+  },
   "Visual Tree": {
     "Comment": "tappable_text_console",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      854,
-      19,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "854, 19",
     "Visual Type": "SpriteVisual",
   },
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/ScrollViewComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/ScrollViewComponentTest.test.ts.snap
@@ -4,84 +4,58 @@ exports[`ScrollView Tests ScrollView has scrollTo method, scroll to bottom butto
 {
   "Automation Tree": {
     "AutomationId": "scroll_to_bottom_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Scroll to bottom",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "scroll_to_bottom_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(204, 204, 204, 255)",
     },
-    "Children": [
+    "Comment": "scroll_to_bottom_button",
+    "Offset": "0, 0, 0",
+    "Size": "906, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              102,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          402,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          102,
-          19,
-        ],
+        "Offset": "402, 5, 0",
+        "Size": "102, 19",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "102, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "scroll_to_bottom_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      906,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -90,84 +64,58 @@ exports[`ScrollView Tests ScrollView has scrollTo method, scroll to end button 1
 {
   "Automation Tree": {
     "AutomationId": "scroll_to_end_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Scroll to end",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "scroll_to_end_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(204, 204, 204, 255)",
     },
-    "Children": [
+    "Comment": "scroll_to_end_button",
+    "Offset": "0, 0, 0",
+    "Size": "906, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              78,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          414,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          78,
-          19,
-        ],
+        "Offset": "414, 5, 0",
+        "Size": "78, 19",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "78, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "scroll_to_end_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      906,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -176,84 +124,58 @@ exports[`ScrollView Tests ScrollView has scrollTo method, scroll to start button
 {
   "Automation Tree": {
     "AutomationId": "scroll_to_start_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Scroll to start",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "scroll_to_start_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(204, 204, 204, 255)",
     },
-    "Children": [
+    "Comment": "scroll_to_start_button",
+    "Offset": "0, 0, 0",
+    "Size": "906, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              82,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          412,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          82,
-          20,
-        ],
+        "Offset": "412, 5, 0",
+        "Size": "82, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "82, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "scroll_to_start_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      906,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -262,84 +184,58 @@ exports[`ScrollView Tests ScrollView has scrollTo method, scroll to top button 1
 {
   "Automation Tree": {
     "AutomationId": "scroll_to_top_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Scroll to top",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "scroll_to_top_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(204, 204, 204, 255)",
     },
-    "Children": [
+    "Comment": "scroll_to_top_button",
+    "Offset": "0, 0, 0",
+    "Size": "906, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              76,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          415,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          76,
-          20,
-        ],
+        "Offset": "415, 5, 0",
+        "Size": "76, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "76, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "scroll_to_top_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      906,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -348,84 +244,58 @@ exports[`ScrollView Tests ScrollViews has flash scroll indicators 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "flash_scroll_indicators_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Flash scroll indicators",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "flash_scroll_indicators_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(204, 204, 204, 255)",
     },
-    "Children": [
+    "Comment": "flash_scroll_indicators_button",
+    "Offset": "0, 0, 0",
+    "Size": "906, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              132,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          387,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          132,
-          20,
-        ],
+        "Offset": "387, 5, 0",
+        "Size": "132, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "132, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "flash_scroll_indicators_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      906,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextComponentTest.test.ts.snap
@@ -5,24 +5,19 @@ exports[`Text Tests Padding can be added to Text 1`] = `
   "Automation Tree": {
     "AutomationId": "text-padding",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "This text is indented by 10px padding on all sides.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-padding",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-padding",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      39,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 39",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -33,24 +28,19 @@ exports[`Text Tests Text can be restricted to one line 1`] = `
   "Automation Tree": {
     "AutomationId": "text-one-line",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Maximum of one line no matter now much I write here. If I keep writing it'll just truncate after one line. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed dapibus felis eget augue condimentum suscipit. Suspendisse hendrerit, libero aliquet malesuada tempor, urna nibh consectetur tellus, vitae efficitur quam erat non mi. Maecenas vitae eros sit amet quam vestibulum porta sed sit amet tellus. Fusce quis lectus congue, fringilla arcu id, luctus urna. Cras sagittis ornare mauris sit amet dictum. Vestibulum feugiat laoreet fringilla. Vivamus ac diam vehicula felis venenatis sagittis vitae ultrices elit. Curabitur libero augue, laoreet quis orci vitae, congue euismod massa. Aenean nec odio sed urna vehicula fermentum non a magna. Quisque ut commodo neque, eget eleifend odio. Sed sit amet lacinia sem. Suspendisse in metus in purus scelerisque vestibulum. Nam metus dui, efficitur nec metus non, tincidunt pharetra sapien. Praesent id convallis metus, ut malesuada arcu. Quisque quam libero, pharetra eu tellus ac, aliquam fringilla erat. Quisque tempus in lorem ac suscipit.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-one-line",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-one-line",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      19,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 19",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -61,24 +51,19 @@ exports[`Text Tests Text can be selectable 1`] = `
   "Automation Tree": {
     "AutomationId": "text-selectable",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "This text is selectable if you click-and-hold, and will offer the native Android selection menus.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-selectable",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-selectable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -89,24 +74,19 @@ exports[`Text Tests Text can have a color 1`] = `
   "Automation Tree": {
     "AutomationId": "text-color",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Red color",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-color",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -117,24 +97,19 @@ exports[`Text Tests Text can have a customized selection color 1`] = `
   "Automation Tree": {
     "AutomationId": "text-selection-color",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "This text will have a orange highlight on selection.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-selection-color",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-selection-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      19,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 19",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -145,24 +120,19 @@ exports[`Text Tests Text can have a size 1`] = `
   "Automation Tree": {
     "AutomationId": "text-size",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Size 23",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-size",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-size",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      32,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 32",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -173,24 +143,19 @@ exports[`Text Tests Text can have an outer color 1`] = `
   "Automation Tree": {
     "AutomationId": "text-outer-color",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "(Normal text,(R)red(G)green(B)blue(C)cyan(M)magenta(Y)yellow(K)black(and bold(and tiny bold italic blue(and tiny normal blue))))",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-outer-color",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-outer-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -201,24 +166,19 @@ exports[`Text Tests Text can have decoration lines: Solid Line Through 1`] = `
   "Automation Tree": {
     "AutomationId": "text-decoration-solid-linethru",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Solid line-through",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-decoration-solid-linethru",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-decoration-solid-linethru",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -229,24 +189,19 @@ exports[`Text Tests Text can have decoration lines: Underline 1`] = `
   "Automation Tree": {
     "AutomationId": "text-decoration-underline",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Solid underline",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-decoration-underline",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-decoration-underline",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -257,24 +212,19 @@ exports[`Text Tests Text can have shadows 1`] = `
   "Automation Tree": {
     "AutomationId": "text-shadow",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Demo text shadow",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-shadow",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-shadow",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      27,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 27",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -285,24 +235,19 @@ exports[`Text Tests Text can wrap 1`] = `
   "Automation Tree": {
     "AutomationId": "text-wrap",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "The text should wrap if it goes on multiple lines. See, this is going to the next line. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed dapibus felis eget augue condimentum suscipit. Suspendisse hendrerit, libero aliquet malesuada tempor, urna nibh consectetur tellus, vitae efficitur quam erat non mi. Maecenas vitae eros sit amet quam vestibulum porta sed sit amet tellus. Fusce quis lectus congue, fringilla arcu id, luctus urna. Cras sagittis ornare mauris sit amet dictum. Vestibulum feugiat laoreet fringilla. Vivamus ac diam vehicula felis venenatis sagittis vitae ultrices elit. Curabitur libero augue, laoreet quis orci vitae, congue euismod massa. Aenean nec odio sed urna vehicula fermentum non a magna. Quisque ut commodo neque, eget eleifend odio. Sed sit amet lacinia sem. Suspendisse in metus in purus scelerisque vestibulum. Nam metus dui, efficitur nec metus non, tincidunt pharetra sapien. Praesent id convallis metus, ut malesuada arcu. Quisque quam libero, pharetra eu tellus ac, aliquam fringilla erat. Quisque tempus in lorem ac suscipit.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "text-wrap",
+    },
+  },
   "Visual Tree": {
     "Comment": "text-wrap",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      834,
-      169,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "834, 169",
     "Visual Type": "SpriteVisual",
   },
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -5,116 +5,59 @@ exports[`TextInput Tests Multi-line TextInputs can enable text selection (Impera
   "Automation Tree": {
     "AutomationId": "multilineImperative-text-input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "multilineImperative-text-input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "multilineImperative-text-input",
+    "Offset": "0, 0, 0",
+    "Size": "916, 50",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -122,31 +65,12 @@ exports[`TextInput Tests Multi-line TextInputs can enable text selection (Impera
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "multilineImperative-text-input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      50,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -156,116 +80,59 @@ exports[`TextInput Tests Multi-line TextInputs can enable text selection 1`] = `
   "Automation Tree": {
     "AutomationId": "multiline-text-input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "multiline-text-input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "multiline-text-input",
+    "Offset": "0, 0, 0",
+    "Size": "916, 50",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -273,31 +140,12 @@ exports[`TextInput Tests Multi-line TextInputs can enable text selection 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "multiline-text-input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      50,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -307,116 +155,59 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection (Imper
   "Automation Tree": {
     "AutomationId": "singlelineImperative-text-input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "singlelineImperative-text-input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "singlelineImperative-text-input",
+    "Offset": "0, 0, 0",
+    "Size": "916, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -424,31 +215,12 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection (Imper
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "singlelineImperative-text-input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -458,116 +230,59 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection 1`] = 
   "Automation Tree": {
     "AutomationId": "singleline-text-input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "singleline-text-input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "singleline-text-input",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -575,31 +290,12 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection 1`] = 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "singleline-text-input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -610,115 +306,60 @@ exports[`TextInput Tests Text have cursorColor 1`] = `
     "AutomationId": "textinput-cursorColor",
     "ControlType": 50004,
     "HelpText": "cursorColor={"green"}",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "cursorColor={"green"}",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-cursorColor",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-cursorColor",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -726,31 +367,12 @@ exports[`TextInput Tests Text have cursorColor 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 128, 0, 255)",
         },
-        "Offset": [
-          83,
-          133,
-          0,
-        ],
+        "Offset": "83, 5, 0",
         "Opacity": 0,
-        "Size": [
-          1,
-          19,
-        ],
+        "Size": "1, 19",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-cursorColor",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -760,116 +382,59 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Character
   "Automation Tree": {
     "AutomationId": "capitalize-characters",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "capitalize-characters",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "capitalize-characters",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -877,31 +442,12 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Character
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "capitalize-characters",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -911,116 +457,59 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Sentences
   "Automation Tree": {
     "AutomationId": "capitalize-sentences",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "capitalize-sentences",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "capitalize-sentences",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -1028,31 +517,12 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Sentences
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "capitalize-sentences",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1062,116 +532,59 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Turned Of
   "Automation Tree": {
     "AutomationId": "capitalize-none",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "capitalize-none",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "capitalize-none",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -1179,31 +592,12 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Turned Of
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "capitalize-none",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1213,116 +607,59 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Words 1`]
   "Automation Tree": {
     "AutomationId": "capitalize-words",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "capitalize-words",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "capitalize-words",
+    "Offset": "0, 0, 0",
+    "Size": "791, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -1330,31 +667,12 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Words 1`]
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "capitalize-words",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1365,115 +683,60 @@ exports[`TextInput Tests TextInputs can autocomplete, address country 1`] = `
     "AutomationId": "textinput-autocomplete-address-country",
     "ControlType": 50004,
     "HelpText": "postal-address-country",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "postal-address-country",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-autocomplete-address-country",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-autocomplete-address-country",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -1481,31 +744,12 @@ exports[`TextInput Tests TextInputs can autocomplete, address country 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-autocomplete-address-country",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1516,115 +760,60 @@ exports[`TextInput Tests TextInputs can autocomplete, country 1`] = `
     "AutomationId": "textinput-autocomplete-country",
     "ControlType": 50004,
     "HelpText": "country",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "country",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-autocomplete-country",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-autocomplete-country",
+    "Offset": "0, 0, 0",
+    "Size": "916, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -1632,31 +821,12 @@ exports[`TextInput Tests TextInputs can autocomplete, country 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-autocomplete-country",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1667,115 +837,60 @@ exports[`TextInput Tests TextInputs can autocomplete, one-time-code 1`] = `
     "AutomationId": "textinput-autocomplete-one-time-code",
     "ControlType": 50004,
     "HelpText": "one-time-code",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "one-time-code",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-autocomplete-one-time-code",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-autocomplete-one-time-code",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -1783,31 +898,12 @@ exports[`TextInput Tests TextInputs can autocomplete, one-time-code 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-autocomplete-one-time-code",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1818,115 +914,60 @@ exports[`TextInput Tests TextInputs can autocomplete, sms-otp 1`] = `
     "AutomationId": "textinput-autocomplete-sms-otp",
     "ControlType": 50004,
     "HelpText": "sms-otp",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "sms-otp",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-autocomplete-sms-otp",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-autocomplete-sms-otp",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -1934,31 +975,12 @@ exports[`TextInput Tests TextInputs can autocomplete, sms-otp 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-autocomplete-sms-otp",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1968,116 +990,59 @@ exports[`TextInput Tests TextInputs can autogrow 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-autogrow",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-autogrow",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-autogrow",
+    "Offset": "0, 0, 0",
+    "Size": "916, 51",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -2085,31 +1050,12 @@ exports[`TextInput Tests TextInputs can autogrow 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-autogrow",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      51,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -2120,115 +1066,60 @@ exports[`TextInput Tests TextInputs can be editable 1`] = `
     "AutomationId": "textinput-editable",
     "ControlType": 50004,
     "HelpText": "editable text input using editable prop",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "editable text input using editable prop",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-editable",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-editable",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -2236,31 +1127,12 @@ exports[`TextInput Tests TextInputs can be editable 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-editable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -2270,116 +1142,59 @@ exports[`TextInput Tests TextInputs can be multiline, bottomright alignment 1`] 
   "Automation Tree": {
     "AutomationId": "textinput-multiline-bottomright",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-multiline-bottomright",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-multiline-bottomright",
+    "Offset": "0, 0, 0",
+    "Size": "916, 60",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -2387,31 +1202,12 @@ exports[`TextInput Tests TextInputs can be multiline, bottomright alignment 1`] 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 255, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-multiline-bottomright",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      60,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -2422,115 +1218,60 @@ exports[`TextInput Tests TextInputs can be multiline, center alignment 1`] = `
     "AutomationId": "textinput-multiline-center",
     "ControlType": 50004,
     "HelpText": "multiline, aligned center",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "multiline, aligned center",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-multiline-center",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-multiline-center",
+    "Offset": "0, 0, 0",
+    "Size": "916, 60",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -2538,31 +1279,12 @@ exports[`TextInput Tests TextInputs can be multiline, center alignment 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-multiline-center",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      60,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -2573,115 +1295,60 @@ exports[`TextInput Tests TextInputs can be multiline, topleft alignment 1`] = `
     "AutomationId": "textinput-multiline-topleft",
     "ControlType": 50004,
     "HelpText": "multiline, aligned top-left",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "multiline, aligned top-left",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-multiline-topleft",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-multiline-topleft",
+    "Offset": "0, 0, 0",
+    "Size": "916, 60",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -2689,31 +1356,12 @@ exports[`TextInput Tests TextInputs can be multiline, topleft alignment 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-multiline-topleft",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      60,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -2723,116 +1371,59 @@ exports[`TextInput Tests TextInputs can be set to not editable 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-not-editable",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-not-editable",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-not-editable",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -2840,31 +1431,12 @@ exports[`TextInput Tests TextInputs can be set to not editable 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-not-editable",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -2875,115 +1447,60 @@ exports[`TextInput Tests TextInputs can be set to not editable 2 1`] = `
     "AutomationId": "textinput-not-editable2",
     "ControlType": 50004,
     "HelpText": "uneditable text input using editable prop",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "uneditable text input using editable prop",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-not-editable2",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-not-editable2",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -2991,31 +1508,12 @@ exports[`TextInput Tests TextInputs can be set to not editable 2 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-not-editable2",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3025,116 +1523,59 @@ exports[`TextInput Tests TextInputs can clear on submit 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-clear-on-submit",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-clear-on-submit",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-clear-on-submit",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -3142,31 +1583,12 @@ exports[`TextInput Tests TextInputs can clear on submit 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          5,
-          5,
-          0,
-        ],
+        "Offset": "5, 5, 0",
         "Opacity": 0,
-        "Size": [
-          1,
-          19,
-        ],
+        "Size": "1, 19",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-clear-on-submit",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3176,116 +1598,59 @@ exports[`TextInput Tests TextInputs can clear on submit with custom submit key e
   "Automation Tree": {
     "AutomationId": "textinput-clear-on-submit-3",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-clear-on-submit-3",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-clear-on-submit-3",
+    "Offset": "0, 0, 0",
+    "Size": "916, 60",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -3293,31 +1658,12 @@ exports[`TextInput Tests TextInputs can clear on submit with custom submit key e
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-clear-on-submit-3",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      60,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3327,116 +1673,59 @@ exports[`TextInput Tests TextInputs can clear on submit with custom submit key e
   "Automation Tree": {
     "AutomationId": "textinput-clear-on-submit-2",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-clear-on-submit-2",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-clear-on-submit-2",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -3444,31 +1733,12 @@ exports[`TextInput Tests TextInputs can clear on submit with custom submit key e
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-clear-on-submit-2",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3478,116 +1748,59 @@ exports[`TextInput Tests TextInputs can customize its padding 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-padding",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-padding",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-padding",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -3595,31 +1808,12 @@ exports[`TextInput Tests TextInputs can customize its padding 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-padding",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3630,115 +1824,60 @@ exports[`TextInput Tests TextInputs can enable spellcheck 1`] = `
     "AutomationId": "textinput-spellcheck",
     "ControlType": 50004,
     "HelpText": "Type text to test spell check functionality.",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Type text to test spell check functionality.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-spellcheck",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-spellcheck",
+    "Offset": "0, 0, 0",
+    "Size": "916, 30",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -3746,31 +1885,12 @@ exports[`TextInput Tests TextInputs can enable spellcheck 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-spellcheck",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      30,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3780,116 +1900,59 @@ exports[`TextInput Tests TextInputs can have a background color 1`] = `
   "Automation Tree": {
     "AutomationId": "style-backgroundColor",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-backgroundColor",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-backgroundColor",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -3897,31 +1960,12 @@ exports[`TextInput Tests TextInputs can have a background color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-backgroundColor",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -3931,116 +1975,59 @@ exports[`TextInput Tests TextInputs can have a color 1`] = `
   "Automation Tree": {
     "AutomationId": "style-color",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-color",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-color",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -4048,31 +2035,12 @@ exports[`TextInput Tests TextInputs can have a color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -4082,116 +2050,59 @@ exports[`TextInput Tests TextInputs can have a font family 1`] = `
   "Automation Tree": {
     "AutomationId": "style-fontFamily",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-fontFamily",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-fontFamily",
+    "Offset": "0, 0, 0",
+    "Size": "791, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -4199,31 +2110,12 @@ exports[`TextInput Tests TextInputs can have a font family 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-fontFamily",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -4233,116 +2125,59 @@ exports[`TextInput Tests TextInputs can have a font size 1`] = `
   "Automation Tree": {
     "AutomationId": "style-fontSize",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-fontSize",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-fontSize",
+    "Offset": "0, 0, 0",
+    "Size": "791, 35",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -4350,31 +2185,12 @@ exports[`TextInput Tests TextInputs can have a font size 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-fontSize",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      35,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -4384,116 +2200,59 @@ exports[`TextInput Tests TextInputs can have a font style 1`] = `
   "Automation Tree": {
     "AutomationId": "style-fontStyle",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-fontStyle",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-fontStyle",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -4501,31 +2260,12 @@ exports[`TextInput Tests TextInputs can have a font style 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-fontStyle",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -4535,116 +2275,59 @@ exports[`TextInput Tests TextInputs can have a font weight 1`] = `
   "Automation Tree": {
     "AutomationId": "style-fontWeight",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-fontWeight",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-fontWeight",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -4652,31 +2335,12 @@ exports[`TextInput Tests TextInputs can have a font weight 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-fontWeight",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -4686,116 +2350,59 @@ exports[`TextInput Tests TextInputs can have attributed text 1`] = `
   "Automation Tree": {
     "AutomationId": "text-input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "text-input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "text-input",
+    "Offset": "0, 0, 0",
+    "Size": "916, 50",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -4803,31 +2410,12 @@ exports[`TextInput Tests TextInputs can have attributed text 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "text-input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      50,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -4838,115 +2426,60 @@ exports[`TextInput Tests TextInputs can have caretHidden 1`] = `
     "AutomationId": "textinput-carethidden",
     "ControlType": 50004,
     "HelpText": "caretHidden={true}",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "caretHidden={true}",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-carethidden",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-carethidden",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -4954,31 +2487,12 @@ exports[`TextInput Tests TextInputs can have caretHidden 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          83,
-          5,
-          0,
-        ],
+        "Offset": "83, 5, 0",
         "Opacity": 0,
-        "Size": [
-          1,
-          19,
-        ],
+        "Size": "1, 19",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-carethidden",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -4989,115 +2503,60 @@ exports[`TextInput Tests TextInputs can have custom return key label, Compile 1`
     "AutomationId": "textinput-return-Compile",
     "ControlType": 50004,
     "HelpText": "returnKeyLabel: Compile",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyLabel: Compile",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-Compile",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-Compile",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -5105,31 +2564,12 @@ exports[`TextInput Tests TextInputs can have custom return key label, Compile 1`
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-Compile",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -5140,115 +2580,60 @@ exports[`TextInput Tests TextInputs can have custom return key label, React Nati
     "AutomationId": "textinput-return-React Native",
     "ControlType": 50004,
     "HelpText": "returnKeyLabel: React Native",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyLabel: React Native",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-React Native",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-React Native",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -5256,31 +2641,12 @@ exports[`TextInput Tests TextInputs can have custom return key label, React Nati
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-React Native",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -5291,115 +2657,60 @@ exports[`TextInput Tests TextInputs can have custom return key type, done 1`] = 
     "AutomationId": "textinput-return-done",
     "ControlType": 50004,
     "HelpText": "returnKeyType: done",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyType: done",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-done",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-done",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -5407,31 +2718,12 @@ exports[`TextInput Tests TextInputs can have custom return key type, done 1`] = 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-done",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -5442,115 +2734,60 @@ exports[`TextInput Tests TextInputs can have custom return key type, go 1`] = `
     "AutomationId": "textinput-return-go",
     "ControlType": 50004,
     "HelpText": "returnKeyType: go",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyType: go",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-go",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-go",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -5558,31 +2795,12 @@ exports[`TextInput Tests TextInputs can have custom return key type, go 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-go",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -5593,115 +2811,60 @@ exports[`TextInput Tests TextInputs can have custom return key type, next 1`] = 
     "AutomationId": "textinput-return-next",
     "ControlType": 50004,
     "HelpText": "returnKeyType: next",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyType: next",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-next",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-next",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -5709,31 +2872,12 @@ exports[`TextInput Tests TextInputs can have custom return key type, next 1`] = 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-next",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -5744,115 +2888,60 @@ exports[`TextInput Tests TextInputs can have custom return key type, none 1`] = 
     "AutomationId": "textinput-return-none",
     "ControlType": 50004,
     "HelpText": "returnKeyType: none",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyType: none",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-none",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-none",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -5860,31 +2949,12 @@ exports[`TextInput Tests TextInputs can have custom return key type, none 1`] = 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-none",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -5895,115 +2965,60 @@ exports[`TextInput Tests TextInputs can have custom return key type, previous 1`
     "AutomationId": "textinput-return-previous",
     "ControlType": 50004,
     "HelpText": "returnKeyType: previous",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyType: previous",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-previous",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-previous",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -6011,31 +3026,12 @@ exports[`TextInput Tests TextInputs can have custom return key type, previous 1`
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-previous",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -6046,115 +3042,60 @@ exports[`TextInput Tests TextInputs can have custom return key type, search 1`] 
     "AutomationId": "textinput-return-search",
     "ControlType": 50004,
     "HelpText": "returnKeyType: search",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyType: search",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-search",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-search",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -6162,31 +3103,12 @@ exports[`TextInput Tests TextInputs can have custom return key type, search 1`] 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-search",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -6197,115 +3119,60 @@ exports[`TextInput Tests TextInputs can have custom return key type, send 1`] = 
     "AutomationId": "textinput-return-send",
     "ControlType": 50004,
     "HelpText": "returnKeyType: send",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "returnKeyType: send",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-return-send",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-return-send",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -6313,31 +3180,12 @@ exports[`TextInput Tests TextInputs can have custom return key type, send 1`] = 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-return-send",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -6348,115 +3196,60 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=-1
     "AutomationId": "textinput-letterspacing--1",
     "ControlType": 50004,
     "HelpText": "letterSpacing = -1",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "letterSpacing = -1",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-letterspacing--1",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-letterspacing--1",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -6464,31 +3257,12 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=-1
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-letterspacing--1",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -6499,115 +3273,60 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=0 
     "AutomationId": "textinput-letterspacing-0",
     "ControlType": 50004,
     "HelpText": "letterSpacing = 0",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "letterSpacing = 0",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-letterspacing-0",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-letterspacing-0",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -6615,31 +3334,12 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=0 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-letterspacing-0",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -6650,115 +3350,60 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=2 
     "AutomationId": "textinput-letterspacing-2",
     "ControlType": 50004,
     "HelpText": "letterSpacing = 2",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "letterSpacing = 2",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-letterspacing-2",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-letterspacing-2",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -6766,31 +3411,12 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=2 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-letterspacing-2",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -6801,115 +3427,60 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=9 
     "AutomationId": "textinput-letterspacing-9",
     "ControlType": 50004,
     "HelpText": "letterSpacing = 9",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "letterSpacing = 9",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-letterspacing-9",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-letterspacing-9",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -6917,31 +3488,12 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=9 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-letterspacing-9",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -6949,6 +3501,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=9 
 exports[`TextInput Tests TextInputs can have customized font weight, 100 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -6956,6 +3509,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 100 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 200 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -6963,6 +3517,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 200 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 300 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -6970,6 +3525,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 300 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 400 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -6977,6 +3533,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 400 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 500 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -6984,6 +3541,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 500 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 600 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -6991,6 +3549,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 600 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 700 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -6998,6 +3557,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 700 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 800 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -7005,6 +3565,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 800 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, 900 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -7012,6 +3573,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, 900 1`] = `
 exports[`TextInput Tests TextInputs can have customized font weight, bold 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -7019,6 +3581,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, bold 1`] = 
 exports[`TextInput Tests TextInputs can have customized font weight, default 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -7026,6 +3589,7 @@ exports[`TextInput Tests TextInputs can have customized font weight, default 1`]
 exports[`TextInput Tests TextInputs can have customized font weight, normal 1`] = `
 {
   "Automation Tree": {},
+  "Component Tree": {},
   "Visual Tree": {},
 }
 `;
@@ -7035,116 +3599,59 @@ exports[`TextInput Tests TextInputs can have customized letter spacing 1`] = `
   "Automation Tree": {
     "AutomationId": "style-letterSpacing",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-letterSpacing",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-letterSpacing",
+    "Offset": "0, 0, 0",
+    "Size": "791, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -7152,31 +3659,12 @@ exports[`TextInput Tests TextInputs can have customized letter spacing 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-letterSpacing",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -7186,116 +3674,59 @@ exports[`TextInput Tests TextInputs can have customized line height 1`] = `
   "Automation Tree": {
     "AutomationId": "style-lineHeight",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-lineHeight",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-lineHeight",
+    "Offset": "0, 0, 0",
+    "Size": "791, 26",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -7303,31 +3734,12 @@ exports[`TextInput Tests TextInputs can have customized line height 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-lineHeight",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      26,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -7338,115 +3750,60 @@ exports[`TextInput Tests TextInputs can have inline images 1`] = `
     "AutomationId": "textinput-inline-images",
     "ControlType": 50004,
     "HelpText": "This has drawableLeft set",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "This has drawableLeft set",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-inline-images",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-inline-images",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -7454,31 +3811,12 @@ exports[`TextInput Tests TextInputs can have inline images 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-inline-images",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -7489,115 +3827,60 @@ exports[`TextInput Tests TextInputs can have inline images, drawable props not s
     "AutomationId": "textinput-inline-images-3",
     "ControlType": 50004,
     "HelpText": "This does not have drawable props set",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "This does not have drawable props set",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-inline-images-3",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-inline-images-3",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -7605,31 +3888,12 @@ exports[`TextInput Tests TextInputs can have inline images, drawable props not s
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-inline-images-3",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -7640,115 +3904,60 @@ exports[`TextInput Tests TextInputs can have inline images, drawableLeft and dra
     "AutomationId": "textinput-inline-images-2",
     "ControlType": 50004,
     "HelpText": "This has drawableLeft and drawablePadding set",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "This has drawableLeft and drawablePadding set",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-inline-images-2",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-inline-images-2",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -7756,31 +3965,12 @@ exports[`TextInput Tests TextInputs can have inline images, drawableLeft and dra
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-inline-images-2",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -7791,115 +3981,60 @@ exports[`TextInput Tests TextInputs can have shadows 1`] = `
     "AutomationId": "textinput-shadow",
     "ControlType": 50004,
     "HelpText": "shadowColor: purple",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "shadowColor: purple",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-shadow",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-shadow",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -7907,31 +4042,12 @@ exports[`TextInput Tests TextInputs can have shadows 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-shadow",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -7941,116 +4057,59 @@ exports[`TextInput Tests TextInputs can have text decoration lines 1`] = `
   "Automation Tree": {
     "AutomationId": "style-textDecorationLine",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-textDecorationLine",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-textDecorationLine",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -8058,31 +4117,12 @@ exports[`TextInput Tests TextInputs can have text decoration lines 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-textDecorationLine",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -8092,116 +4132,59 @@ exports[`TextInput Tests TextInputs can have text shadows 1`] = `
   "Automation Tree": {
     "AutomationId": "style-textShadow",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "style-textShadow",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "style-textShadow",
+    "Offset": "0, 0, 0",
+    "Size": "791, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -8209,31 +4192,12 @@ exports[`TextInput Tests TextInputs can have text shadows 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "style-textShadow",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      791,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -8244,115 +4208,60 @@ exports[`TextInput Tests TextInputs can propagate events 1`] = `
     "AutomationId": "textinput-propagation",
     "ControlType": 50004,
     "HelpText": "Click inside the box to observe events being fired.",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Click inside the box to observe events being fired.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-propagation",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-propagation",
+    "Offset": "0, 0, 0",
+    "Size": "916, 30",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -8360,31 +4269,12 @@ exports[`TextInput Tests TextInputs can propagate events 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-propagation",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      30,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -8395,115 +4285,60 @@ exports[`TextInput Tests TextInputs can register press events 1`] = `
     "AutomationId": "textinput-press",
     "ControlType": 50004,
     "HelpText": "Click inside the box to observe events being fired.",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Click inside the box to observe events being fired.",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-press",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-press",
+    "Offset": "0, 0, 0",
+    "Size": "916, 30",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -8511,31 +4346,12 @@ exports[`TextInput Tests TextInputs can register press events 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-press",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      30,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -8545,116 +4361,59 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with C
   "Automation Tree": {
     "AutomationId": "rewrite_clear_input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "rewrite_clear_input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "rewrite_clear_input",
+    "Offset": "0, 0, 0",
+    "Size": "867, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -8662,31 +4421,12 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with C
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "rewrite_clear_input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      867,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -8696,116 +4436,59 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with N
   "Automation Tree": {
     "AutomationId": "rewrite_no_sp_input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "rewrite_no_sp_input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "rewrite_no_sp_input",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -8813,31 +4496,12 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with N
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "rewrite_no_sp_input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -8847,116 +4511,59 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with U
   "Automation Tree": {
     "AutomationId": "rewrite_sp_underscore_input",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "rewrite_sp_underscore_input",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "rewrite_sp_underscore_input",
+    "Offset": "0, 0, 0",
+    "Size": "892, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -8964,31 +4571,12 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with U
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "rewrite_sp_underscore_input",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      892,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -8999,115 +4587,60 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to false 1`] = `
     "AutomationId": "textinput-readonly-false",
     "ControlType": 50004,
     "HelpText": "editable text input using readOnly prop",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "editable text input using readOnly prop",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-readonly-false",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-readonly-false",
+    "Offset": "0, 0, 0",
+    "Size": "916, 29",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -9115,31 +4648,12 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to false 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-readonly-false",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      29,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -9150,115 +4664,60 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to true 1`] = `
     "AutomationId": "textinput-readyonly",
     "ControlType": 50004,
     "HelpText": "uneditable text input using readOnly prop",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "uneditable text input using readOnly prop",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-readyonly",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-readyonly",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -9266,31 +4725,12 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to true 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-readyonly",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -9300,116 +4740,59 @@ exports[`TextInput Tests TextInputs can submit with custom key, multilined and s
   "Automation Tree": {
     "AutomationId": "textinput-clear-on-submit-4",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-clear-on-submit-4",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-clear-on-submit-4",
+    "Offset": "0, 0, 0",
+    "Size": "916, 60",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -9417,31 +4800,12 @@ exports[`TextInput Tests TextInputs can submit with custom key, multilined and s
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          5,
-          5,
-          0,
-        ],
+        "Offset": "5, 5, 0",
         "Opacity": 0,
-        "Size": [
-          1,
-          19,
-        ],
+        "Size": "1, 19",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-clear-on-submit-4",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      60,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -9451,116 +4815,59 @@ exports[`TextInput Tests TextInputs have a custom background color 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-custom-background-color",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-custom-background-color",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-custom-background-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -9568,31 +4875,12 @@ exports[`TextInput Tests TextInputs have a custom background color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-custom-background-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -9602,116 +4890,59 @@ exports[`TextInput Tests TextInputs have a custom highlight color 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-custom-highlight-color",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-custom-highlight-color",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-custom-highlight-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -9719,31 +4950,12 @@ exports[`TextInput Tests TextInputs have a custom highlight color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-custom-highlight-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -9754,115 +4966,60 @@ exports[`TextInput Tests TextInputs have a custom placeholder text color 1`] = `
     "AutomationId": "textinput-custom-placeholder-color",
     "ControlType": 50004,
     "HelpText": "Red placeholder text color",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Red placeholder text color",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-custom-placeholder-color",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-custom-placeholder-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -9870,31 +5027,12 @@ exports[`TextInput Tests TextInputs have a custom placeholder text color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-custom-placeholder-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -9904,116 +5042,59 @@ exports[`TextInput Tests TextInputs have a custom text color 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-custom-color",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-custom-color",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-custom-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -10021,31 +5102,12 @@ exports[`TextInput Tests TextInputs have a custom text color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 128, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-custom-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -10056,115 +5118,60 @@ exports[`TextInput Tests TextInputs have a custom underline color 1`] = `
     "AutomationId": "textinput-custom-underline-color",
     "ControlType": 50004,
     "HelpText": "Blue underline color",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Blue underline color",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-custom-underline-color",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-custom-underline-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -10172,31 +5179,12 @@ exports[`TextInput Tests TextInputs have a custom underline color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-custom-underline-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -10207,115 +5195,60 @@ exports[`TextInput Tests TextInputs have a default placeholder text color 1`] = 
     "AutomationId": "textinput-default-placeholder-color",
     "ControlType": 50004,
     "HelpText": "Default placeholder text color",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Default placeholder text color",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-default-placeholder-color",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-default-placeholder-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -10323,31 +5256,12 @@ exports[`TextInput Tests TextInputs have a default placeholder text color 1`] = 
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-default-placeholder-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -10357,116 +5271,59 @@ exports[`TextInput Tests TextInputs have a default text color 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-default-color",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-default-color",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-default-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -10474,31 +5331,12 @@ exports[`TextInput Tests TextInputs have a default text color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-default-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -10509,115 +5347,60 @@ exports[`TextInput Tests TextInputs have a default underline color 1`] = `
     "AutomationId": "textinput-default-underline-color",
     "ControlType": 50004,
     "HelpText": "Default underline color",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "Default underline color",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-default-underline-color",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-default-underline-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -10625,31 +5408,12 @@ exports[`TextInput Tests TextInputs have a default underline color 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-default-underline-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -10659,116 +5423,59 @@ exports[`TextInput Tests TextInputs support secure entry 1`] = `
   "Automation Tree": {
     "AutomationId": "textinput-password",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-password",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-password",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -10776,31 +5483,12 @@ exports[`TextInput Tests TextInputs support secure entry 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-password",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -10811,115 +5499,60 @@ exports[`TextInput Tests TextInputs support secure entry, with placeholder text 
     "AutomationId": "textinput-password-placeholder",
     "ControlType": 50004,
     "HelpText": "color is supported too",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "color is supported too",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-password-placeholder",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-password-placeholder",
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -10927,31 +5560,12 @@ exports[`TextInput Tests TextInputs support secure entry, with placeholder text 
           "Brush Type": "ColorBrush",
           "Color": "rgba(255, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-password-placeholder",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -10962,115 +5576,60 @@ exports[`TextInput Tests TextInputs with set height and padding from theme 1`] =
     "AutomationId": "textinput-theme-padding",
     "ControlType": 50004,
     "HelpText": "If you set height, beware of padding set from themes",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
     "Name": "If you set height, beware of padding set from themes",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "textinput-theme-padding",
+    },
+  },
   "Visual Tree": {
-    "Children": [
+    "Comment": "textinput-theme-padding",
+    "Offset": "0, 0, 0",
+    "Size": "916, 30",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -11078,31 +5637,12 @@ exports[`TextInput Tests TextInputs with set height and padding from theme 1`] =
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "textinput-theme-padding",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      30,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -11112,116 +5652,59 @@ exports[`TextInput Tests Uncontrolled TextInput 1`] = `
   "Automation Tree": {
     "AutomationId": "uncontrolled-textinput",
     "ControlType": 50004,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "edit",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "uncontrolled-textinput",
+    },
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "uncontrolled-textinput",
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
         "Visual Type": "SpriteVisual",
       },
       {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
         "Visual Type": "SpriteVisual",
       },
       {
@@ -11229,31 +5712,12 @@ exports[`TextInput Tests Uncontrolled TextInput 1`] = `
           "Brush Type": "ColorBrush",
           "Color": "rgba(0, 0, 0, 255)",
         },
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
+        "Offset": "0, 0, 0",
         "Opacity": 0,
-        "Size": [
-          0,
-          0,
-        ],
+        "Size": "0, 0",
         "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "uncontrolled-textinput",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TouchableComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TouchableComponentTest.test.ts.snap
@@ -5,24 +5,19 @@ exports[`Touchable Tests Text components can be tappable 1`] = `
   "Automation Tree": {
     "AutomationId": "tappable_text",
     "ControlType": 50020,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "text",
     "Name": "Text has built-in onPress handling",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+    "_Props": {
+      "TestId": "tappable_text",
+    },
+  },
   "Visual Tree": {
     "Comment": "tappable_text",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 20",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -32,80 +27,54 @@ exports[`Touchable Tests TouchableWithoutFeedback components should not give vis
 {
   "Automation Tree": {
     "AutomationId": "touchable_without_feedback_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Tap Here For No Feedback!",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "touchable_without_feedback_button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              904,
-              22,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          6,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          904,
-          22,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "touchable_without_feedback_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      33,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "6, 6, 0",
+        "Size": "904, 22",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "904, 22",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -114,80 +83,54 @@ exports[`Touchable Tests Touchables can contain a Text component 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "touchable_highlight_text_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Tap Here For Custom Highlight!",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "touchable_highlight_text_button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              224,
-              22,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          6,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          224,
-          22,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "touchable_highlight_text_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      234,
-      50,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "234, 50",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "6, 6, 0",
+        "Size": "224, 22",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "224, 22",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -197,68 +140,52 @@ exports[`Touchable Tests Touchables can contain an Image component 1`] = `
   "Automation Tree": {
     "AutomationId": "touchable_highlight_image_button",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
     "IsKeyboardFocusable": true,
     "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "touchable_highlight_image_button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ImageComponentView",
+        "_Props": {
+          "Sources": [
+            {
+              "Type": "Remote",
+              "Uri": "https://www.facebook.com/favicon.ico",
+            },
+          ],
+        },
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "touchable_highlight_image_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      50,
-      50,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "50, 50",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -267,80 +194,54 @@ exports[`Touchable Tests Touchables can delay events 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "touchable_delay_events_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Me",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "touchable_delay_events_button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              56,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          56,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "touchable_delay_events_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      56,
-      19,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "56, 19",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "56, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "56, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -349,84 +250,58 @@ exports[`Touchable Tests Touchables can enable a hit slop region 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "touchable_hit_slop_button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Outside This View",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "touchable_hit_slop_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(255, 0, 0, 255)",
     },
-    "Children": [
+    "Comment": "touchable_hit_slop_button",
+    "Offset": "0, 0, 0",
+    "Size": "146, 18",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              146,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          146,
-          20,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "146, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "146, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "touchable_hit_slop_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      146,
-      18,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -435,80 +310,56 @@ exports[`Touchable Tests Touchables can register feedback events 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "touchable_feedback_events_button",
-    "Children": [
+    "ControlType": 50000,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "touchable feedback events",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press Me",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "touchable feedback events",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "touchable feedback events",
+      "TestId": "touchable_feedback_events_button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              56,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          56,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "touchable_feedback_events_button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      56,
-      18,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "56, 18",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "56, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "56, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/test/__snapshots__/ViewComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/ViewComponentTest.test.ts.snap
@@ -5,11 +5,15 @@ exports[`View Tests Views can have a hitslop region 1`] = `
   "Automation Tree": {
     "AutomationId": "hitslop",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
     "Name": "HitSlop Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "HitSlop Example",
+      "TestId": "hitslop",
+    },
   },
   "Visual Tree": {
     "Brush": {
@@ -17,16 +21,8 @@ exports[`View Tests Views can have a hitslop region 1`] = `
       "Color": "rgba(128, 128, 128, 255)",
     },
     "Comment": "hitslop",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      200,
-      200,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "200, 200",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -36,80 +32,55 @@ exports[`View Tests Views can have a nativeid 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "nativeid",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "NativeID Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "A View with a nativeID "native-id-view"",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "NativeID Example",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "NativeID Example",
+      "TestId": "nativeid",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "nativeid",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      18,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 18",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -118,468 +89,278 @@ exports[`View Tests Views can have a z-index 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "z-index-button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ZIndex -1",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Tap to flip sorting order",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ZIndex 0",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ZIndex 1",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "ZIndex 2",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "z-index-button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "z-index-button",
+    "Offset": "0, 0, 0",
+    "Size": "916, 198",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
+        "Offset": "150, 149, 0",
+        "Size": "100, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(100, 181, 246, 255)",
             },
-            "Children": [
+            "Offset": "0, 0, 0",
+            "Size": "100, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      100,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  15,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  100,
-                  20,
-                ],
+                "Offset": "0, 15, 0",
+                "Size": "100, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "100, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              100,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          150,
-          149,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          100,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          30,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "916, 30",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
       {
-        "Children": [
+        "Offset": "100, 109, 0",
+        "Size": "100, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(129, 199, 132, 255)",
             },
-            "Children": [
+            "Offset": "0, 0, 0",
+            "Size": "100, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      100,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  15,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  100,
-                  20,
-                ],
+                "Offset": "0, 15, 0",
+                "Size": "100, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "100, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              100,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          100,
-          109,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          100,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
+        "Offset": "50, 69, 0",
+        "Size": "100, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(255, 241, 118, 255)",
             },
-            "Children": [
+            "Offset": "0, 0, 0",
+            "Size": "100, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      100,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  15,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  100,
-                  20,
-                ],
+                "Offset": "0, 15, 0",
+                "Size": "100, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "100, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              100,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          50,
-          69,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          100,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
+        "Offset": "0, 29, 0",
+        "Size": "100, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(229, 115, 115, 255)",
             },
-            "Children": [
+            "Offset": "0, 0, 0",
+            "Size": "100, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      100,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  15,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  100,
-                  20,
-                ],
+                "Offset": "0, 15, 0",
+                "Size": "100, 20",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "100, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              100,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          0,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          100,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "z-index-button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      198,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -588,84 +369,59 @@ exports[`View Tests Views can have aria-labels 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-aria-label",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Blue background View with Text",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Blue background",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Blue background View with Text",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Blue background View with Text",
+      "TestId": "view-test-aria-label",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(82, 127, 228, 255)",
     },
-    "Children": [
+    "Comment": "view-test-aria-label",
+    "Offset": "0, 0, 0",
+    "Size": "916, 24",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              906,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          5,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          906,
-          16,
-        ],
+        "Offset": "5, 5, 0",
+        "Size": "906, 16",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "906, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "view-test-aria-label",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      24,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -674,512 +430,294 @@ exports[`View Tests Views can have backface visibility 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-backface-visibility",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Backface Visibility Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "View #1, front is visible, back is hidden.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Front",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Back (You should not see this)",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "View #2, front is hidden, back is visible.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Front (You should not see this)",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Back",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Backface Visibility Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Backface Visibility Example",
+      "TestId": "view-test-backface-visibility",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
+    "Comment": "view-test-backface-visibility",
+    "Offset": "0, 0, 0",
+    "Size": "916, 367",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              29,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          29,
-        ],
+        "Offset": "0, 0, 0",
+        "Size": "916, 29",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 29",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
       {
-        "Children": [
+        "Offset": "383, 29, 0",
+        "Size": "150, 150",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(0, 0, 255, 255)",
             },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              150,
-              150,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "150, 150",
             "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          383,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          150,
-          150,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              34,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          441,
-          94,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          34,
-          20,
-        ],
+        "Offset": "441, 94, 0",
+        "Size": "34, 20",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "34, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
       {
-        "Children": [
+        "Offset": "383, 29, 0",
+        "Size": "150, 150",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(255, 0, 0, 255)",
             },
-            "Children": [
+            "Offset": "0, 0, 0",
+            "Size": "150, 150",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      130,
-                      38,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  10,
-                  56,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  130,
-                  38,
-                ],
+                "Offset": "10, 56, 0",
+                "Size": "130, 38",
                 "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "130, 38",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
               },
             ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              150,
-              150,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          383,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          150,
-          150,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              40,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          178,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          40,
-        ],
+        "Offset": "0, 178, 0",
+        "Size": "916, 40",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 40",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
       {
-        "Children": [
+        "Offset": "383, 217, 0",
+        "Size": "150, 150",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(0, 0, 255, 255)",
             },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              150,
-              150,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "150, 150",
             "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          383,
-          217,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          150,
-          150,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              134,
-              38,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          391,
-          273,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          134,
-          38,
-        ],
+        "Offset": "391, 273, 0",
+        "Size": "134, 38",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "134, 38",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
       {
-        "Children": [
+        "Offset": "383, 217, 0",
+        "Size": "150, 150",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(255, 0, 0, 255)",
             },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              150,
-              150,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "150, 150",
             "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          383,
-          217,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          150,
-          150,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          443,
-          282,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          19,
-        ],
+        "Offset": "443, 282, 0",
+        "Size": "30, 19",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "30, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "view-test-backface-visibility",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      367,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1188,84 +726,59 @@ exports[`View Tests Views can have background color 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-background-color",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Background Color Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Blue background",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Background Color Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Background Color Example",
+      "TestId": "view-test-background-color",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
     "Brush": {
       "Brush Type": "ColorBrush",
       "Color": "rgba(82, 127, 228, 255)",
     },
-    "Children": [
+    "Comment": "view-test-background-color",
+    "Offset": "0, 0, 0",
+    "Size": "916, 24",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              906,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          5,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          906,
-          16,
-        ],
+        "Offset": "5, 5, 0",
+        "Size": "906, 16",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "906, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
     ],
-    "Comment": "view-test-background-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      24,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -1274,424 +787,207 @@ exports[`View Tests Views can have border styles 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "border-style-button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Dashed border style",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Dotted border style",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "border-style-button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              26,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          26,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              904,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          6,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          904,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -12,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -12,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -6,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  6,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -12,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -12,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          32,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              904,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          38,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          904,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "border-style-button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      58,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 58",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 26",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 26",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 6, 0",
+        "Size": "904, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "904, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 32, 0",
+        "Size": "916, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 27",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "6, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "6, 0, 0",
+                "Size": "-12, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-6, 0, 0",
+                "Size": "6, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 6, 0",
+                "Size": "1, -12",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-6, -6, 0",
+                "Size": "6, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "6, -1, 0",
+                "Size": "-12, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -6, 0",
+                "Size": "6, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 6, 0",
+                "Size": "1, -12",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 38, 0",
+        "Size": "904, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "904, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1700,184 +996,95 @@ exports[`View Tests Views can have borders 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-border",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Border Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "5px blue border",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Border Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Border Example",
+      "TestId": "view-test-border",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          5,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -10,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -5,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -5,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          -10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -5,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          5,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -10,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          5,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          5,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          5,
-          -10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              886,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          15,
-          15,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          886,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-border",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      44,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 44",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "5, 0, 0",
+        "Size": "-10, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-5, 0, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-5, 5, 0",
+        "Size": "5, -10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-5, -5, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "5, -5, 0",
+        "Size": "-10, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -5, 0",
+        "Size": "5, 5",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 5, 0",
+        "Size": "5, -10",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "15, 15, 0",
+        "Size": "886, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "886, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -1886,171 +1093,105 @@ exports[`View Tests Views can have customized accessibility 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "accessibility",
-    "Children": [
+    "ControlType": 50000,
+    "HelpText": "Accessibility Hint",
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "A View with accessibility values",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "A View with accessibility values.",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Current Number of Accessibility Taps: 0",
       },
     ],
-    "ControlType": 50000,
-    "HelpText": "Accessibility Hint",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "button",
-    "Name": "A View with accessibility values",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "A View with accessibility values",
+      "TestId": "accessibility",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          18,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          37,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "accessibility",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      55,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 55",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 18, 0",
+        "Size": "916, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 37, 0",
+        "Size": "916, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2059,638 +1200,385 @@ exports[`View Tests Views can have customized opacity 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-opacity",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Opacity Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Opacity 0",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Opacity 0.1",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Opacity 0.3",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Opacity 0.5",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Opacity 0.7",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Opacity 0.9",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Opacity 1",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Opacity Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Opacity Example",
+      "TestId": "view-test-opacity",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0,
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.10000000149011612,
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.30000001192092896,
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.5,
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.699999988079071,
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.8999999761581421,
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0,
-            "Size": [
-              916,
-              18,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          18,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      19,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  19,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.10000000149011612,
-            "Size": [
-              916,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          19,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.30000001192092896,
-            "Size": [
-              916,
-              18,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          37,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          18,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.5,
-            "Size": [
-              916,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          56,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      19,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  19,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.699999988079071,
-            "Size": [
-              916,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          74,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      916,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  916,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.8999999761581421,
-            "Size": [
-              916,
-              18,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          93,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          18,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          112,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-opacity",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      130,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 130",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 18",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0,
+            "Size": "916, 18",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 19, 0",
+        "Size": "916, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.10000000149011612,
+            "Size": "916, 19",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 19",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 19",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 37, 0",
+        "Size": "916, 18",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.30000001192092896,
+            "Size": "916, 18",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 56, 0",
+        "Size": "916, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.5,
+            "Size": "916, 19",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 74, 0",
+        "Size": "916, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.699999988079071,
+            "Size": "916, 19",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 19",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 19",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 93, 0",
+        "Size": "916, 18",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Opacity": 0.8999999761581421,
+            "Size": "916, 18",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "916, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "916, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 112, 0",
+        "Size": "916, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -2699,787 +1587,377 @@ exports[`View Tests Views can have customized pasdding and margins 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-padding-margin",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Padding/Margin Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "5px padding",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "5px margin",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "5px margin and padding,",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "widthAutonomous=true",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Padding/Margin Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Padding/Margin Example",
+      "TestId": "view-test-padding-margin",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              915,
-              27,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          915,
-          27,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              903,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          7,
-          7,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          903,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              905,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          32,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          905,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              903,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          7,
-          33,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          903,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              133,
-              42,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          59,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          133,
-          42,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              123,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          12,
-          65,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          123,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              123,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          12,
-          79,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          123,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-padding-margin",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      105,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 105",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 1, 0",
+        "Size": "915, 27",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "915, 27",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "7, 7, 0",
+        "Size": "903, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "903, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 32, 0",
+        "Size": "905, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "905, 16",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "7, 33, 0",
+        "Size": "903, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "903, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 59, 0",
+        "Size": "133, 42",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "133, 42",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "12, 65, 0",
+        "Size": "123, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "123, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "12, 79, 0",
+        "Size": "123, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "123, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -3488,80 +1966,54 @@ exports[`View Tests Views can have display: none 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "display-none-button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Press to toggle \`display: none\`",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "display-none-button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
     ],
+  },
+  "Visual Tree": {
     "Comment": "display-none-button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      28,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 28",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -3571,626 +2023,340 @@ exports[`View Tests Views can have flexgap 1`] = `
   "Automation Tree": {
     "AutomationId": "view-test-flexgap",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
     "Name": "Flex Gap Example",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Flex Gap Example",
+      "TestId": "view-test-flexgap",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+    ],
+  },
   "Visual Tree": {
-    "Children": [
-      {
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          -1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          1,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          -2,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          -1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          1,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Offset": [
-          0,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          1,
-          -2,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          61,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 192, 203, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          121,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          181,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          241,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          301,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          361,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 192, 203, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          421,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 192, 203, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          481,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 192, 203, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          541,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 192, 203, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              30,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          601,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          30,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-flexgap",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      32,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "61, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "121, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 192, 203, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "181, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "241, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "301, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "361, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "421, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 192, 203, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "481, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 192, 203, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "541, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 192, 203, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "601, 1, 0",
+        "Size": "30, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 192, 203, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "30, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -4199,1724 +2365,831 @@ exports[`View Tests Views can have insets 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-insets",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "inset 10",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "insetBlock 5",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "insetBlockEnd 5",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "insetBlockStart 5",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "insetInline 5",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "insetInlineEnd 5",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "insetInlineStart 5",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "view-test-insets",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              894,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          11,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          894,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              884,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          16,
-          16,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          884,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          60,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              68,
-              38,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          1,
-          66,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          68,
-          38,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              58,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          71,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          58,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          120,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              86,
-              25,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          1,
-          139,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          86,
-          25,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              77,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          144,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          77,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          180,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              90,
-              24,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          1,
-          186,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          90,
-          24,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              81,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          191,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          81,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          240,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              904,
-              24,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          241,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          904,
-          24,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              894,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          246,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          894,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          300,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              87,
-              24,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          823,
-          301,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          87,
-          24,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              77,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          828,
-          306,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          77,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          360,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(82, 127, 228, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              91,
-              24,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          6,
-          361,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          91,
-          24,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              81,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          366,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          81,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-insets",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      410,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 410",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 11, 0",
+        "Size": "894, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "894, 28",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "16, 16, 0",
+        "Size": "884, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "884, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 60, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "1, 66, 0",
+        "Size": "68, 38",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "68, 38",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 71, 0",
+        "Size": "58, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "58, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 120, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "1, 139, 0",
+        "Size": "86, 25",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "86, 25",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 144, 0",
+        "Size": "77, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "77, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 180, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "1, 186, 0",
+        "Size": "90, 24",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "90, 24",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 191, 0",
+        "Size": "81, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "81, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 240, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 241, 0",
+        "Size": "904, 24",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "904, 24",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 246, 0",
+        "Size": "894, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "894, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 300, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "823, 301, 0",
+        "Size": "87, 24",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "87, 24",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "828, 306, 0",
+        "Size": "77, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "77, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 360, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "6, 361, 0",
+        "Size": "91, 24",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(82, 127, 228, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "91, 24",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 366, 0",
+        "Size": "81, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "81, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -5925,450 +3198,259 @@ exports[`View Tests Views can have layout conformance 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-layout-conformance",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Layout Conformance Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Unset",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Classic",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Strict",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Layout Conformance Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Layout Conformance Example",
+      "TestId": "view-test-layout-conformance",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 255, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          19,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          34,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          70,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 255, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          70,
-          19,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          70,
-          34,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              19,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          140,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          19,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(0, 0, 255, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              60,
-              60,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          140,
-          19,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          60,
-          60,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Brush": {
-              "Brush Type": "ColorBrush",
-              "Color": "rgba(255, 0, 0, 255)",
-            },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          140,
-          34,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          0,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-layout-conformance",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      79,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 79",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "60, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "60, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 19, 0",
+        "Size": "60, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 255, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "60, 60",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 34, 0",
+        "Size": "60, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "60, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "70, 0, 0",
+        "Size": "60, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "60, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "70, 19, 0",
+        "Size": "60, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 255, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "60, 60",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "70, 34, 0",
+        "Size": "60, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "60, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "140, 0, 0",
+        "Size": "60, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "60, 19",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "140, 19, 0",
+        "Size": "60, 60",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(0, 0, 255, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "60, 60",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "140, 34, 0",
+        "Size": "0, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Brush": {
+              "Brush Type": "ColorBrush",
+              "Color": "rgba(255, 0, 0, 255)",
+            },
+            "Offset": "0, 0, 0",
+            "Size": "0, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -6377,768 +3459,361 @@ exports[`View Tests Views can have logical border colors 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-logical-border-color",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Logical Border Color Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "borderBlockColor orange",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "borderBlockStartColor purple",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "borderBlockEndColor green",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Logical Border Color Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Logical Border Color Example",
+      "TestId": "view-test-logical-border-color",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  5,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -10,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -5,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -5,
-                  5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  -10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -5,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  5,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -10,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  -10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              894,
-              28,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          11,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          894,
-          28,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              884,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          16,
-          16,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          884,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              65,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          60,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          65,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  5,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -10,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -5,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -5,
-                  5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  -10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -5,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  5,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -10,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  -10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              894,
-              43,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          11,
-          71,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          894,
-          43,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              884,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          16,
-          76,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          884,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              884,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          16,
-          90,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          884,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-logical-border-color",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      125,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 125",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 11, 0",
+        "Size": "894, 28",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "894, 28",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "5, 0, 0",
+                "Size": "-10, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-5, 0, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-5, 5, 0",
+                "Size": "5, -10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-5, -5, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "5, -5, 0",
+                "Size": "-10, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -5, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 5, 0",
+                "Size": "5, -10",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "16, 16, 0",
+        "Size": "884, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "884, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 60, 0",
+        "Size": "916, 65",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 65",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "11, 71, 0",
+        "Size": "894, 43",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "894, 43",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "5, 0, 0",
+                "Size": "-10, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-5, 0, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-5, 5, 0",
+                "Size": "5, -10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-5, -5, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "5, -5, 0",
+                "Size": "-10, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -5, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 5, 0",
+                "Size": "5, -10",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "16, 76, 0",
+        "Size": "884, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "884, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "16, 90, 0",
+        "Size": "884, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "884, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -7147,403 +3822,236 @@ exports[`View Tests Views can have offscreen alpha compositing 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "offscreen-alpha-compositing-button",
-    "Children": [
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Blobs",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Same blobs, but their shared container have 0.5 opacity",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "Tap to deactivate needsOffscreenAlphaCompositing",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": true,
-    "LocalizedControlType": "group",
-    "Name": "",
   },
-  "Visual Tree": {
-    "Children": [
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "offscreen-alpha-compositing-button",
+    },
+    "__Children": [
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          30,
-        ],
-        "Visual Type": "SpriteVisual",
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
       },
       {
-        "Children": [
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {
+          "Opacity": 0.800000011920929,
+        },
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+            "_Props": {},
+          },
+          {
+            "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+    ],
+  },
+  "Visual Tree": {
+    "Comment": "offscreen-alpha-compositing-button",
+    "Offset": "0, 0, 0",
+    "Size": "916, 215",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 30",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 29, 0",
+        "Size": "100, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(255, 111, 89, 255)",
             },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              100,
-              50,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "100, 50",
             "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          0,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          100,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
+        "Offset": "50, 29, 0",
+        "Size": "100, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
             "Brush": {
               "Brush Type": "ColorBrush",
               "Color": "rgba(247, 203, 21, 255)",
             },
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              100,
-              50,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "100, 50",
             "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          50,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          100,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              29,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          108,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          29,
-        ],
+        "Offset": "0, 108, 0",
+        "Size": "916, 29",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 29",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
       {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              30,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          137,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          30,
-        ],
+        "Offset": "0, 137, 0",
+        "Size": "916, 30",
         "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 30",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
       },
       {
-        "Children": [
+        "Offset": "0, 166, 0",
+        "Size": "916, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
           {
-            "Children": [
+            "Offset": "0, 0, 0",
+            "Opacity": 0.800000011920929,
+            "Size": "916, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
               {
-                "Children": [
+                "Offset": "0, 0, 0",
+                "Size": "100, 50",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
                   {
                     "Brush": {
                       "Brush Type": "ColorBrush",
                       "Color": "rgba(255, 111, 89, 255)",
                     },
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      100,
-                      50,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "100, 50",
                     "Visual Type": "SpriteVisual",
                   },
                   {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
                     "Visual Type": "SpriteVisual",
                   },
                 ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  100,
-                  50,
-                ],
-                "Visual Type": "SpriteVisual",
               },
               {
-                "Children": [
+                "Offset": "50, 0, 0",
+                "Size": "100, 50",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
                   {
                     "Brush": {
                       "Brush Type": "ColorBrush",
                       "Color": "rgba(247, 203, 21, 255)",
                     },
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      100,
-                      50,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "100, 50",
                     "Visual Type": "SpriteVisual",
                   },
                   {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
                     "Visual Type": "SpriteVisual",
                   },
                 ],
-                "Offset": [
-                  50,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  100,
-                  50,
-                ],
-                "Visual Type": "SpriteVisual",
               },
             ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 0.800000011920929,
-            "Size": [
-              916,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
           },
           {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
             "Visual Type": "SpriteVisual",
           },
         ],
-        "Offset": [
-          0,
-          166,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
       },
     ],
-    "Comment": "offscreen-alpha-compositing-button",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      215,
-    ],
-    "Visual Type": "SpriteVisual",
   },
 }
 `;
@@ -7552,664 +4060,323 @@ exports[`View Tests Views can have overflow 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "view-test-overflow",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Rounded Borders Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "undefined",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "hidden",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "visible",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Rounded Borders Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Rounded Borders Example",
+      "TestId": "view-test-overflow",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+        "__Children": [
+          {
+            "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+            "_Props": {},
+          },
+        ],
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              95,
-              12,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          95,
-          12,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              200,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          1,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          200,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              95,
-              12,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          111,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          95,
-          12,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Children": [
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      200,
-                      20,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                  {
-                    "Offset": [
-                      0,
-                      0,
-                      0,
-                    ],
-                    "Opacity": 1,
-                    "Size": [
-                      0,
-                      0,
-                    ],
-                    "Visual Type": "SpriteVisual",
-                  },
-                ],
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  200,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              93,
-              10,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          112,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          93,
-          10,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  -1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  1,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Offset": [
-                  0,
-                  1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              95,
-              12,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          222,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          95,
-          12,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              200,
-              20,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          223,
-          1,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          200,
-          20,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-overflow",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      20,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 20",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "95, 12",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "95, 12",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "1, 1, 0",
+        "Size": "200, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "200, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "111, 0, 0",
+        "Size": "95, 12",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "95, 12",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "112, 1, 0",
+        "Size": "93, 10",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "93, 10",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "200, 20",
+                "Visual Type": "SpriteVisual",
+                "__Children": [
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "200, 20",
+                    "Visual Type": "SpriteVisual",
+                  },
+                  {
+                    "Offset": "0, 0, 0",
+                    "Size": "0, 0",
+                    "Visual Type": "SpriteVisual",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "222, 0, 0",
+        "Size": "95, 12",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "95, 12",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Offset": "0, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 0, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "-1, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "1, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, -1, 0",
+                "Size": "1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Offset": "0, 1, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "223, 1, 0",
+        "Size": "200, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "200, 20",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -8219,1459 +4386,785 @@ exports[`View Tests Views can have rounded borders 1`] = `
   "Automation Tree": {
     "AutomationId": "view-test-rounded-borders",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
     "Name": "Rounded Borders Example",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Rounded Borders Example",
+      "TestId": "view-test-rounded-borders",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+    ],
+  },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  35,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -20,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -35,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -10,
-                  35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  -20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -35,
-                  -35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  35,
-                  -10,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -20,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  -20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          60,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  5,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -11,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  11,
-                  11,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  11,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  22,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -17,
-                  -17,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  17,
-                  17,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  34,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -34,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  34,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  11,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          120,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  14,
-                  14,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  14,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  16,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -20,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  20,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -10,
-                  20,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  43,
-                  -10,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -19,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -43,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  43,
-                  43,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  14,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  -7,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          180,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  6,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          240,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          290,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          340,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          390,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-rounded-borders",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      50,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 50",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 26, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 26, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "60, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "35, 0, 0",
+                "Size": "-20, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-35, 0, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-10, 35, 0",
+                "Size": "10, -20",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-35, -35, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "35, -10, 0",
+                "Size": "-20, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -35, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 35, 0",
+                "Size": "10, -20",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "120, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "5, 0, 0",
+                "Size": "34, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-11, 0, 0",
+                "Size": "11, 11",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 11, 0",
+                "Size": "1, 22",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-17, -17, 0",
+                "Size": "17, 17",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "34, -1, 0",
+                "Size": "-1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -34, 0",
+                "Size": "34, 34",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 5, 0",
+                "Size": "1, 11",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "180, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "14, 14",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "14, 0, 0",
+                "Size": "16, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-20, 0, 0",
+                "Size": "20, 20",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-10, 20, 0",
+                "Size": "10, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "43, -10, 0",
+                "Size": "-19, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -43, 0",
+                "Size": "43, 43",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 14, 0",
+                "Size": "10, -7",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "240, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, 0, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 0, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 6, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, -0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "6, -0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 26, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "290, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, 26, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, -0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 6, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "340, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "6, 0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 0, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, -6, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, -6, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "390, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, 0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, 0, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -6, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -6, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -9681,1459 +5174,785 @@ exports[`View Tests Views can have rounded borders 2`] = `
   "Automation Tree": {
     "AutomationId": "view-test-rounded-borders",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
     "Name": "Rounded Borders Example",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Rounded Borders Example",
+      "TestId": "view-test-rounded-borders",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+        "_Props": {},
+      },
+    ],
+  },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -2,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  -2,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  35,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -20,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -35,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -10,
-                  35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  -20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -35,
-                  -35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  35,
-                  -10,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -20,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  35,
-                  35,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  35,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  -20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          60,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  5,
-                  5,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  5,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -11,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  11,
-                  11,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -1,
-                  11,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  22,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -17,
-                  -17,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  17,
-                  17,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  34,
-                  -1,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -1,
-                  1,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -34,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  34,
-                  34,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  5,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  1,
-                  11,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          120,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  14,
-                  14,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  14,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  16,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -20,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  20,
-                  20,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -10,
-                  20,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  4,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  43,
-                  -10,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  -19,
-                  10,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -43,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  43,
-                  43,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  14,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  10,
-                  -7,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          180,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  6,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          240,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          290,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -0,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  26,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          340,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Children": [
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  44,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  0,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -6,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  6,
-                  24,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  -26,
-                  -26,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  26,
-                  26,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  24,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  -6,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  6,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-              {
-                "Brush": {
-                  "Brush Type": "ColorBrush",
-                  "Color": "rgba(0, 0, 0, 255)",
-                },
-                "Offset": [
-                  0,
-                  0,
-                  0,
-                ],
-                "Opacity": 1,
-                "Size": [
-                  0,
-                  44,
-                ],
-                "Visual Type": "SpriteVisual",
-              },
-            ],
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              50,
-              50,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          390,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          50,
-          50,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "view-test-rounded-borders",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      50,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 50",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, 0, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 26, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, -1, 0",
+                "Size": "-2, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 26, 0",
+                "Size": "1, -2",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "60, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "35, 0, 0",
+                "Size": "-20, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-35, 0, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-10, 35, 0",
+                "Size": "10, -20",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-35, -35, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "35, -10, 0",
+                "Size": "-20, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -35, 0",
+                "Size": "35, 35",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 35, 0",
+                "Size": "10, -20",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "120, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "5, 5",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "5, 0, 0",
+                "Size": "34, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-11, 0, 0",
+                "Size": "11, 11",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-1, 11, 0",
+                "Size": "1, 22",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-17, -17, 0",
+                "Size": "17, 17",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "34, -1, 0",
+                "Size": "-1, 1",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -34, 0",
+                "Size": "34, 34",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 5, 0",
+                "Size": "1, 11",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "180, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "14, 14",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "14, 0, 0",
+                "Size": "16, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-20, 0, 0",
+                "Size": "20, 20",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-10, 20, 0",
+                "Size": "10, 4",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "43, -10, 0",
+                "Size": "-19, 10",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -43, 0",
+                "Size": "43, 43",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 14, 0",
+                "Size": "10, -7",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "240, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, 0, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 0, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 6, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, -0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "6, -0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 26, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "290, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, 0, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, 26, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, -0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 6, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "340, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "6, 0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, 0, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-0, -6, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "26, -6, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "390, 0, 0",
+        "Size": "50, 50",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "50, 50",
+            "Visual Type": "SpriteVisual",
+            "__Children": [
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "0, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "44, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, 0, 0",
+                "Size": "6, 0",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-6, 0, 0",
+                "Size": "6, 24",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "-26, -26, 0",
+                "Size": "26, 26",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -6, 0",
+                "Size": "24, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, -6, 0",
+                "Size": "0, 6",
+                "Visual Type": "SpriteVisual",
+              },
+              {
+                "Brush": {
+                  "Brush Type": "ColorBrush",
+                  "Color": "rgba(0, 0, 0, 255)",
+                },
+                "Offset": "0, 0, 0",
+                "Size": "0, 44",
+                "Visual Type": "SpriteVisual",
+              },
+            ],
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;
@@ -11143,24 +5962,20 @@ exports[`View Tests Views can have shadows 1`] = `
   "Automation Tree": {
     "AutomationId": "shadow",
     "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
     "LocalizedControlType": "group",
     "Name": "Shadow Example",
   },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Shadow Example",
+      "TestId": "shadow",
+    },
+  },
   "Visual Tree": {
     "Comment": "shadow",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      50,
-      50,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "50, 50",
     "Visual Type": "SpriteVisual",
   },
 }
@@ -11170,180 +5985,109 @@ exports[`View Tests Views can have tooltips 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "tool-tip",
-    "Children": [
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "Name": "Tooltip Example",
+    "__Children": [
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "This Parent View has tooltip "Parent View"",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "This view has tooltip "Child View 1"",
       },
       {
         "AutomationId": "",
         "ControlType": 50020,
-        "HelpText": "",
-        "IsEnabled": true,
-        "IsKeyboardFocusable": false,
         "LocalizedControlType": "text",
         "Name": "This view has tooltip "Child View 2"",
       },
     ],
-    "ControlType": 50026,
-    "HelpText": "",
-    "IsEnabled": true,
-    "IsKeyboardFocusable": false,
-    "LocalizedControlType": "group",
-    "Name": "Tooltip Example",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Tooltip Example",
+      "TestId": "tool-tip",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
   },
   "Visual Tree": {
-    "Children": [
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          0,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              15,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          15,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          15,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-      {
-        "Children": [
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              916,
-              16,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-          {
-            "Offset": [
-              0,
-              0,
-              0,
-            ],
-            "Opacity": 1,
-            "Size": [
-              0,
-              0,
-            ],
-            "Visual Type": "SpriteVisual",
-          },
-        ],
-        "Offset": [
-          0,
-          29,
-          0,
-        ],
-        "Opacity": 1,
-        "Size": [
-          916,
-          16,
-        ],
-        "Visual Type": "SpriteVisual",
-      },
-    ],
     "Comment": "tool-tip",
-    "Offset": [
-      0,
-      0,
-      0,
-    ],
-    "Opacity": 1,
-    "Size": [
-      916,
-      43,
-    ],
+    "Offset": "0, 0, 0",
+    "Size": "916, 43",
     "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "916, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 15, 0",
+        "Size": "916, 15",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 15",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "0, 29, 0",
+        "Size": "916, 16",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "916, 16",
+            "Visual Type": "SpriteVisual",
+          },
+          {
+            "Offset": "0, 0, 0",
+            "Size": "0, 0",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
   },
 }
 `;

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -236,7 +236,7 @@ void InsertSizeValue(
     const winrt::Windows::Data::Json::JsonObject &obj,
     winrt::hstring name,
     winrt::Windows::Foundation::Size value) {
-  auto str =winrt::to_hstring(value.Width) + L", " + winrt::to_hstring(value.Height);
+  auto str = winrt::to_hstring(value.Width) + L", " + winrt::to_hstring(value.Height);
   obj.Insert(name, winrt::Windows::Data::Json::JsonValue::CreateStringValue(str));
 }
 
@@ -252,8 +252,7 @@ void InsertFloat3Value(
     const winrt::Windows::Data::Json::JsonObject &obj,
     winrt::hstring name,
     winrt::Windows::Foundation::Numerics::float3 value) {
-  auto str = winrt::to_hstring(value.x) + L", " + winrt::to_hstring(value.y) + L", " +
-      winrt::to_hstring(value.z);
+  auto str = winrt::to_hstring(value.x) + L", " + winrt::to_hstring(value.y) + L", " + winrt::to_hstring(value.z);
   obj.Insert(name, winrt::Windows::Data::Json::JsonValue::CreateStringValue(str));
 }
 

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.vcxproj
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.vcxproj
@@ -95,7 +95,6 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions Condition="'$(UseFabric)'=='true'">USE_FABRIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <PropertyGroup Label="UserMacros" />


### PR DESCRIPTION
- Changed the format of the snapshots for the E2E fabric app to make them more readable.
- Changed the field name of the children property so that it is always at the bottom of the object.  This means that the properties of the parent visual are no longer split between above the children and below them.
- Use a formatted string for Offset/Size fields so that they do not take up 5 lines in the snaphots.
- Added a snapshot of the native ComponentView's as an additional set of testing.

