### PR TITLE
Add timeout to Fabric e2etest snapshot update task

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -210,6 +210,7 @@ jobs:
                 displayName: Update snapshots
                 workingDirectory: packages/e2e-test-app-fabric
                 condition: and(failed(), eq(variables.StartedFabricTests, 'true'))
+                timeoutInMinutes: 10 # Time to wait for this task to complete before the server kills it.
 
               - task: PowerShell@2
                 displayName: Stop tracing


### PR DESCRIPTION
## Description
#13166 added a timeout to the e2etest run since it can hang forever, but if the task fails and it tries to update the snapshots, that tasks can hang too. 

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13233)