### PR TITLE
[Fabric] Add various native focus APIs

### DIFF
--- a/change/react-native-windows-8549cb15-fcb5-48e9-b8bf-8d6e2ae1d896.json
+++ b/change/react-native-windows-8549cb15-fcb5-48e9-b8bf-8d6e2ae1d896.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add various native focus APIs",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -13,6 +13,7 @@ void *winrt_make_Microsoft_ReactNative_Composition_Experimental_MicrosoftComposi
 void *winrt_make_Microsoft_ReactNative_Composition_Experimental_SystemCompositionContextHelper();
 void *winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
 void* winrt_make_Microsoft_ReactNative_Composition_ViewComponentView();
+void *winrt_make_Microsoft_ReactNative_Composition_FocusManager();
 void* winrt_make_Microsoft_ReactNative_JsiRuntime();
 void* winrt_make_Microsoft_ReactNative_ReactCoreInjection();
 void* winrt_make_Microsoft_ReactNative_ReactDispatcherHelper();
@@ -28,6 +29,9 @@ void* winrt_make_facebook_react_NativeTraceEventSource();
 
 #ifndef USE_FABRIC
 void* winrt_make_Microsoft_ReactNative_Composition_ViewComponentView() {
+    winrt::throw_hresult(E_NOTIMPL);
+}
+void *winrt_make_Microsoft_ReactNative_Composition_FocusManager() {
     winrt::throw_hresult(E_NOTIMPL);
 }
 #endif
@@ -67,6 +71,9 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
     }
     if (requal(name, L"Microsoft.ReactNative.Composition.CompositionUIService")) {
       return winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
+    }
+    if (requal(name, L"Microsoft.ReactNative.Composition.FocusManager")) {
+      return winrt_make_Microsoft_ReactNative_Composition_FocusManager();
     }
     if (requal(name, L"Microsoft.ReactNative.Composition.ViewComponentView")) {
       return winrt_make_Microsoft_ReactNative_Composition_ViewComponentView();

--- a/vnext/Microsoft.ReactNative/ComponentView.idl
+++ b/vnext/Microsoft.ReactNative/ComponentView.idl
@@ -52,6 +52,26 @@ namespace Microsoft.ReactNative
 
   [experimental]
   [webhosthidden]
+  runtimeclass LosingFocusEventArgs : Microsoft.ReactNative.Composition.Input.RoutedEventArgs {
+    Microsoft.ReactNative.ComponentView NewFocusedComponent { get; };
+    Microsoft.ReactNative.ComponentView OldFocusedComponent { get; };
+
+    void TryCancel();
+    void TrySetNewFocusedComponent(Microsoft.ReactNative.ComponentView component);
+  };
+
+  [experimental]
+  [webhosthidden]
+  runtimeclass GettingFocusEventArgs : Microsoft.ReactNative.Composition.Input.RoutedEventArgs {
+    Microsoft.ReactNative.ComponentView NewFocusedComponent { get; };
+    Microsoft.ReactNative.ComponentView OldFocusedComponent { get; };
+
+    void TryCancel();
+    void TrySetNewFocusedComponent(Microsoft.ReactNative.ComponentView component);
+  };
+
+  [experimental]
+  [webhosthidden]
   unsealed runtimeclass ComponentView {
     ComponentView(CreateComponentViewArgs args);
 
@@ -84,6 +104,12 @@ namespace Microsoft.ReactNative
     overridable void OnPointerExited(Microsoft.ReactNative.Composition.Input.PointerRoutedEventArgs args);
     overridable void OnPointerCaptureLost();
 
+    Boolean TryFocus();
+    
+    event Windows.Foundation.EventHandler<LosingFocusEventArgs> LosingFocus;
+    event Windows.Foundation.EventHandler<GettingFocusEventArgs> GettingFocus;
+    event Windows.Foundation.EventHandler<Microsoft.ReactNative.Composition.Input.RoutedEventArgs> LostFocus;
+    event Windows.Foundation.EventHandler<Microsoft.ReactNative.Composition.Input.RoutedEventArgs> GotFocus;
   };
 
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/CompositionComponentView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionComponentView.idl
@@ -48,6 +48,7 @@ namespace Microsoft.ReactNative.Composition
     ComponentView(CreateCompositionComponentViewArgs args);
 
     Microsoft.UI.Composition.Compositor Compositor { get; };
+    RootComponentView Root { get; };
     Theme Theme;
     overridable void OnThemeChanged();
     Boolean CapturePointer(Microsoft.ReactNative.Composition.Input.Pointer pointer);
@@ -88,6 +89,7 @@ namespace Microsoft.ReactNative.Composition
   [webhosthidden]
   [default_interface]
   unsealed runtimeclass RootComponentView : ViewComponentView {
+    Microsoft.ReactNative.ComponentView GetFocusedComponent();
   };
   
   [experimental]

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
@@ -145,7 +145,7 @@ ComponentView::rootComponentView() noexcept {
 void ComponentView::parent(const winrt::Microsoft::ReactNative::ComponentView &parent) noexcept {
   if (m_parent != parent) {
     auto oldRootView = rootComponentView();
-    m_rootView = nullptr;\
+    m_rootView = nullptr;
     auto oldParent = m_parent;
     m_parent = parent;
     if (!parent) {
@@ -217,65 +217,73 @@ facebook::react::Point ComponentView::getClientOffset() const noexcept {
   return {};
 }
 
-void ComponentView::onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
+void ComponentView::onLostFocus(
+    const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
   m_lostFocusEvent(*this, args);
   if (m_parent) {
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onLostFocus(args);
   }
 }
 
-void ComponentView::onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
-    m_gotFocusEvent(*this, args);
+void ComponentView::onGotFocus(
+    const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
+  m_gotFocusEvent(*this, args);
   if (m_parent) {
-      winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onGotFocus(args);
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onGotFocus(args);
   }
 }
 
-void ComponentView::onLosingFocus(const winrt::Microsoft::ReactNative::LosingFocusEventArgs& args) noexcept {
+void ComponentView::onLosingFocus(const winrt::Microsoft::ReactNative::LosingFocusEventArgs &args) noexcept {
   m_losingFocusEvent(*this, args);
   if (m_parent) {
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onLosingFocus(args);
   }
 }
 
-void ComponentView::onGettingFocus(const winrt::Microsoft::ReactNative::GettingFocusEventArgs& args) noexcept {
+void ComponentView::onGettingFocus(const winrt::Microsoft::ReactNative::GettingFocusEventArgs &args) noexcept {
   m_gettingFocusEvent(*this, args);
   if (m_parent) {
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onGettingFocus(args);
   }
 }
 
-winrt::event_token ComponentView::LosingFocus(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs> const& handler) noexcept {
+winrt::event_token ComponentView::LosingFocus(
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs> const
+        &handler) noexcept {
   return m_losingFocusEvent.add(handler);
 }
 
-void ComponentView::LosingFocus(winrt::event_token const& token) noexcept {
+void ComponentView::LosingFocus(winrt::event_token const &token) noexcept {
   m_losingFocusEvent.remove(token);
 }
 
 winrt::event_token ComponentView::GettingFocus(
     winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::GettingFocusEventArgs> const
         &handler) noexcept {
- return m_gettingFocusEvent.add(handler);
+  return m_gettingFocusEvent.add(handler);
 }
 
-void ComponentView::GettingFocus(winrt::event_token const& token) noexcept {
+void ComponentView::GettingFocus(winrt::event_token const &token) noexcept {
   m_gettingFocusEvent.remove(token);
 }
 
-winrt::event_token ComponentView::LostFocus(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const& handler) noexcept {
- return m_lostFocusEvent.add(handler);
+winrt::event_token ComponentView::LostFocus(
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const
+        &handler) noexcept {
+  return m_lostFocusEvent.add(handler);
 }
 
-void ComponentView::LostFocus(winrt::event_token const& token) noexcept {
+void ComponentView::LostFocus(winrt::event_token const &token) noexcept {
   m_lostFocusEvent.remove(token);
 }
 
-winrt::event_token ComponentView::GotFocus(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const& handler) noexcept {
- return m_gotFocusEvent.add(handler);
+winrt::event_token ComponentView::GotFocus(
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const
+        &handler) noexcept {
+  return m_gotFocusEvent.add(handler);
 }
 
-void ComponentView::GotFocus(winrt::event_token const& token) noexcept {
+void ComponentView::GotFocus(winrt::event_token const &token) noexcept {
   m_gotFocusEvent.remove(token);
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -87,23 +87,27 @@ struct ComponentView : public ComponentViewT<ComponentView> {
   virtual RECT getClientRect() const noexcept;
   // The offset from this elements parent to its children (accounts for things like scroll position)
   virtual facebook::react::Point getClientOffset() const noexcept;
-  virtual void onLosingFocus(const winrt::Microsoft::ReactNative::LosingFocusEventArgs& args) noexcept;
-  virtual void onGettingFocus(const winrt::Microsoft::ReactNative::GettingFocusEventArgs& args) noexcept;
-  virtual void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept;
+  virtual void onLosingFocus(const winrt::Microsoft::ReactNative::LosingFocusEventArgs &args) noexcept;
+  virtual void onGettingFocus(const winrt::Microsoft::ReactNative::GettingFocusEventArgs &args) noexcept;
+  virtual void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept;
   virtual void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept;
- 
-  winrt::event_token LosingFocus(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs> const& handler) noexcept;
-  void LosingFocus(winrt::event_token const& token) noexcept;
-  winrt::event_token GettingFocus(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::GettingFocusEventArgs> const& handler) noexcept;
-  void GettingFocus(winrt::event_token const& token) noexcept;
+
+  winrt::event_token LosingFocus(
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs> const
+          &handler) noexcept;
+  void LosingFocus(winrt::event_token const &token) noexcept;
+  winrt::event_token GettingFocus(
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::GettingFocusEventArgs> const
+          &handler) noexcept;
+  void GettingFocus(winrt::event_token const &token) noexcept;
   winrt::event_token LostFocus(
       winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const
           &handler) noexcept;
-  void LostFocus(winrt::event_token const& token) noexcept;
+  void LostFocus(winrt::event_token const &token) noexcept;
   winrt::event_token GotFocus(
       winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const
           &handler) noexcept;
-  void GotFocus(winrt::event_token const& token) noexcept;
+  void GotFocus(winrt::event_token const &token) noexcept;
 
   bool TryFocus() noexcept;
 
@@ -175,10 +179,16 @@ struct ComponentView : public ComponentViewT<ComponentView> {
   winrt::Microsoft::ReactNative::ComponentView m_parent{nullptr};
   winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::ComponentView> m_children{
       winrt::single_threaded_vector<winrt::Microsoft::ReactNative::ComponentView>()};
-  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs>> m_losingFocusEvent;
-  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::GettingFocusEventArgs>> m_gettingFocusEvent;
-  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs>> m_lostFocusEvent;
-  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs>> m_gotFocusEvent;
+  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs>>
+      m_losingFocusEvent;
+  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::GettingFocusEventArgs>>
+      m_gettingFocusEvent;
+  winrt::event<
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs>>
+      m_lostFocusEvent;
+  winrt::event<
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs>>
+      m_gotFocusEvent;
 };
 
 // Run fn on all nodes of the component view tree starting from this one until fn returns true

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -87,8 +87,25 @@ struct ComponentView : public ComponentViewT<ComponentView> {
   virtual RECT getClientRect() const noexcept;
   // The offset from this elements parent to its children (accounts for things like scroll position)
   virtual facebook::react::Point getClientOffset() const noexcept;
-  virtual void onFocusLost() noexcept;
-  virtual void onFocusGained() noexcept;
+  virtual void onLosingFocus(const winrt::Microsoft::ReactNative::LosingFocusEventArgs& args) noexcept;
+  virtual void onGettingFocus(const winrt::Microsoft::ReactNative::GettingFocusEventArgs& args) noexcept;
+  virtual void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept;
+  virtual void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept;
+ 
+  winrt::event_token LosingFocus(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs> const& handler) noexcept;
+  void LosingFocus(winrt::event_token const& token) noexcept;
+  winrt::event_token GettingFocus(winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::GettingFocusEventArgs> const& handler) noexcept;
+  void GettingFocus(winrt::event_token const& token) noexcept;
+  winrt::event_token LostFocus(
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const
+          &handler) noexcept;
+  void LostFocus(winrt::event_token const& token) noexcept;
+  winrt::event_token GotFocus(
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> const
+          &handler) noexcept;
+  void GotFocus(winrt::event_token const& token) noexcept;
+
+  bool TryFocus() noexcept;
 
   virtual bool focusable() const noexcept;
   virtual facebook::react::SharedViewEventEmitter eventEmitterAtPoint(facebook::react::Point pt) noexcept;
@@ -158,6 +175,10 @@ struct ComponentView : public ComponentViewT<ComponentView> {
   winrt::Microsoft::ReactNative::ComponentView m_parent{nullptr};
   winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::ComponentView> m_children{
       winrt::single_threaded_vector<winrt::Microsoft::ReactNative::ComponentView>()};
+  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::LosingFocusEventArgs>> m_losingFocusEvent;
+  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::GettingFocusEventArgs>> m_gettingFocusEvent;
+  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs>> m_lostFocusEvent;
+  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs>> m_gotFocusEvent;
 };
 
 // Run fn on all nodes of the component view tree starting from this one until fn returns true

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -132,6 +132,12 @@ CompositionRootView::CompositionRootView(const winrt::Microsoft::UI::Composition
 #endif
 
 CompositionRootView::~CompositionRootView() noexcept {
+#ifdef USE_WINUI3
+  if (m_island && m_island.IsConnected()) {
+    m_island.AutomationProviderRequested(m_islandAutomationProviderRequestedToken);
+  }
+#endif
+
   if (m_uiDispatcher) {
     assert(m_uiDispatcher.HasThreadAccess());
     UninitRootView();
@@ -193,7 +199,7 @@ void CompositionRootView::RemoveRenderedVisual(
 
 bool CompositionRootView::TrySetFocus() noexcept {
 #ifdef USE_WINUI3
-  if (m_island) {
+  if (m_island && m_island.IsConnected()) {
     auto focusController = winrt::Microsoft::UI::Input::InputFocusController::GetForIsland(m_island);
     return focusController.TrySetFocus();
   }
@@ -664,20 +670,29 @@ winrt::Microsoft::UI::Content::ContentIsland CompositionRootView::Island() noexc
             rootVisual));
     m_island = winrt::Microsoft::UI::Content::ContentIsland::Create(rootVisual);
 
-    m_island.AutomationProviderRequested(
-        [this](
+    // ContentIsland does not support weak_ref, so we cannot use auto_revoke for these events
+    m_islandAutomationProviderRequestedToken = m_island.AutomationProviderRequested(
+        [weakThis = get_weak()](
             winrt::Microsoft::UI::Content::ContentIsland const &,
             winrt::Microsoft::UI::Content::ContentIslandAutomationProviderRequestedEventArgs const &args) {
-          auto provider = GetUiaProvider();
-          auto pRootProvider =
-              static_cast<winrt::Microsoft::ReactNative::implementation::CompositionRootAutomationProvider *>(
-                  provider.as<IRawElementProviderSimple>().get());
-          if (pRootProvider != nullptr) {
-            pRootProvider->SetIsland(m_island);
+          if (auto pThis = weakThis.get()) {
+            auto provider = pThis->GetUiaProvider();
+            auto pRootProvider =
+                static_cast<winrt::Microsoft::ReactNative::implementation::CompositionRootAutomationProvider *>(
+                    provider.as<IRawElementProviderSimple>().get());
+            if (pRootProvider != nullptr) {
+              pRootProvider->SetIsland(pThis->m_island);
+            }
+            args.AutomationProvider(std::move(provider));
+            args.Handled(true);
           }
-          args.AutomationProvider(std::move(provider));
-          args.Handled(true);
         });
+
+    m_islandFrameworkClosedToken = m_island.FrameworkClosed([weakThis = get_weak()]() {
+      if (auto pThis = weakThis.get()) {
+        pThis->m_island = nullptr;
+      }
+    });
   }
   return m_island;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -121,6 +121,8 @@ struct CompositionRootView
 #ifdef USE_WINUI3
   winrt::Microsoft::UI::Composition::Compositor m_compositor{nullptr};
   winrt::Microsoft::UI::Content::ContentIsland m_island{nullptr};
+  winrt::event_token m_islandFrameworkClosedToken;
+  winrt::event_token m_islandAutomationProviderRequestedToken;
 #endif
 
   HWND m_hwnd{0};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -183,7 +183,8 @@ void ComponentView::FinalizeUpdates(winrt::Microsoft::ReactNative::ComponentView
   base_type::FinalizeUpdates(updateMask);
 }
 
-void ComponentView::onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
+void ComponentView::onLostFocus(
+    const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
   if (args.OriginalSource() == Tag()) {
     m_eventEmitter->onBlur();
     showFocusVisual(false);
@@ -195,7 +196,8 @@ void ComponentView::onLostFocus(const winrt::Microsoft::ReactNative::Composition
   base_type::onLostFocus(args);
 }
 
-void ComponentView::onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
+void ComponentView::onGotFocus(
+    const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
   if (args.OriginalSource() == Tag()) {
     m_eventEmitter->onFocus();
     if (m_enableFocusVisual) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -75,7 +75,7 @@ struct ComponentView
   void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept;
   winrt::Microsoft::ReactNative::Composition::Theme Theme() const noexcept;
   void onThemeChanged() noexcept override;
-  void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept override;
+  void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept override;
   void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept override;
   bool CapturePointer(const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept;
   void ReleasePointerCapture(const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -69,11 +69,14 @@ struct ComponentView
     assert(false);
     return emptyProps;
   };
+
+  winrt::Microsoft::ReactNative::Composition::RootComponentView Root() noexcept;
+
   void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept;
   winrt::Microsoft::ReactNative::Composition::Theme Theme() const noexcept;
   void onThemeChanged() noexcept override;
-  void onFocusLost() noexcept override;
-  void onFocusGained() noexcept override;
+  void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept override;
+  void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept override;
   bool CapturePointer(const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept;
   void ReleasePointerCapture(const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept;
 
@@ -189,6 +192,7 @@ struct ViewComponentView : public ViewComponentViewT<ViewComponentView, Componen
       facebook::react::LayoutMetrics const &layoutMetrics,
       facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept override;
   void prepareForRecycle() noexcept override;
+  bool TryFocus() noexcept;
   bool focusable() const noexcept override;
   void OnKeyDown(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "FocusManager.h"
+#include "Composition.FocusManager.g.cpp"
+#include <Fabric/FabricUIManagerModule.h>
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+LostFocusEventArgs::LostFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource) : m_originalSource(originalSource ? originalSource.Tag() : -1) {}
+int32_t LostFocusEventArgs::OriginalSource() noexcept {
+  return m_originalSource;
+}
+
+GotFocusEventArgs::GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource) : m_originalSource(originalSource ? originalSource.Tag() : -1) {}
+int32_t GotFocusEventArgs::OriginalSource() noexcept {
+  return m_originalSource;
+}
+
+LosingFocusEventArgs::LosingFocusEventArgs(
+    const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+    const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
+    const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent)
+    : m_originalSource(originalSource ? originalSource.Tag() : -1), m_old(oldFocusedComponent), m_new(newFocusedComponent) {}
+
+int32_t LosingFocusEventArgs::OriginalSource() noexcept {
+  return m_originalSource;
+}
+winrt::Microsoft::ReactNative::ComponentView LosingFocusEventArgs::NewFocusedComponent() noexcept {
+  return m_new;
+}
+winrt::Microsoft::ReactNative::ComponentView LosingFocusEventArgs::OldFocusedComponent() noexcept {
+  return m_old;
+}
+
+void LosingFocusEventArgs::TryCancel() noexcept {
+  m_new = m_old;
+}
+
+void LosingFocusEventArgs::TrySetNewFocusedComponent(
+    const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent) noexcept {
+  auto selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(newFocusedComponent);
+  if (selfView->focusable()) {
+    m_new = newFocusedComponent;
+  } else {
+    auto target = winrt::Microsoft::ReactNative::Composition::FocusManager::FindFirstFocusableElement(newFocusedComponent);
+    if (!target)
+      return;
+    m_new = target;
+  }
+}
+
+GettingFocusEventArgs::GettingFocusEventArgs(
+    const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+    const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
+    const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent)
+    : m_originalSource(originalSource ? originalSource.Tag() : -1), m_old(oldFocusedComponent), m_new(newFocusedComponent) {}
+
+int32_t GettingFocusEventArgs::OriginalSource() noexcept {
+  return m_originalSource;
+}
+winrt::Microsoft::ReactNative::ComponentView GettingFocusEventArgs::NewFocusedComponent() noexcept {
+  return m_new;
+}
+winrt::Microsoft::ReactNative::ComponentView GettingFocusEventArgs::OldFocusedComponent() noexcept {
+  return m_old;
+}
+
+void GettingFocusEventArgs::TryCancel() noexcept {
+  m_new = m_old;
+}
+
+void GettingFocusEventArgs::TrySetNewFocusedComponent(
+    const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent) noexcept {
+  auto selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(newFocusedComponent);
+  if (selfView->focusable()) {
+    m_new = newFocusedComponent;
+  } else {
+    auto target =
+        winrt::Microsoft::ReactNative::Composition::FocusManager::FindFirstFocusableElement(newFocusedComponent);
+    if (!target)
+      return;
+    m_new = target;
+  }
+}
+
+}
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+winrt::Microsoft::ReactNative::implementation::ComponentView *NavigateFocusHelper(
+    winrt::Microsoft::ReactNative::implementation::ComponentView &view,
+    winrt::Microsoft::ReactNative::FocusNavigationReason reason) {
+  if (reason == winrt::Microsoft::ReactNative::FocusNavigationReason::First) {
+    if (view.focusable()) {
+      return &view;
+    }
+  }
+  winrt::Microsoft::ReactNative::implementation::ComponentView *toFocus = nullptr;
+
+  Mso::Functor<bool(::winrt::Microsoft::ReactNative::implementation::ComponentView & v)> fn =
+      [reason, &toFocus](::winrt::Microsoft::ReactNative::implementation::ComponentView &v) noexcept
+      -> bool { return (toFocus = NavigateFocusHelper(v, reason)); };
+
+  if (view.runOnChildren(reason == winrt::Microsoft::ReactNative::FocusNavigationReason::First, fn)) {
+    return toFocus;
+  }
+
+  if (reason == winrt::Microsoft::ReactNative::FocusNavigationReason::Last) {
+    if (view.focusable()) {
+      return &view;
+    }
+  }
+
+  return nullptr;
+}
+
+winrt::Microsoft::ReactNative::ComponentView FocusManager::FindFirstFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept {
+  auto selfSearchScope = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(searchScope);
+  auto view = NavigateFocusHelper(*selfSearchScope, winrt::Microsoft::ReactNative::FocusNavigationReason::First);
+  if (view) {
+    winrt::Microsoft::ReactNative::ComponentView component{nullptr};
+    winrt::check_hresult(view->QueryInterface(
+        winrt::guid_of<winrt::Microsoft::ReactNative::ComponentView>(), winrt::put_abi(component)));
+    return *view;
+  }
+  return nullptr;
+}
+
+winrt::Microsoft::ReactNative::ComponentView FocusManager::FindLastFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept {
+  auto selfSearchScope = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(searchScope);
+  auto view = NavigateFocusHelper(*selfSearchScope, winrt::Microsoft::ReactNative::FocusNavigationReason::Last);
+  if (view) {
+    winrt::Microsoft::ReactNative::ComponentView component{nullptr};
+    winrt::check_hresult(view->QueryInterface(
+        winrt::guid_of<winrt::Microsoft::ReactNative::ComponentView>(), winrt::put_abi(component)));
+    return *view;
+  }
+  return nullptr;
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.cpp
@@ -8,21 +8,25 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-LostFocusEventArgs::LostFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource) : m_originalSource(originalSource ? originalSource.Tag() : -1) {}
+LostFocusEventArgs::LostFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView &originalSource)
+    : m_originalSource(originalSource ? originalSource.Tag() : -1) {}
 int32_t LostFocusEventArgs::OriginalSource() noexcept {
   return m_originalSource;
 }
 
-GotFocusEventArgs::GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource) : m_originalSource(originalSource ? originalSource.Tag() : -1) {}
+GotFocusEventArgs::GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView &originalSource)
+    : m_originalSource(originalSource ? originalSource.Tag() : -1) {}
 int32_t GotFocusEventArgs::OriginalSource() noexcept {
   return m_originalSource;
 }
 
 LosingFocusEventArgs::LosingFocusEventArgs(
-    const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+    const winrt::Microsoft::ReactNative::ComponentView &originalSource,
     const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
     const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent)
-    : m_originalSource(originalSource ? originalSource.Tag() : -1), m_old(oldFocusedComponent), m_new(newFocusedComponent) {}
+    : m_originalSource(originalSource ? originalSource.Tag() : -1),
+      m_old(oldFocusedComponent),
+      m_new(newFocusedComponent) {}
 
 int32_t LosingFocusEventArgs::OriginalSource() noexcept {
   return m_originalSource;
@@ -44,7 +48,8 @@ void LosingFocusEventArgs::TrySetNewFocusedComponent(
   if (selfView->focusable()) {
     m_new = newFocusedComponent;
   } else {
-    auto target = winrt::Microsoft::ReactNative::Composition::FocusManager::FindFirstFocusableElement(newFocusedComponent);
+    auto target =
+        winrt::Microsoft::ReactNative::Composition::FocusManager::FindFirstFocusableElement(newFocusedComponent);
     if (!target)
       return;
     m_new = target;
@@ -52,10 +57,12 @@ void LosingFocusEventArgs::TrySetNewFocusedComponent(
 }
 
 GettingFocusEventArgs::GettingFocusEventArgs(
-    const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+    const winrt::Microsoft::ReactNative::ComponentView &originalSource,
     const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
     const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent)
-    : m_originalSource(originalSource ? originalSource.Tag() : -1), m_old(oldFocusedComponent), m_new(newFocusedComponent) {}
+    : m_originalSource(originalSource ? originalSource.Tag() : -1),
+      m_old(oldFocusedComponent),
+      m_new(newFocusedComponent) {}
 
 int32_t GettingFocusEventArgs::OriginalSource() noexcept {
   return m_originalSource;
@@ -85,7 +92,7 @@ void GettingFocusEventArgs::TrySetNewFocusedComponent(
   }
 }
 
-}
+} // namespace winrt::Microsoft::ReactNative::implementation
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
@@ -116,7 +123,8 @@ winrt::Microsoft::ReactNative::implementation::ComponentView *NavigateFocusHelpe
   return nullptr;
 }
 
-winrt::Microsoft::ReactNative::ComponentView FocusManager::FindFirstFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept {
+winrt::Microsoft::ReactNative::ComponentView FocusManager::FindFirstFocusableElement(
+    const winrt::Microsoft::ReactNative::ComponentView &searchScope) noexcept {
   auto selfSearchScope = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(searchScope);
   auto view = NavigateFocusHelper(*selfSearchScope, winrt::Microsoft::ReactNative::FocusNavigationReason::First);
   if (view) {
@@ -128,7 +136,8 @@ winrt::Microsoft::ReactNative::ComponentView FocusManager::FindFirstFocusableEle
   return nullptr;
 }
 
-winrt::Microsoft::ReactNative::ComponentView FocusManager::FindLastFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept {
+winrt::Microsoft::ReactNative::ComponentView FocusManager::FindLastFocusableElement(
+    const winrt::Microsoft::ReactNative::ComponentView &searchScope) noexcept {
   auto selfSearchScope = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(searchScope);
   auto view = NavigateFocusHelper(*selfSearchScope, winrt::Microsoft::ReactNative::FocusNavigationReason::Last);
   if (view) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.h
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#include "Composition.FocusManager.g.h"
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
+#include <winrt/Microsoft.ReactNative.Composition.Input.h>
+#include "LosingFocusEventArgs.g.h"
+#include "GettingFocusEventArgs.g.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct LostFocusEventArgs
+    : winrt::implements<LostFocusEventArgs, winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> {
+  LostFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource);
+  int32_t OriginalSource() noexcept;
+
+ private:
+  const int32_t m_originalSource;
+};
+
+struct GotFocusEventArgs
+    : winrt::implements<GotFocusEventArgs, winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> {
+  GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource);
+  int32_t OriginalSource() noexcept;
+
+ private:
+  const int32_t m_originalSource;
+};
+
+struct LosingFocusEventArgs
+    : winrt::Microsoft::ReactNative::implementation::LosingFocusEventArgsT<LosingFocusEventArgs> {
+  LosingFocusEventArgs(
+      const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+      const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
+      const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent);
+  int32_t OriginalSource() noexcept;
+  winrt::Microsoft::ReactNative::ComponentView NewFocusedComponent() noexcept;
+  winrt::Microsoft::ReactNative::ComponentView OldFocusedComponent() noexcept;
+
+  void TryCancel() noexcept;
+  void TrySetNewFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent) noexcept;
+
+ private:
+  const int32_t m_originalSource;
+  winrt::Microsoft::ReactNative::ComponentView m_old{nullptr};
+  winrt::Microsoft::ReactNative::ComponentView m_new{nullptr};
+};
+
+struct GettingFocusEventArgs
+    : winrt::Microsoft::ReactNative::implementation::GettingFocusEventArgsT<GettingFocusEventArgs> {
+  GettingFocusEventArgs(
+      const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+      const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
+      const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent);
+  int32_t OriginalSource() noexcept;
+  winrt::Microsoft::ReactNative::ComponentView NewFocusedComponent() noexcept;
+  winrt::Microsoft::ReactNative::ComponentView OldFocusedComponent() noexcept;
+
+  void TryCancel() noexcept;
+  void TrySetNewFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent) noexcept;
+
+ private:
+  const int32_t m_originalSource;
+  winrt::Microsoft::ReactNative::ComponentView m_old{nullptr};
+  winrt::Microsoft::ReactNative::ComponentView m_new{nullptr};
+};
+}
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+
+struct FocusManager : FocusManagerT<FocusManager> {
+  FocusManager() = default;
+
+  static winrt::Microsoft::ReactNative::ComponentView FindFirstFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept;
+  static winrt::Microsoft::ReactNative::ComponentView FindLastFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept;
+};
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation
+
+namespace winrt::Microsoft::ReactNative::Composition::factory_implementation {
+struct FocusManager : FocusManagerT<FocusManager, implementation::FocusManager> {};
+} // namespace winrt::Microsoft::ReactNative::Composition::factory_implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.h
@@ -3,16 +3,16 @@
 
 #pragma once
 #include "Composition.FocusManager.g.h"
+#include "GettingFocusEventArgs.g.h"
+#include "LosingFocusEventArgs.g.h"
 #include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include <winrt/Microsoft.ReactNative.Composition.Input.h>
-#include "LosingFocusEventArgs.g.h"
-#include "GettingFocusEventArgs.g.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
 struct LostFocusEventArgs
     : winrt::implements<LostFocusEventArgs, winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> {
-  LostFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource);
+  LostFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView &originalSource);
   int32_t OriginalSource() noexcept;
 
  private:
@@ -21,7 +21,7 @@ struct LostFocusEventArgs
 
 struct GotFocusEventArgs
     : winrt::implements<GotFocusEventArgs, winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> {
-  GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView& originalSource);
+  GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView &originalSource);
   int32_t OriginalSource() noexcept;
 
  private:
@@ -31,7 +31,7 @@ struct GotFocusEventArgs
 struct LosingFocusEventArgs
     : winrt::Microsoft::ReactNative::implementation::LosingFocusEventArgsT<LosingFocusEventArgs> {
   LosingFocusEventArgs(
-      const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+      const winrt::Microsoft::ReactNative::ComponentView &originalSource,
       const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
       const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent);
   int32_t OriginalSource() noexcept;
@@ -50,7 +50,7 @@ struct LosingFocusEventArgs
 struct GettingFocusEventArgs
     : winrt::Microsoft::ReactNative::implementation::GettingFocusEventArgsT<GettingFocusEventArgs> {
   GettingFocusEventArgs(
-      const winrt::Microsoft::ReactNative::ComponentView& originalSource,
+      const winrt::Microsoft::ReactNative::ComponentView &originalSource,
       const winrt::Microsoft::ReactNative::ComponentView &oldFocusedComponent,
       const winrt::Microsoft::ReactNative::ComponentView &newFocusedComponent);
   int32_t OriginalSource() noexcept;
@@ -65,16 +65,17 @@ struct GettingFocusEventArgs
   winrt::Microsoft::ReactNative::ComponentView m_old{nullptr};
   winrt::Microsoft::ReactNative::ComponentView m_new{nullptr};
 };
-}
+} // namespace winrt::Microsoft::ReactNative::implementation
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
-
 
 struct FocusManager : FocusManagerT<FocusManager> {
   FocusManager() = default;
 
-  static winrt::Microsoft::ReactNative::ComponentView FindFirstFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept;
-  static winrt::Microsoft::ReactNative::ComponentView FindLastFocusableElement(const winrt::Microsoft::ReactNative::ComponentView& searchScope) noexcept;
+  static winrt::Microsoft::ReactNative::ComponentView FindFirstFocusableElement(
+      const winrt::Microsoft::ReactNative::ComponentView &searchScope) noexcept;
+  static winrt::Microsoft::ReactNative::ComponentView FindLastFocusableElement(
+      const winrt::Microsoft::ReactNative::ComponentView &searchScope) noexcept;
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -54,7 +54,8 @@ void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative:
 
   if (m_focusedComponent) {
     auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::LostFocusEventArgs>(m_focusedComponent);
-    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_focusedComponent)->onLostFocus(args);
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_focusedComponent)
+        ->onLostFocus(args);
   }
 
   if (value) {
@@ -74,7 +75,9 @@ bool RootComponentView::NavigateFocus(const winrt::Microsoft::ReactNative::Focus
     return m_focusedComponent != nullptr;
   }
 
-  auto view = (request.Reason() == winrt::Microsoft::ReactNative::FocusNavigationReason::First) ? FocusManager::FindFirstFocusableElement(*this) : FocusManager::FindLastFocusableElement(*this);
+  auto view = (request.Reason() == winrt::Microsoft::ReactNative::FocusNavigationReason::First)
+      ? FocusManager::FindFirstFocusableElement(*this)
+      : FocusManager::FindLastFocusableElement(*this);
   if (view) {
     TrySetFocusedComponent(view);
   }
@@ -90,12 +93,12 @@ bool RootComponentView::TrySetFocusedComponent(const winrt::Microsoft::ReactNati
       return false;
     selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(target);
   }
-  
+
   if (selfView->rootComponentView() != this)
     return false;
 
   auto losingFocusArgs = winrt::make<winrt::Microsoft::ReactNative::implementation::LosingFocusEventArgs>(
-    target, m_focusedComponent, target);
+      target, m_focusedComponent, target);
   if (m_focusedComponent) {
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_focusedComponent)
         ->onLosingFocus(losingFocusArgs);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -87,14 +87,14 @@ bool RootComponentView::NavigateFocus(const winrt::Microsoft::ReactNative::Focus
 bool RootComponentView::TrySetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept {
   auto target = view;
   auto selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(target);
-  if (!selfView->focusable()) {
+  if (selfView && !selfView->focusable()) {
     target = FocusManager::FindFirstFocusableElement(target);
     if (!target)
       return false;
     selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(target);
   }
 
-  if (selfView->rootComponentView() != this)
+  if (selfView && selfView->rootComponentView() != this)
     return false;
 
   auto losingFocusArgs = winrt::make<winrt::Microsoft::ReactNative::implementation::LosingFocusEventArgs>(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -45,7 +45,7 @@ RootComponentView *RootComponentView::rootComponentView() noexcept {
   return this;
 }
 
-winrt::Microsoft::ReactNative::ComponentView &RootComponentView::GetFocusedComponent() noexcept {
+winrt::Microsoft::ReactNative::ComponentView RootComponentView::GetFocusedComponent() noexcept {
   return m_focusedComponent;
 }
 void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &value) noexcept {
@@ -53,44 +53,19 @@ void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative:
     return;
 
   if (m_focusedComponent) {
-    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_focusedComponent)->onFocusLost();
+    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::LostFocusEventArgs>(m_focusedComponent);
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_focusedComponent)->onLostFocus(args);
   }
 
   if (value) {
     if (auto rootView = m_wkRootView.get()) {
       winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->TrySetFocus();
     }
-    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(value)->onFocusGained();
+    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value);
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(value)->onGotFocus(args);
   }
 
   m_focusedComponent = value;
-}
-
-winrt::Microsoft::ReactNative::implementation::ComponentView *NavigateFocusHelper(
-    winrt::Microsoft::ReactNative::implementation::ComponentView &view,
-    winrt::Microsoft::ReactNative::FocusNavigationReason reason) {
-  if (reason == winrt::Microsoft::ReactNative::FocusNavigationReason::First) {
-    if (view.focusable()) {
-      return &view;
-    }
-  }
-  winrt::Microsoft::ReactNative::implementation::ComponentView *toFocus = nullptr;
-
-  Mso::Functor<bool(::winrt::Microsoft::ReactNative::implementation::ComponentView & v)> fn =
-      [reason, &toFocus](::winrt::Microsoft::ReactNative::implementation::ComponentView &v) noexcept
-      -> bool { return (toFocus = NavigateFocusHelper(v, reason)); };
-
-  if (view.runOnChildren(reason == winrt::Microsoft::ReactNative::FocusNavigationReason::First, fn)) {
-    return toFocus;
-  }
-
-  if (reason == winrt::Microsoft::ReactNative::FocusNavigationReason::Last) {
-    if (view.focusable()) {
-      return &view;
-    }
-  }
-
-  return nullptr;
 }
 
 bool RootComponentView::NavigateFocus(const winrt::Microsoft::ReactNative::FocusNavigationRequest &request) noexcept {
@@ -99,23 +74,45 @@ bool RootComponentView::NavigateFocus(const winrt::Microsoft::ReactNative::Focus
     return m_focusedComponent != nullptr;
   }
 
-  auto view = NavigateFocusHelper(*this, request.Reason());
+  auto view = (request.Reason() == winrt::Microsoft::ReactNative::FocusNavigationReason::First) ? FocusManager::FindFirstFocusableElement(*this) : FocusManager::FindLastFocusableElement(*this);
   if (view) {
-    winrt::Microsoft::ReactNative::ComponentView component{nullptr};
-    winrt::check_hresult(view->QueryInterface(
-        winrt::guid_of<winrt::Microsoft::ReactNative::ComponentView>(), winrt::put_abi(component)));
-    SetFocusedComponent(component);
+    TrySetFocusedComponent(view);
   }
   return view != nullptr;
 }
 
 bool RootComponentView::TrySetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept {
-  auto selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(view);
-  if (selfView->focusable()) {
-    selfView->rootComponentView()->SetFocusedComponent(view);
-    return true;
+  auto target = view;
+  auto selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(target);
+  if (!selfView->focusable()) {
+    target = FocusManager::FindFirstFocusableElement(target);
+    if (!target)
+      return false;
+    selfView = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(target);
   }
-  return false;
+  
+  if (selfView->rootComponentView() != this)
+    return false;
+
+  auto losingFocusArgs = winrt::make<winrt::Microsoft::ReactNative::implementation::LosingFocusEventArgs>(
+    target, m_focusedComponent, target);
+  if (m_focusedComponent) {
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_focusedComponent)
+        ->onLosingFocus(losingFocusArgs);
+  }
+
+  if (losingFocusArgs.NewFocusedComponent()) {
+    auto gettingFocusArgs = winrt::make<winrt::Microsoft::ReactNative::implementation::GettingFocusEventArgs>(
+        target, m_focusedComponent, losingFocusArgs.NewFocusedComponent());
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(losingFocusArgs.NewFocusedComponent())
+        ->onGettingFocus(gettingFocusArgs);
+
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(losingFocusArgs.NewFocusedComponent())
+        ->rootComponentView()
+        ->SetFocusedComponent(gettingFocusArgs.NewFocusedComponent());
+  }
+
+  return true;
 }
 
 bool RootComponentView::TryMoveFocus(bool next) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
@@ -52,10 +52,8 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
 
   virtual ~RootComponentView();
 
-
   winrt::Microsoft::ReactNative::ComponentView FindFirstFocusableElement() noexcept;
   winrt::Microsoft::ReactNative::ComponentView FindLastFocusableElement() noexcept;
-
 
  private:
   // should this be a ReactTaggedView? - It shouldn't actually matter since if the view is going away it should always

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
@@ -8,6 +8,7 @@
 #include <Microsoft.ReactNative.Cxx/ReactContext.h>
 
 #include "CompositionViewComponentView.h"
+#include "FocusManager.h"
 #include "Theme.h"
 
 #include "Composition.RootComponentView.g.h"
@@ -25,7 +26,7 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  winrt::Microsoft::ReactNative::ComponentView &GetFocusedComponent() noexcept;
+  winrt::Microsoft::ReactNative::ComponentView GetFocusedComponent() noexcept;
   void SetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &value) noexcept;
   bool TrySetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &view) noexcept;
 
@@ -50,6 +51,11 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
   virtual ~RootComponentView();
+
+
+  winrt::Microsoft::ReactNative::ComponentView FindFirstFocusableElement() noexcept;
+  winrt::Microsoft::ReactNative::ComponentView FindLastFocusableElement() noexcept;
+
 
  private:
   // should this be a ReactTaggedView? - It shouldn't actually matter since if the view is going away it should always

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -224,7 +224,7 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
     winrt::Microsoft::ReactNative::ComponentView view{nullptr};
     winrt::check_hresult(
         m_outer->QueryInterface(winrt::guid_of<winrt::Microsoft::ReactNative::ComponentView>(), winrt::put_abi(view)));
-    m_outer->rootComponentView()->SetFocusedComponent(view);
+    m_outer->rootComponentView()->TrySetFocusedComponent(view);
     // assert(false);
     // TODO focus
   }
@@ -929,8 +929,8 @@ void WindowsTextInputComponentView::UnmountChildComponentView(
   base_type::UnmountChildComponentView(childComponentView, index);
 }
 
-void WindowsTextInputComponentView::onFocusLost() noexcept {
-  Super::onFocusLost();
+void WindowsTextInputComponentView::onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
+  Super::onLostFocus(args);
   if (m_textServices) {
     LRESULT lresult;
     DrawBlock db(*this);
@@ -939,8 +939,8 @@ void WindowsTextInputComponentView::onFocusLost() noexcept {
   m_caretVisual.IsVisible(false);
 }
 
-void WindowsTextInputComponentView::onFocusGained() noexcept {
-  Super::onFocusGained();
+void WindowsTextInputComponentView::onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
+  Super::onGotFocus(args);
   if (m_textServices) {
     LRESULT lresult;
     DrawBlock db(*this);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -929,7 +929,8 @@ void WindowsTextInputComponentView::UnmountChildComponentView(
   base_type::UnmountChildComponentView(childComponentView, index);
 }
 
-void WindowsTextInputComponentView::onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
+void WindowsTextInputComponentView::onLostFocus(
+    const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
   Super::onLostFocus(args);
   if (m_textServices) {
     LRESULT lresult;
@@ -939,7 +940,8 @@ void WindowsTextInputComponentView::onLostFocus(const winrt::Microsoft::ReactNat
   m_caretVisual.IsVisible(false);
 }
 
-void WindowsTextInputComponentView::onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept {
+void WindowsTextInputComponentView::onGotFocus(
+    const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
   Super::onGotFocus(args);
   if (m_textServices) {
     LRESULT lresult;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -49,8 +49,8 @@ struct WindowsTextInputComponentView
   void HandleCommand(winrt::hstring commandName, const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept
       override;
   void OnRenderingDeviceLost() noexcept override;
-  void onFocusLost() noexcept override;
-  void onFocusGained() noexcept override;
+  void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept override;
+  void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept override;
   std::string DefaultControlType() const noexcept override;
   std::string DefaultAccessibleName() const noexcept override;
   std::string DefaultHelpText() const noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -49,8 +49,8 @@ struct WindowsTextInputComponentView
   void HandleCommand(winrt::hstring commandName, const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept
       override;
   void OnRenderingDeviceLost() noexcept override;
-  void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept override;
-  void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs& args) noexcept override;
+  void onLostFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept override;
+  void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept override;
   std::string DefaultControlType() const noexcept override;
   std::string DefaultAccessibleName() const noexcept override;
   std::string DefaultHelpText() const noexcept override;

--- a/vnext/Microsoft.ReactNative/FocusManager.idl
+++ b/vnext/Microsoft.ReactNative/FocusManager.idl
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "ComponentView.idl";
+#include "DocString.h"
+
+namespace Microsoft.ReactNative.Composition
+{
+
+  [default_interface]
+  [webhosthidden]
+  [experimental]
+  runtimeclass FocusManager
+  {
+    DOC_STRING("Retrieves the first component that can receive focus based on the specified scope.")
+    static Microsoft.ReactNative.ComponentView FindFirstFocusableElement(Microsoft.ReactNative.ComponentView searchScope);
+
+    DOC_STRING("Retrieves the last component that can receive focus based on the specified scope.")
+    static Microsoft.ReactNative.ComponentView FindLastFocusableElement(Microsoft.ReactNative.ComponentView searchScope);
+  }
+
+} // namespace Microsoft.ReactNative.Composition

--- a/vnext/Microsoft.ReactNative/packages.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.1.18, )",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "requested": "[0.1.21, )",
+        "resolved": "0.1.21",
+        "contentHash": "5njCh+3eXTLOv7+8nOnp6nJ5C0r6it5ze54c0nuWleeDptuK8t3dEDB79XTU4D5DKNvAPlqJpgXRDOak5nYIug=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -84,6 +84,11 @@
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\FocusManager.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\FocusManager.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UriImageManager.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\UriImageManager.idl</DependentUpon>
@@ -642,6 +647,7 @@
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ComponentView.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Composition.Input.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionComponentView.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\FocusManager.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionContext.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionHwndHost.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionRootView.idl" />


### PR DESCRIPTION
## Description
Adding native APIs to support implementation of FURN's FocusTrapZone. And generally expand native focus capabilities.

## New APIs

New static FocusManager runtimeclass::
```
static ComponentView FocusManager.FindFirstFocusableElement(ComponentView searchScope);
static ComponentView FocusManager.FindLastFocusableElement(ComponentView searchScope);
```

New events on ComponentView:
```
event Windows.Foundation.EventHandler<LosingFocusEventArgs> LosingFocus;
event Windows.Foundation.EventHandler<GettingFocusEventArgs> GettingFocus;
event Windows.Foundation.EventHandler<Microsoft.ReactNative.Composition.Input.RoutedEventArgs> LostFocus;
event Windows.Foundation.EventHandler<Microsoft.ReactNative.Composition.Input.RoutedEventArgs> GotFocus;
```

New method on ComponentView:
```
bool TryFocus();
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13234)