### PR TITLE
[0.73] [Win32] Fix PaperUIManager

### DIFF
--- a/change/@office-iss-react-native-win32-2f3250d9-6d3a-44a7-bf44-ad79a1ab1fbc.json
+++ b/change/@office-iss-react-native-win32-2f3250d9-6d3a-44a7-bf44-ad79a1ab1fbc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for PaperUIManger",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/ReactNative/PaperUIManager.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/ReactNative/PaperUIManager.win32.js
@@ -86,6 +86,10 @@ for (const propName of Object.getOwnPropertyNames(
   // $FlowFixMe
   UIManagerJS[propName] = NativeUIManager[propName];
 }
+for (const propName of Object.getOwnPropertyNames(NativeUIManager)) {
+  // $FlowFixMe
+  UIManagerJS[propName] = NativeUIManager[propName];
+}
 // Windows]
 
 /* $FlowFixMe(>=0.123.0 site=react_native_fb) This comment suppresses an error


### PR DESCRIPTION
## Description
Fix fallout from #13009.

Basically, trying to get the UIManager to work with both a 0,74 and a 0.73 dll for internal work.  Previous PR made it work with 0.74 dll, but broke it when using a 0.73 dll.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13267)