### PR TITLE
Fix build error for sample-app-fabric

### DIFF
--- a/packages/sample-app-fabric/windows/SampleAppFabric/SampleAppFabric.cpp
+++ b/packages/sample-app-fabric/windows/SampleAppFabric/SampleAppFabric.cpp
@@ -34,8 +34,9 @@ void UpdateRootViewSizeToAppWindow(
   // Do not relayout when minimized
   if (window.Presenter().as<winrt::Microsoft::UI::Windowing::OverlappedPresenter>().State() !=
       winrt::Microsoft::UI::Windowing::OverlappedPresenterState::Minimized) {
-    rootView.Arrange(size);
-    rootView.Size(size);
+    winrt::Microsoft::ReactNative::LayoutConstraints constraints;
+    constraints.MaximumSize = constraints.MinimumSize = size;
+    rootView.Arrange(constraints, {0, 0});
   }
 }
 


### PR DESCRIPTION
## Description
### Why
Due to recent changes on arrange APIs: https://github.com/microsoft/react-native-windows/pull/13269 the sample-app-fabric needs to be adjusted.

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13288)