### PR TITLE
AsynchronousEventBeat can get locked where it will not beat anymore

### DIFF
--- a/change/react-native-windows-f33cdf8f-4643-430c-8acb-2f41336cca25.json
+++ b/change/react-native-windows-f33cdf8f-4643-430c-8acb-2f41336cca25.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "AsynchronousEventBeat can get locked where it will not beat anymore",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/AsynchronousEventBeat.cpp
+++ b/vnext/Microsoft.ReactNative/AsynchronousEventBeat.cpp
@@ -30,8 +30,7 @@ void AsynchronousEventBeat::induce() const {
 }
 
 void AsynchronousEventBeat::request() const {
-  bool alreadyRequested = isRequested_;
-  EventBeat::request();
+  bool alreadyRequested = isRequested_.exchange(true);
   if (!alreadyRequested) {
     if (m_context.UIDispatcher().HasThreadAccess()) {
       induce();


### PR DESCRIPTION
## Description
There is a race condition where on a subsequent `AsynchronousEventBeat::request` call, first it will query `isRequested_`, which is true from the previous run.  Then on a separate thread `AsynchronousEventBeat::induce` runs and sets `isRequested_` to false.

Back on the first thread we call into `EventBeat::request` which would set `isRequested_` back to true, but because we separately queried the value of `isRequested_` back when it was true, the call to `induce` is not run, and `isRequested_` remains stuck true forever, and `induce` is never run again.

But switching to `bool alreadyRequested = isRequested_.exchange(true);` we ensure that this race condition can never happen.

## Testing
This was semi regularly causing the app to become unresponsive in the playground/E2E apps for me.  It probably causes intermittent failures on the E2E test app.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13293)