### PR TITLE
[0.74] [Fabric] Support blob: images

### DIFF
--- a/change/react-native-windows-c33514c0-2412-40ff-b4ad-4739c95260e7.json
+++ b/change/react-native-windows-c33514c0-2412-40ff-b4ad-4739c95260e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Fabric] Support blob: images, and provide better image.onError callbacks",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -52,43 +52,41 @@ void RegisterCustomComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder
  *
  * This allows applications to provide custom image rendering pipelines.
  */
-struct EllipseImageHandler : winrt::implements<
-                                 EllipseImageHandler,
-                                 winrt::Microsoft::ReactNative::Composition::Experimental::IUriBrushProvider,
-                                 winrt::Microsoft::ReactNative::Composition::IUriImageProvider> {
+struct EllipseImageHandler
+    : winrt::implements<EllipseImageHandler, winrt::Microsoft::ReactNative::Composition::IUriImageProvider> {
   bool CanLoadImageUri(winrt::Microsoft::ReactNative::IReactContext context, winrt::Windows::Foundation::Uri uri) {
     return uri.SchemeName() == L"ellipse";
   }
 
-  winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory>
-  GetSourceAsync(
+  winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::ImageResponse>
+  GetImageResponseAsync(
       const winrt::Microsoft::ReactNative::IReactContext &context,
       const winrt::Microsoft::ReactNative::Composition::ImageSource &imageSource) {
-    co_return [uri = imageSource.Uri(), size = imageSource.Size(), scale = imageSource.Scale(), context](
-                  const winrt::Microsoft::ReactNative::IReactContext &reactContext,
-                  const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext
-                      &compositionContext) -> winrt::Microsoft::ReactNative::Composition::Experimental::IBrush {
-      auto compositor =
-          winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerCompositor(
-              compositionContext);
-      auto drawingBrush = compositionContext.CreateDrawingSurfaceBrush(
-          size,
-          winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
-          winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
-      POINT pt;
-      Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingBrush, scale, &pt);
-      auto renderTarget = autoDraw.GetRenderTarget();
+    co_return winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactoryImageResponse(
+        [uri = imageSource.Uri(), size = imageSource.Size(), scale = imageSource.Scale(), context](
+            const winrt::Microsoft::ReactNative::IReactContext &reactContext,
+            const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compositionContext)
+            -> winrt::Microsoft::ReactNative::Composition::Experimental::IBrush {
+          auto compositor = winrt::Microsoft::ReactNative::Composition::Experimental::
+              MicrosoftCompositionContextHelper::InnerCompositor(compositionContext);
+          auto drawingBrush = compositionContext.CreateDrawingSurfaceBrush(
+              size,
+              winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
+              winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
+          POINT pt;
+          Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingBrush, scale, &pt);
+          auto renderTarget = autoDraw.GetRenderTarget();
 
-      winrt::com_ptr<ID2D1SolidColorBrush> brush;
-      renderTarget->CreateSolidColorBrush({1.0f, 0.0f, 0.0f, 1.0f}, brush.put());
-      renderTarget->DrawEllipse(
-          {{(pt.x + size.Width / 2) / scale, (pt.y + size.Height / 2) / scale},
-           (size.Width / 2) / scale,
-           (size.Height / 2) / scale},
-          brush.get());
+          winrt::com_ptr<ID2D1SolidColorBrush> brush;
+          renderTarget->CreateSolidColorBrush({1.0f, 0.0f, 0.0f, 1.0f}, brush.put());
+          renderTarget->DrawEllipse(
+              {{(pt.x + size.Width / 2) / scale, (pt.y + size.Height / 2) / scale},
+               (size.Width / 2) / scale,
+               (size.Height / 2) / scale},
+              brush.get());
 
-      return drawingBrush;
-    };
+          return drawingBrush;
+        });
   }
 };
 

--- a/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
@@ -212,6 +212,8 @@ TEST_CLASS (HttpResourceIntegrationTest) {
     string error;
     IHttpResource::Response response;
 
+    MicrosoftReactSetRuntimeOptionString("Http.UserAgent", "React Native Windows");
+
     auto resource = IHttpResource::Make();
     resource->SetOnResponse([&rcPromise, &response](int64_t, IHttpResource::Response callbackResponse) {
       response = callbackResponse;
@@ -221,8 +223,6 @@ TEST_CLASS (HttpResourceIntegrationTest) {
       error = std::move(message);
       rcPromise.set_value();
     });
-
-    MicrosoftReactSetRuntimeOptionString("Http.UserAgent", "React Native Windows");
 
     //clang-format off
     resource->SendRequest(

--- a/vnext/Desktop.UnitTests/RedirectHttpFilterUnitTest.cpp
+++ b/vnext/Desktop.UnitTests/RedirectHttpFilterUnitTest.cpp
@@ -39,7 +39,7 @@ TEST_CLASS (RedirectHttpFilterUnitTest) {
   }
 
   TEST_METHOD(QueryInterfacesSucceeds) {
-    auto filter = winrt::make<RedirectHttpFilter>();
+    auto filter = winrt::make<RedirectHttpFilter>(winrt::hstring{});
 
     auto iFilter = filter.try_as<IHttpFilter>();
     Assert::IsFalse(iFilter == nullptr);
@@ -82,7 +82,7 @@ TEST_CLASS (RedirectHttpFilterUnitTest) {
       co_return response;
     };
 
-    auto filter = winrt::make<RedirectHttpFilter>(std::move(mockFilter1), std::move(mockFilter2));
+    auto filter = winrt::make<RedirectHttpFilter>(std::move(mockFilter1), std::move(mockFilter2), winrt::hstring{});
     auto client = HttpClient{filter};
     auto request = HttpRequestMessage{HttpMethod::Get(), Uri{url1}};
     auto sendOp = client.SendRequestAsync(request);
@@ -118,7 +118,7 @@ TEST_CLASS (RedirectHttpFilterUnitTest) {
       co_return response;
     };
 
-    auto filter = winrt::make<RedirectHttpFilter>(std::move(mockFilter1), std::move(mockFilter2));
+    auto filter = winrt::make<RedirectHttpFilter>(std::move(mockFilter1), std::move(mockFilter2), winrt::hstring{});
     // Disable automatic redirect
     filter.try_as<IHttpBaseProtocolFilter>().AllowAutoRedirect(false);
 
@@ -176,7 +176,8 @@ TEST_CLASS (RedirectHttpFilterUnitTest) {
       co_return response;
     };
 
-    auto filter = winrt::make<RedirectHttpFilter>(maxRedirects, std::move(mockFilter1), std::move(mockFilter2));
+    auto filter =
+        winrt::make<RedirectHttpFilter>(maxRedirects, std::move(mockFilter1), std::move(mockFilter2), winrt::hstring{});
     auto client = HttpClient{filter};
     auto request = HttpRequestMessage{HttpMethod::Get(), Uri{url1}};
     ResponseOperation sendOp = nullptr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -685,13 +685,21 @@ void CompositionRootView::Arrange(
 }
 
 #ifdef USE_WINUI3
-winrt::Microsoft::UI::Content::ContentIsland CompositionRootView::Island() noexcept {
+winrt::Microsoft::UI::Content::ContentIsland CompositionRootView::Island() {
   if (!m_compositor) {
     return nullptr;
   }
 
   if (!m_island) {
-    auto rootVisual = m_compositor.CreateSpriteVisual();
+    winrt::Microsoft::UI::Composition::SpriteVisual rootVisual{nullptr};
+    try {
+      rootVisual = m_compositor.CreateSpriteVisual();
+    } catch (const winrt::hresult_error &e) {
+      // If the compositor has been shutdown, then we shouldn't attempt to initialize the island
+      if (e.code() == RO_E_CLOSED)
+        return nullptr;
+      throw e;
+    }
 
     InternalRootVisual(
         winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::CreateVisual(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -48,7 +48,7 @@ struct CompositionRootView
 
 #ifdef USE_WINUI3
   CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept;
-  winrt::Microsoft::UI::Content::ContentIsland Island() noexcept;
+  winrt::Microsoft::UI::Content::ContentIsland Island();
 #endif
 
   // property ReactViewHost

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1411,7 +1411,7 @@ winrt::com_ptr<::IDWriteTextLayout> WindowsTextInputComponentView::CreatePlaceho
 
 void WindowsTextInputComponentView::DrawText() noexcept {
   m_needsRedraw = true;
-  if (m_cDrawBlock || theme()->IsEmpty()) {
+  if (m_cDrawBlock || theme()->IsEmpty() || !m_textServices) {
     return;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.cpp
@@ -285,15 +285,9 @@ ImageResponseOrImageErrorInfo ImageResponse::ResolveImage() {
 
 ImageResponseOrImageErrorInfo ImageFailedResponse::ResolveImage() {
   ImageResponseOrImageErrorInfo imageOrError;
-  imageOrError.errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
-  imageOrError.errorInfo->responseCode = static_cast<int>(m_statusCode);
-  imageOrError.errorInfo->error = winrt::to_string(m_errorMessage);
-  if (imageOrError.errorInfo->error.empty()) {
-    imageOrError.errorInfo->error = "Failed to load image.";
-  }
-  for (auto &&[header, value] : m_responseHeaders) {
-    imageOrError.errorInfo->httpResponseHeaders.push_back(
-        std::make_pair<std::string, std::string>(winrt::to_string(header), winrt::to_string(value)));
+  imageOrError.errorInfo = winrt::to_string(m_errorMessage);
+  if (imageOrError.errorInfo.empty()) {
+    imageOrError.errorInfo = "Failed to load image.";
   }
   return imageOrError;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
@@ -3,10 +3,16 @@
 
 #pragma once
 
+#include <Composition.Experimental.UriBrushFactoryImageResponse.g.h>
+#include <Composition.ImageFailedResponse.g.h>
+#include <Composition.ImageResponse.g.h>
+#include <Composition.StreamImageResponse.g.h>
+#include <Composition.UriBrushFactoryImageResponse.g.h>
 #include <ReactPropertyBag.h>
 #include <Utils/ImageUtils.h>
 #include <react/renderer/imagemanager/primitives.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
+#include "ImageResponseImage.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
@@ -33,4 +39,77 @@ struct UriImageManager {
 winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(
     const facebook::react::ImageSource &source) noexcept;
 
+struct ImageResponseOrImageErrorInfo {
+  std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage> image;
+  std::shared_ptr<facebook::react::ImageErrorInfo> errorInfo;
+};
+
+struct ImageResponse : ImageResponseT<ImageResponse /*, IResolveImage*/> {
+  ImageResponse() noexcept = default;
+  virtual ImageResponseOrImageErrorInfo ResolveImage();
+};
+
+struct ImageFailedResponse : ImageFailedResponseT<ImageFailedResponse, ImageResponse /*, IResolveImage*/> {
+  ImageFailedResponse(winrt::hstring errorMessage) noexcept : base_type(), m_errorMessage(errorMessage) {}
+  ImageFailedResponse(
+      winrt::hstring errorMessage,
+      winrt::Windows::Web::Http::HttpStatusCode statusCode,
+      const winrt::Windows::Web::Http::Headers::HttpResponseHeaderCollection &responseHeaders) noexcept
+      : base_type(), m_errorMessage(errorMessage), m_statusCode(statusCode), m_responseHeaders(responseHeaders) {}
+
+  virtual ImageResponseOrImageErrorInfo ResolveImage();
+
+ private:
+  const winrt::hstring m_errorMessage;
+  const winrt::Windows::Web::Http::HttpStatusCode m_statusCode{winrt::Windows::Web::Http::HttpStatusCode::None};
+  const winrt::Windows::Web::Http::Headers::HttpResponseHeaderCollection m_responseHeaders{nullptr};
+};
+
+struct StreamImageResponse : StreamImageResponseT<StreamImageResponse, ImageResponse /*, IResolveImage*/> {
+  StreamImageResponse(const winrt::Windows::Storage::Streams::IRandomAccessStream &stream) noexcept
+      : base_type(), m_stream(stream) {}
+  virtual ImageResponseOrImageErrorInfo ResolveImage();
+
+ private:
+  const winrt::Windows::Storage::Streams::IRandomAccessStream m_stream;
+};
+
+struct UriBrushFactoryImageResponse
+    : UriBrushFactoryImageResponseT<UriBrushFactoryImageResponse, ImageResponse /*, IResolveImage*/> {
+  UriBrushFactoryImageResponse(const winrt::Microsoft::ReactNative::Composition::UriBrushFactory &factory) noexcept
+      : base_type(), m_factory(factory) {}
+  virtual ImageResponseOrImageErrorInfo ResolveImage();
+
+ private:
+  const winrt::Microsoft::ReactNative::Composition::UriBrushFactory m_factory;
+};
+
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation
+
+namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation {
+struct UriBrushFactoryImageResponse
+    : UriBrushFactoryImageResponseT<
+          UriBrushFactoryImageResponse,
+          winrt::Microsoft::ReactNative::Composition::implementation::
+              ImageResponse /*, winrt::Microsoft::ReactNative::Composition::implementation::IResolveImage*/> {
+  UriBrushFactoryImageResponse(
+      const winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory &factory) noexcept
+      : base_type(), m_factory(factory) {}
+  virtual winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseOrImageErrorInfo ResolveImage();
+
+ private:
+  const winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory m_factory;
+};
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation
+
+namespace winrt::Microsoft::ReactNative::Composition::factory_implementation {
+struct ImageFailedResponse : ImageFailedResponseT<ImageFailedResponse, implementation::ImageFailedResponse> {};
+struct StreamImageResponse : StreamImageResponseT<StreamImageResponse, implementation::StreamImageResponse> {};
+struct UriBrushFactoryImageResponse
+    : UriBrushFactoryImageResponseT<UriBrushFactoryImageResponse, implementation::UriBrushFactoryImageResponse> {};
+} // namespace winrt::Microsoft::ReactNative::Composition::factory_implementation
+
+namespace winrt::Microsoft::ReactNative::Composition::Experimental::factory_implementation {
+struct UriBrushFactoryImageResponse
+    : UriBrushFactoryImageResponseT<UriBrushFactoryImageResponse, implementation::UriBrushFactoryImageResponse> {};
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental::factory_implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
@@ -41,7 +41,7 @@ winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(
 
 struct ImageResponseOrImageErrorInfo {
   std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage> image;
-  std::shared_ptr<facebook::react::ImageErrorInfo> errorInfo;
+  std::string errorInfo;
 };
 
 struct ImageResponse : ImageResponseT<ImageResponse /*, IResolveImage*/> {

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
@@ -63,7 +63,7 @@ std::tuple<winrt::com_ptr<IWICBitmapSource>, winrt::com_ptr<IWICImagingFactory>,
 
     winrt::com_ptr<IWICBitmapFrameDecode> decodedFrame;
     winrt::check_hresult(bitmapDecoder->GetFrame(0, decodedFrame.put()));
-    return {decodedFrame, imagingFactory, nullptr};
+    return {decodedFrame, imagingFactory, {}};
   } catch (winrt::hresult_error const &ex) {
     return {nullptr, nullptr, ::Microsoft::ReactNative::FormatHResultError(winrt::hresult_error(ex))};
   }

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
@@ -5,111 +5,131 @@
 
 #include "WindowsImageManager.h"
 
+#include <CppRuntimeOptions.h>
 #include <Fabric/Composition/CompositionContextHelper.h>
 #include <Fabric/Composition/ImageResponseImage.h>
 #include <Fabric/Composition/UriImageManager.h>
+#include <Networking/NetworkPropertyIds.h>
 #include <Utils/ImageUtils.h>
+#include <fmt/format.h>
 #include <functional/functor.h>
 #include <shcore.h>
 #include <wincodec.h>
+#include <winrt/Microsoft.ReactNative.Composition.h>
+#include <winrt/Windows.Web.Http.Headers.h>
+#include <winrt/Windows.Web.Http.h>
 
 extern "C" HRESULT WINAPI WICCreateImagingFactory_Proxy(UINT SDKVersion, IWICImagingFactory **ppIWICImagingFactory);
 
 namespace Microsoft::ReactNative {
 
+std::string FormatHResultError(winrt::hresult_error const &ex) {
+  return fmt::format("[0x{:0>8x}] {}", static_cast<uint32_t>(ex.code()), winrt::to_string(ex.message()));
+}
+
 WindowsImageManager::WindowsImageManager(winrt::Microsoft::ReactNative::ReactContext reactContext)
     : m_reactContext(reactContext) {
   m_uriImageManager =
       winrt::Microsoft::ReactNative::Composition::implementation::UriImageManager::Get(reactContext.Properties());
+
+  // Ideally we'd just set m_httpClient.DefaultRequestHeaders().UserAgent().ParseAdd(m_defaultUserAgent), but when we do
+  // we start hitting E_STATE_CHANGED errors. Which appears to be this issue
+  // https://github.com/MicrosoftDocs/winrt-api/issues/2410 So instead we apply the header to each request
+  auto userAgent = Microsoft::React::GetRuntimeOptionString("Http.UserAgent");
+  if (userAgent.size() > 0) {
+    m_defaultUserAgent = winrt::to_hstring(userAgent);
+  } else if (auto userAgentProp = reactContext.Properties().Get(::Microsoft::React::DefaultUserAgentPropertyId())) {
+    m_defaultUserAgent = *userAgentProp;
+  }
 }
 
-winrt::com_ptr<IWICBitmapSource> wicBitmapSourceFromStream(
-    const winrt::Windows::Storage::Streams::IRandomAccessStream &results) noexcept {
-  if (!results) {
-    return nullptr;
-  }
+std::tuple<
+    winrt::com_ptr<IWICBitmapSource>,
+    winrt::com_ptr<IWICImagingFactory>,
+    std::shared_ptr<facebook::react::ImageErrorInfo>>
+wicBitmapSourceFromStream(const winrt::Windows::Storage::Streams::IRandomAccessStream &stream) noexcept {
+  try {
+    winrt::com_ptr<IWICImagingFactory> imagingFactory;
+    winrt::check_hresult(WICCreateImagingFactory_Proxy(WINCODEC_SDK_VERSION, imagingFactory.put()));
 
-  winrt::com_ptr<IWICImagingFactory> imagingFactory;
-  winrt::check_hresult(WICCreateImagingFactory_Proxy(WINCODEC_SDK_VERSION, imagingFactory.put()));
+    winrt::com_ptr<IStream> istream;
+    winrt::check_hresult(
+        CreateStreamOverRandomAccessStream(stream.as<IUnknown>().get(), __uuidof(IStream), istream.put_void()));
 
-  winrt::com_ptr<IStream> istream;
-  winrt::check_hresult(
-      CreateStreamOverRandomAccessStream(results.as<IUnknown>().get(), __uuidof(IStream), istream.put_void()));
+    winrt::com_ptr<IWICBitmapDecoder> bitmapDecoder;
+    winrt::check_hresult(imagingFactory->CreateDecoderFromStream(
+        istream.get(), nullptr, WICDecodeMetadataCacheOnDemand, bitmapDecoder.put()));
 
-  winrt::com_ptr<IWICBitmapDecoder> bitmapDecoder;
-  if (imagingFactory->CreateDecoderFromStream(
-          istream.get(), nullptr, WICDecodeMetadataCacheOnDemand, bitmapDecoder.put()) < 0) {
-    return nullptr;
-  }
-
-  winrt::com_ptr<IWICBitmapFrameDecode> decodedFrame;
-  winrt::check_hresult(bitmapDecoder->GetFrame(0, decodedFrame.put()));
-  return decodedFrame;
-}
-
-std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage> generateBitmap(
-    const winrt::Windows::Storage::Streams::IRandomAccessStream &results) noexcept {
-  winrt::com_ptr<IWICBitmapSource> decodedFrame = wicBitmapSourceFromStream(results);
-
-  if (!decodedFrame) {
-    return nullptr;
-  }
-
-  winrt::com_ptr<IWICImagingFactory> imagingFactory;
-  winrt::check_hresult(WICCreateImagingFactory_Proxy(WINCODEC_SDK_VERSION, imagingFactory.put()));
-  winrt::com_ptr<IWICFormatConverter> converter;
-  winrt::check_hresult(imagingFactory->CreateFormatConverter(converter.put()));
-
-  winrt::check_hresult(converter->Initialize(
-      decodedFrame.get(),
-      GUID_WICPixelFormat32bppPBGRA,
-      WICBitmapDitherTypeNone,
-      nullptr,
-      0.0f,
-      WICBitmapPaletteTypeMedianCut));
-
-  winrt::com_ptr<IWICBitmap> wicbmp;
-  winrt::check_hresult(imagingFactory->CreateBitmapFromSource(converter.get(), WICBitmapCacheOnLoad, wicbmp.put()));
-
-  auto image = std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
-  image->m_wicbmp = wicbmp;
-  return image;
-}
-
-template <typename T>
-void ProcessImageRequestTask(
-    std::weak_ptr<const facebook::react::ImageResponseObserverCoordinator> &weakObserverCoordinator,
-    const winrt::Windows::Foundation::IAsyncOperation<T> &task,
-    Mso::Functor<std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>(
-        const T &result)> &&onSuccess) {
-  task.Completed([weakObserverCoordinator, onSuccess = std::move(onSuccess)](auto asyncOp, auto status) {
-    auto observerCoordinator = weakObserverCoordinator.lock();
-    if (!observerCoordinator) {
-      return;
+    if (!bitmapDecoder) {
+      auto errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
+      errorInfo->error = "Failed to decode the image.";
+      return {nullptr, nullptr, errorInfo};
     }
 
-    switch (status) {
-      case winrt::Windows::Foundation::AsyncStatus::Completed: {
-        auto imageResponseImage = onSuccess(asyncOp.GetResults());
-        if (imageResponseImage)
-          observerCoordinator->nativeImageResponseComplete(
-              facebook::react::ImageResponse(imageResponseImage, nullptr /*metadata*/));
-        else
-          observerCoordinator->nativeImageResponseFailed();
-        break;
-      }
-      case winrt::Windows::Foundation::AsyncStatus::Canceled: {
-        observerCoordinator->nativeImageResponseFailed();
-        break;
-      }
-      case winrt::Windows::Foundation::AsyncStatus::Error: {
-        observerCoordinator->nativeImageResponseFailed();
-        break;
-      }
-      case winrt::Windows::Foundation::AsyncStatus::Started: {
+    winrt::com_ptr<IWICBitmapFrameDecode> decodedFrame;
+    winrt::check_hresult(bitmapDecoder->GetFrame(0, decodedFrame.put()));
+    return {decodedFrame, imagingFactory, nullptr};
+  } catch (winrt::hresult_error const &ex) {
+    auto errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
+    errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
+    errorInfo->error = ::Microsoft::ReactNative::FormatHResultError(winrt::hresult_error(ex));
+    return {nullptr, nullptr, errorInfo};
+  }
+}
+
+winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::ImageResponse>
+WindowsImageManager::GetImageRandomAccessStreamAsync(ReactImageSource source) const {
+  co_await winrt::resume_background();
+
+  winrt::Windows::Foundation::Uri uri(winrt::to_hstring(source.uri));
+  bool isFile = (uri.SchemeName() == L"file");
+  bool isAppx = (uri.SchemeName() == L"ms-appx");
+
+  if (isFile || isAppx) {
+    winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::StorageFile> getFileSync{nullptr};
+
+    if (isFile) {
+      getFileSync = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(uri.AbsoluteCanonicalUri());
+    } else {
+      getFileSync = winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
+    }
+
+    winrt::Windows::Storage::StorageFile file(co_await getFileSync);
+    co_return winrt::Microsoft::ReactNative::Composition::StreamImageResponse(co_await file.OpenReadAsync());
+  }
+
+  auto httpMethod{
+      source.method.empty() ? winrt::Windows::Web::Http::HttpMethod::Get()
+                            : winrt::Windows::Web::Http::HttpMethod{winrt::to_hstring(source.method)}};
+
+  winrt::Windows::Web::Http::HttpRequestMessage request{httpMethod, uri};
+
+  if (!m_defaultUserAgent.empty()) {
+    request.Headers().Append(L"User-Agent", m_defaultUserAgent);
+  }
+
+  if (!source.headers.empty()) {
+    for (auto &header : source.headers) {
+      if (_stricmp(header.first.c_str(), "authorization") == 0) {
+        request.Headers().TryAppendWithoutValidation(winrt::to_hstring(header.first), winrt::to_hstring(header.second));
+      } else {
+        request.Headers().Append(winrt::to_hstring(header.first), winrt::to_hstring(header.second));
       }
     }
-  });
+  }
+
+  winrt::Windows::Web::Http::HttpResponseMessage response(co_await m_httpClient.SendRequestAsync(request));
+
+  if (!response.IsSuccessStatusCode()) {
+    co_return winrt::Microsoft::ReactNative::Composition::ImageFailedResponse(
+        response.ReasonPhrase(), response.StatusCode(), response.Headers());
+  }
+
+  winrt::Windows::Storage::Streams::InMemoryRandomAccessStream memoryStream;
+  co_await response.Content().WriteToStreamAsync(memoryStream);
+  memoryStream.Seek(0);
+
+  co_return winrt::Microsoft::ReactNative::Composition::StreamImageResponse(memoryStream.CloneStream());
 }
 
 facebook::react::ImageRequest WindowsImageManager::requestImage(
@@ -123,51 +143,11 @@ facebook::react::ImageRequest WindowsImageManager::requestImage(
   auto rnImageSource = winrt::Microsoft::ReactNative::Composition::implementation::MakeImageSource(imageSource);
   auto provider = m_uriImageManager->TryGetUriImageProvider(m_reactContext.Handle(), rnImageSource);
 
-  if (auto bProvider = provider.try_as<winrt::Microsoft::ReactNative::Composition::IUriBrushProvider>()) {
-    ProcessImageRequestTask<winrt::Microsoft::ReactNative::Composition::UriBrushFactory>(
-        weakObserverCoordinator,
-        bProvider.GetSourceAsync(m_reactContext.Handle(), rnImageSource),
-        [](const winrt::Microsoft::ReactNative::Composition::UriBrushFactory &factory) noexcept {
-          auto image =
-              std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
+  winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::ImageResponse>
+      imageResponseTask{nullptr};
 
-          // Wrap the UriBrushFactory to provide the internal CompositionContext types
-          image->m_brushFactory =
-              [factory](
-                  const winrt::Microsoft::ReactNative::IReactContext &context,
-                  const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext
-                      &compositionContext) {
-                auto compositor = winrt::Microsoft::ReactNative::Composition::Experimental::
-                    MicrosoftCompositionContextHelper::InnerCompositor(compositionContext);
-                auto brush = factory(context, compositor);
-                return winrt::Microsoft::ReactNative::Composition::Experimental::implementation::
-                    MicrosoftCompositionContextHelper::WrapBrush(brush);
-              };
-          return image;
-        });
-
-    return imageRequest;
-  }
-
-  if (auto brushProvider =
-          provider.try_as<winrt::Microsoft::ReactNative::Composition::Experimental::IUriBrushProvider>()) {
-    ProcessImageRequestTask<winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory>(
-        weakObserverCoordinator,
-        brushProvider.GetSourceAsync(m_reactContext.Handle(), rnImageSource),
-        [](const winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory &factory) noexcept {
-          auto image =
-              std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
-          image->m_brushFactory = factory;
-          return image;
-        });
-
-    return imageRequest;
-  };
-
-  winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> task;
-  if (auto imageStreamProvider =
-          provider.try_as<winrt::Microsoft::ReactNative::Composition::IUriImageStreamProvider>()) {
-    task = imageStreamProvider.GetSourceAsync(m_reactContext.Handle(), rnImageSource);
+  if (provider) {
+    imageResponseTask = provider.GetImageResponseAsync(m_reactContext.Handle(), rnImageSource);
   } else {
     ReactImageSource source;
     source.uri = imageSource.uri;
@@ -175,18 +155,122 @@ facebook::react::ImageRequest WindowsImageManager::requestImage(
     source.width = imageSource.size.width;
     source.sourceType = ImageSourceType::Download;
 
-    task = GetImageStreamAsync(source);
+    imageResponseTask = GetImageRandomAccessStreamAsync(source);
   }
 
-  // TODO progress? - Can we register for progress off the download task?
-  // observerCoordinator->nativeImageResponseProgress((float)progress / (float)total);
+  imageResponseTask.Completed([weakObserverCoordinator](auto asyncOp, auto status) {
+    auto observerCoordinator = weakObserverCoordinator.lock();
+    if (!observerCoordinator) {
+      return;
+    }
 
-  ProcessImageRequestTask<winrt::Windows::Storage::Streams::IRandomAccessStream>(
-      weakObserverCoordinator, task, [](const winrt::Windows::Storage::Streams::IRandomAccessStream &stream) {
-        return generateBitmap(stream);
-      });
-
+    switch (status) {
+      case winrt::Windows::Foundation::AsyncStatus::Completed: {
+        auto imageResponse = asyncOp.GetResults();
+        auto selfImageResponse =
+            winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponse>(imageResponse);
+        auto imageResultOrError = selfImageResponse->ResolveImage();
+        if (imageResultOrError.image) {
+          observerCoordinator->nativeImageResponseComplete(
+              facebook::react::ImageResponse(imageResultOrError.image, nullptr /*metadata*/));
+        } else {
+          observerCoordinator->nativeImageResponseFailed(facebook::react::ImageLoadError(imageResultOrError.errorInfo));
+        }
+        break;
+      }
+      case winrt::Windows::Foundation::AsyncStatus::Canceled: {
+        auto errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
+        errorInfo->error = FormatHResultError(winrt::hresult_error(asyncOp.ErrorCode()));
+        observerCoordinator->nativeImageResponseFailed(facebook::react::ImageLoadError(errorInfo));
+        break;
+      }
+      case winrt::Windows::Foundation::AsyncStatus::Error: {
+        auto errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
+        errorInfo->error = FormatHResultError(winrt::hresult_error(asyncOp.ErrorCode()));
+        observerCoordinator->nativeImageResponseFailed(facebook::react::ImageLoadError(errorInfo));
+        break;
+      }
+      case winrt::Windows::Foundation::AsyncStatus::Started: {
+        // TODO progress? - Can we register for progress off the download task?
+        // observerCoordinator->nativeImageResponseProgress(0.0/*progress*/, 0/*completed*/, 0/*total*/);
+        break;
+      }
+    }
+  });
   return imageRequest;
 }
 
 } // namespace Microsoft::ReactNative
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+ImageResponseOrImageErrorInfo StreamImageResponse::ResolveImage() {
+  ImageResponseOrImageErrorInfo imageOrError;
+  try {
+    auto result = ::Microsoft::ReactNative::wicBitmapSourceFromStream(m_stream);
+
+    if (auto errorInfo = std::get<std::shared_ptr<facebook::react::ImageErrorInfo>>(result)) {
+      imageOrError.errorInfo = errorInfo;
+      return imageOrError;
+    }
+
+    auto imagingFactory = std::get<winrt::com_ptr<IWICImagingFactory>>(result);
+    auto decodedFrame = std::get<winrt::com_ptr<IWICBitmapSource>>(result);
+
+    winrt::com_ptr<IWICFormatConverter> converter;
+    winrt::check_hresult(imagingFactory->CreateFormatConverter(converter.put()));
+
+    winrt::check_hresult(converter->Initialize(
+        decodedFrame.get(),
+        GUID_WICPixelFormat32bppPBGRA,
+        WICBitmapDitherTypeNone,
+        nullptr,
+        0.0f,
+        WICBitmapPaletteTypeMedianCut));
+
+    imageOrError.image =
+        std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
+    winrt::check_hresult(imagingFactory->CreateBitmapFromSource(
+        converter.get(), WICBitmapCacheOnLoad, imageOrError.image->m_wicbmp.put()));
+  } catch (winrt::hresult_error const &ex) {
+    imageOrError.errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
+    imageOrError.errorInfo->error = ::Microsoft::ReactNative::FormatHResultError(winrt::hresult_error(ex));
+  }
+  return imageOrError;
+}
+
+ImageResponseOrImageErrorInfo UriBrushFactoryImageResponse::ResolveImage() {
+  ImageResponseOrImageErrorInfo imageOrError;
+  imageOrError.image =
+      std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
+
+  // Wrap the UriBrushFactory to provide the internal CompositionContext types
+  imageOrError.image
+      ->m_brushFactory = [factory = m_factory](
+                             const winrt::Microsoft::ReactNative::IReactContext &context,
+                             const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext
+                                 &compositionContext) {
+    auto compositor =
+        winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerCompositor(
+            compositionContext);
+    auto brush = factory(context, compositor);
+    return winrt::Microsoft::ReactNative::Composition::Experimental::implementation::MicrosoftCompositionContextHelper::
+        WrapBrush(brush);
+  };
+  return imageOrError;
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation
+
+namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation {
+
+winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseOrImageErrorInfo
+UriBrushFactoryImageResponse::ResolveImage() {
+  winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseOrImageErrorInfo imageOrError;
+  imageOrError.image =
+      std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
+  imageOrError.image->m_brushFactory = m_factory;
+  return imageOrError;
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
@@ -30,10 +30,7 @@ struct WindowsImageManager {
   std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::UriImageManager> m_uriImageManager;
 };
 
-std::tuple<
-    winrt::com_ptr<IWICBitmapSource>,
-    winrt::com_ptr<IWICImagingFactory>,
-    std::shared_ptr<facebook::react::ImageErrorInfo>>
-wicBitmapSourceFromStream(const winrt::Windows::Storage::Streams::IRandomAccessStream &stream) noexcept;
+std::tuple<winrt::com_ptr<IWICBitmapSource>, winrt::com_ptr<IWICImagingFactory>, std::string> wicBitmapSourceFromStream(
+    const winrt::Windows::Storage::Streams::IRandomAccessStream &stream) noexcept;
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
@@ -7,6 +7,9 @@
 
 #include <Fabric/Composition/UriImageManager.h>
 #include <ReactContext.h>
+#include <Utils/ImageUtils.h>
+#include <winrt/Microsoft.ReactNative.Composition.h>
+#include <winrt/Windows.Web.Http.h>
 
 namespace Microsoft::ReactNative {
 
@@ -18,8 +21,19 @@ struct WindowsImageManager {
       facebook::react::SurfaceId surfaceId) const;
 
  private:
+  winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::ImageResponse>
+  GetImageRandomAccessStreamAsync(ReactImageSource source) const;
+
+  winrt::Windows::Web::Http::HttpClient m_httpClient;
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;
+  winrt::hstring m_defaultUserAgent;
   std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::UriImageManager> m_uriImageManager;
 };
+
+std::tuple<
+    winrt::com_ptr<IWICBitmapSource>,
+    winrt::com_ptr<IWICImagingFactory>,
+    std::shared_ptr<facebook::react::ImageErrorInfo>>
+wicBitmapSourceFromStream(const winrt::Windows::Storage::Streams::IRandomAccessStream &stream) noexcept;
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/HttpSettings.idl
+++ b/vnext/Microsoft.ReactNative/HttpSettings.idl
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "ReactInstanceSettings.idl";
+
+#include "DocString.h"
+
+namespace Microsoft.ReactNative
+{
+  [webhosthidden]
+  DOC_STRING(
+    "Provides settings for Http functionality. ")
+  runtimeclass HttpSettings
+  {
+    DOC_STRING(
+      "Configures the react instance to use a user-agent header by default on http requests.")
+    static void SetDefaultUserAgent(Microsoft.ReactNative.ReactInstanceSettings settings, String userAgent);
+  }
+} // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
@@ -78,7 +78,8 @@ winrt::fire_and_forget GetImageSizeAsync(
 #ifdef USE_FABRIC
     } else {
       auto result = wicBitmapSourceFromStream(memoryStream);
-      if (!std::get<std::shared_ptr<facebook::react::ImageErrorInfo>>(result)) {
+      auto &errorInfo = std::get<std::string>(result);
+      if (errorInfo.empty()) {
         auto imagingFactory = std::get<winrt::com_ptr<IWICImagingFactory>>(result);
         auto wicBmpSource = std::get<winrt::com_ptr<IWICBitmapSource>>(result);
         UINT width, height;

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
@@ -14,6 +14,7 @@
 #include <Views/Image/ReactImage.h>
 #include <cxxreact/JsArgumentHelpers.h>
 #ifdef USE_FABRIC
+#include <Fabric/WindowsImageManager.h>
 #include <Utils/Helpers.h>
 #include <wincodec.h>
 #include "XamlUtils.h"
@@ -29,12 +30,8 @@ using namespace xaml::Media::Imaging;
 
 namespace Microsoft::ReactNative {
 
-#ifdef USE_FABRIC
-winrt::com_ptr<IWICBitmapSource> wicBitmapSourceFromStream(
-    const winrt::Windows::Storage::Streams::IRandomAccessStream &results) noexcept;
-#endif // USE_FABRIC
-
 winrt::fire_and_forget GetImageSizeAsync(
+    const winrt::Microsoft::ReactNative::IReactPropertyBag &properties,
     std::string uriString,
     winrt::Microsoft::ReactNative::JSValue &&headers,
     Mso::Functor<void(int32_t width, int32_t height)> successCallback,
@@ -62,7 +59,7 @@ winrt::fire_and_forget GetImageSizeAsync(
 
     winrt::IRandomAccessStream memoryStream;
     if (needsDownload) {
-      memoryStream = co_await GetImageStreamAsync(source);
+      memoryStream = co_await GetImageStreamAsync(properties, source);
     } else if (inlineData) {
       memoryStream = co_await GetImageInlineDataAsync(source);
     }
@@ -80,11 +77,15 @@ winrt::fire_and_forget GetImageSizeAsync(
       }
 #ifdef USE_FABRIC
     } else {
-      UINT width, height;
-      auto wicBmpSource = wicBitmapSourceFromStream(memoryStream);
-      if (SUCCEEDED(wicBmpSource->GetSize(&width, &height))) {
-        successCallback(width, height);
-        succeeded = true;
+      auto result = wicBitmapSourceFromStream(memoryStream);
+      if (!std::get<std::shared_ptr<facebook::react::ImageErrorInfo>>(result)) {
+        auto imagingFactory = std::get<winrt::com_ptr<IWICImagingFactory>>(result);
+        auto wicBmpSource = std::get<winrt::com_ptr<IWICBitmapSource>>(result);
+        UINT width, height;
+        if (SUCCEEDED(wicBmpSource->GetSize(&width, &height))) {
+          successCallback(width, height);
+          succeeded = true;
+        }
       }
     }
 #endif // USE_FABRIC
@@ -105,6 +106,7 @@ void ImageLoader::getSize(std::string uri, React::ReactPromise<std::vector<doubl
   m_context.UIDispatcher().Post(
       [context = m_context, uri = std::move(uri), result = std::move(result)]() mutable noexcept {
         GetImageSizeAsync(
+            context.Properties().Handle(),
             std::move(uri),
             {},
             [result, context](double width, double height) noexcept {
@@ -133,6 +135,7 @@ void ImageLoader::getSizeWithHeaders(
                                  headers = std::move(headers),
                                  result = std::move(result)]() mutable noexcept {
     GetImageSizeAsync(
+        context.Properties().Handle(),
         std::move(uri),
         std::move(headers),
         [result, context](double width, double height) noexcept {

--- a/vnext/Microsoft.ReactNative/UriImageManager.idl
+++ b/vnext/Microsoft.ReactNative/UriImageManager.idl
@@ -20,27 +20,33 @@ namespace Microsoft.ReactNative.Composition
     Single Scale { get; };
   };
 
-
   [webhosthidden]
   [experimental]
-  interface IUriImageProvider
+  [default_interface]
+  unsealed runtimeclass ImageResponse
   {
-    DOC_STRING(
-      "This should return true if this provider will provide an image for the provided uri.")
-    Boolean CanLoadImageUri(Microsoft.ReactNative.IReactContext context, Windows.Foundation.Uri uri);
   }
 
   [webhosthidden]
   [experimental]
-    DOC_STRING(
-      "This allows applications to provide their own image caching / storage pipelines. Or to generate images on the fly based on uri.")
-  interface IUriImageStreamProvider requires IUriImageProvider
+  [default_interface]
+   DOC_STRING(
+    "Use this as a return value from @IUriImageProvider.GetImageResponseAsync to provide information about why the image load failed.")
+  runtimeclass ImageFailedResponse : ImageResponse
   {
-    DOC_STRING(
-      "Returns a stream of an image file that can be decoded by Windows Imaging Component - https://learn.microsoft.com/en-us/windows/win32/api/_wic/ ")
-    Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.IRandomAccessStream> GetSourceAsync(Microsoft.ReactNative.IReactContext context, ImageSource imageSource);
+    ImageFailedResponse(String errorMessage);
+    ImageFailedResponse(String errorMessage, Windows.Web.Http.HttpStatusCode responseCode, Windows.Web.Http.Headers.HttpResponseHeaderCollection responseHeaders);
   }
 
+  [webhosthidden]
+  [experimental]
+  [default_interface]
+  runtimeclass StreamImageResponse : ImageResponse
+  {
+   DOC_STRING(
+    "Takes a stream of an image file that can be decoded by Windows Imaging Component - https://learn.microsoft.com/en-us/windows/win32/api/_wic/ ")
+    StreamImageResponse(Windows.Storage.Streams.IRandomAccessStream stream);
+  }
  
   [webhosthidden]
   [experimental]
@@ -48,13 +54,12 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
+  [default_interface]
   DOC_STRING(
     "This allows applications to provide their own image rendering pipeline. Or to generate graphics on the fly based on uri.")
-  interface IUriBrushProvider requires IUriImageProvider
+  runtimeclass UriBrushFactoryImageResponse : ImageResponse
   {
-  DOC_STRING(
-    "This allows applications to provide their own image rendering pipeline. Or to generate graphics on the fly based on uri.")
-    Windows.Foundation.IAsyncOperation<UriBrushFactory> GetSourceAsync(Microsoft.ReactNative.IReactContext context, Microsoft.ReactNative.Composition.ImageSource imageSource);
+    UriBrushFactoryImageResponse(UriBrushFactory factory);
   }
 
   namespace Experimental {
@@ -65,11 +70,24 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
+  [default_interface]
   DOC_STRING(
     "This allows applications to provide their own image rendering pipeline. Or to generate graphics on the fly based on uri.")
-  interface IUriBrushProvider requires Microsoft.ReactNative.Composition.IUriImageProvider
+  runtimeclass UriBrushFactoryImageResponse : Microsoft.ReactNative.Composition.ImageResponse
   {
-    Windows.Foundation.IAsyncOperation<UriBrushFactory> GetSourceAsync(Microsoft.ReactNative.IReactContext context, Microsoft.ReactNative.Composition.ImageSource imageSource);
+    UriBrushFactoryImageResponse(UriBrushFactory factory);
   }
+  } // namespace Experimental
+
+  [webhosthidden]
+  [experimental]
+    DOC_STRING(
+      "This allows applications to provide their own image caching / storage pipelines. Or to generate images on the fly based on uri.")
+  interface IUriImageProvider
+  {
+    DOC_STRING(
+      "This should return true if this provider will provide an image for the provided uri.")
+    Boolean CanLoadImageUri(Microsoft.ReactNative.IReactContext context, Windows.Foundation.Uri uri);
+    Windows.Foundation.IAsyncOperation<ImageResponse> GetImageResponseAsync(Microsoft.ReactNative.IReactContext context, ImageSource imageSource);
   }
 } // namespace Microsoft.ReactNative.Composition

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <ReactContext.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <string>
 
@@ -23,9 +24,10 @@ struct ReactImageSource {
 };
 
 winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
-GetImageMemoryStreamAsync(ReactImageSource source);
+GetImageMemoryStreamAsync(winrt::Microsoft::ReactNative::IReactPropertyBag properties, ReactImageSource source);
 
 winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> GetImageStreamAsync(
+    winrt::Microsoft::ReactNative::IReactPropertyBag properties,
     ReactImageSource source);
 
 winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -114,7 +114,7 @@ const wchar_t *ImageViewManager::GetName() const {
 }
 
 XamlView ImageViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
-  return ReactImage::Create().as<winrt::Grid>();
+  return ReactImage::Create(GetReactContext()).as<winrt::Grid>();
 }
 
 ShadowNode *ImageViewManager::createShadow() const {

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -9,6 +9,7 @@
 #include <UI.Xaml.Controls.h>
 
 #include <JSValue.h>
+#include <React.h>
 #include <Utils/ImageUtils.h>
 #include <folly/dynamic.h>
 
@@ -17,10 +18,10 @@ namespace Microsoft::ReactNative {
 struct ReactImage : xaml::Controls::GridT<ReactImage> {
   using Super = xaml::Controls::GridT<ReactImage>;
 
-  ReactImage() = default;
+  ReactImage(const Mso::React::IReactContext &context);
 
  public:
-  static winrt::com_ptr<ReactImage> Create();
+  static winrt::com_ptr<ReactImage> Create(const Mso::React::IReactContext &context);
 
   // Overrides
   winrt::Windows::Foundation::Size ArrangeOverride(winrt::Windows::Foundation::Size finalSize);
@@ -59,6 +60,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   double GetHeight();
 
   bool m_useCompositionBrush{false};
+  Mso::CntPtr<const Mso::React::IReactContext> m_reactContext;
   float m_blurRadius{0};
   int m_imageSourceId{0};
   ReactImageSource m_imageSource;

--- a/vnext/Shared/Modules/FileReaderModule.cpp
+++ b/vnext/Shared/Modules/FileReaderModule.cpp
@@ -5,6 +5,7 @@
 
 #include <CreateModules.h>
 #include <ReactPropertyBag.h>
+#include "Networking/NetworkPropertyIds.h"
 
 // React Native
 #include <cxxreact/JsArgumentHelpers.h>
@@ -113,9 +114,8 @@ std::vector<module::CxxModule::Method> FileReaderModule::getMethods() {
 #pragma region FileReaderTurboModule
 
 void FileReaderTurboModule::Initialize(msrn::ReactContext const &reactContext) noexcept {
-  auto propId = msrn::ReactPropertyId<msrn::ReactNonAbiValue<weak_ptr<IBlobPersistor>>>{L"Blob.Persistor"};
   auto props = reactContext.Properties();
-  auto prop = props.Get(propId);
+  auto prop = props.Get(BlobModulePersistorPropertyId());
   m_resource = IFileReaderResource::Make(prop.Value());
 }
 
@@ -195,10 +195,9 @@ void FileReaderTurboModule::ReadAsText(
 
 /*extern*/ std::unique_ptr<module::CxxModule> CreateFileReaderModule(
     IInspectable const &inspectableProperties) noexcept {
-  auto propId = msrn::ReactPropertyId<msrn::ReactNonAbiValue<weak_ptr<IBlobPersistor>>>{L"Blob.Persistor"};
   auto propBag = msrn::ReactPropertyBag{inspectableProperties.try_as<msrn::IReactPropertyBag>()};
 
-  if (auto prop = propBag.Get(propId)) {
+  if (auto prop = propBag.Get(BlobModulePersistorPropertyId())) {
     auto weakBlobPersistor = prop.Value();
 
     return std::make_unique<FileReaderModule>(weakBlobPersistor);

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -10,6 +10,7 @@
 #include <Modules/CxxModuleUtilities.h>
 #include <Modules/IWebSocketModuleContentHandler.h>
 #include <ReactPropertyBag.h>
+#include "Networking/NetworkPropertyIds.h"
 
 // fmt
 #include <fmt/format.h>
@@ -52,11 +53,15 @@ using Microsoft::React::Networking::IWebSocketResource;
 
 constexpr char s_moduleName[] = "WebSocketModule";
 constexpr wchar_t s_moduleNameW[] = L"WebSocketModule";
-constexpr wchar_t s_proxyNameW[] = L"WebSocketModule.Proxy";
-constexpr wchar_t s_sharedStateNameW[] = L"WebSocketModule.SharedState";
-constexpr wchar_t s_contentHandlerNameW[] = L"BlobModule.ContentHandler";
 
 msrn::ReactModuleProvider s_moduleProvider = msrn::MakeTurboModuleProvider<Microsoft::React::WebSocketTurboModule>();
+
+const ReactPropertyId<msrn::ReactNonAbiValue<weak_ptr<WebSocketModule::SharedState>>>
+WebSocketModuleSharedStatePropertyId() noexcept {
+  static const ReactPropertyId<msrn::ReactNonAbiValue<weak_ptr<WebSocketModule::SharedState>>> prop{
+      L"WebSocketModule.SharedState"};
+  return prop;
+}
 
 static shared_ptr<IWebSocketResource>
 GetOrCreateWebSocket(int64_t id, string &&url, weak_ptr<WebSocketModule::SharedState> weakState) {
@@ -121,9 +126,7 @@ GetOrCreateWebSocket(int64_t id, string &&url, weak_ptr<WebSocketModule::SharedS
 
           auto args = msrn::JSValueObject{{"id", id}, {"type", isBinary ? "binary" : "text"}};
           shared_ptr<Microsoft::React::IWebSocketModuleContentHandler> contentHandler;
-          auto propId = ReactPropertyId<ReactNonAbiValue<weak_ptr<Microsoft::React::IWebSocketModuleContentHandler>>>{
-              s_contentHandlerNameW};
-          if (auto prop = propBag.Get(propId))
+          if (auto prop = propBag.Get(Microsoft::React::BlobModuleContentHandlerPropertyId()))
             contentHandler = prop.Value().lock();
 
           if (contentHandler) {
@@ -174,13 +177,11 @@ WebSocketModule::WebSocketModule(winrt::Windows::Foundation::IInspectable const 
 
   auto propBag = ReactPropertyBag{m_sharedState->InspectableProps.try_as<IReactPropertyBag>()};
 
-  auto proxyPropId = ReactPropertyId<ReactNonAbiValue<weak_ptr<IWebSocketModuleProxy>>>{s_proxyNameW};
   auto proxy = weak_ptr<IWebSocketModuleProxy>{m_proxy};
-  propBag.Set(proxyPropId, std::move(proxy));
+  propBag.Set(WebSocketModuleProxyPropertyId(), std::move(proxy));
 
-  auto statePropId = ReactPropertyId<ReactNonAbiValue<weak_ptr<SharedState>>>{s_sharedStateNameW};
   auto state = weak_ptr<SharedState>{m_sharedState};
-  propBag.Set(statePropId, std::move(state));
+  propBag.Set(WebSocketModuleSharedStatePropertyId(), std::move(state));
 }
 
 WebSocketModule::~WebSocketModule() noexcept /*override*/ {
@@ -314,8 +315,7 @@ WebSocketModuleProxy::WebSocketModuleProxy(IInspectable const &inspectableProper
 
 void WebSocketModuleProxy::SendBinary(string &&base64String, int64_t id) noexcept /*override*/ {
   auto propBag = ReactPropertyBag{m_inspectableProps.try_as<IReactPropertyBag>()};
-  auto sharedPropId = ReactPropertyId<ReactNonAbiValue<weak_ptr<WebSocketModule::SharedState>>>{s_sharedStateNameW};
-  auto state = propBag.Get(sharedPropId).Value();
+  auto state = propBag.Get(WebSocketModuleSharedStatePropertyId()).Value();
 
   weak_ptr weakWs = GetOrCreateWebSocket(id, {}, std::move(state));
   if (auto sharedWs = weakWs.lock()) {
@@ -355,9 +355,8 @@ shared_ptr<IWebSocketResource> WebSocketTurboModule::CreateResource(int64_t id, 
   rc->SetOnMessage([id, context = m_context](size_t length, const string &message, bool isBinary) {
     auto args = msrn::JSValueObject{{"id", id}, {"type", isBinary ? "binary" : "text"}};
     shared_ptr<IWebSocketModuleContentHandler> contentHandler;
-    auto propId = ReactPropertyId<ReactNonAbiValue<weak_ptr<IWebSocketModuleContentHandler>>>{s_contentHandlerNameW};
     auto propBag = context.Properties();
-    if (auto prop = propBag.Get(propId))
+    if (auto prop = propBag.Get(BlobModuleContentHandlerPropertyId()))
       contentHandler = prop.Value().lock();
 
     if (contentHandler) {
@@ -399,9 +398,8 @@ void WebSocketTurboModule::Initialize(msrn::ReactContext const &reactContext) no
   m_context = reactContext.Handle();
   m_proxy = std::make_shared<WebSocketTurboModuleProxy>(m_resourceMap);
 
-  auto proxyPropId = ReactPropertyId<ReactNonAbiValue<weak_ptr<IWebSocketModuleProxy>>>{s_proxyNameW};
   auto proxy = weak_ptr<IWebSocketModuleProxy>{m_proxy};
-  m_context.Properties().Set(proxyPropId, std::move(proxy));
+  m_context.Properties().Set(WebSocketModuleProxyPropertyId(), std::move(proxy));
 }
 
 void WebSocketTurboModule::Connect(

--- a/vnext/Shared/Networking/NetworkPropertyIds.cpp
+++ b/vnext/Shared/Networking/NetworkPropertyIds.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "NetworkPropertyIds.h"
+
+namespace Microsoft::React {
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IWebSocketModuleContentHandler>>>
+BlobModuleContentHandlerPropertyId() noexcept {
+  static const winrt::Microsoft::ReactNative::ReactPropertyId<
+      winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IWebSocketModuleContentHandler>>>
+      prop{L"BlobModule.ContentHandler"};
+  return prop;
+}
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IBlobPersistor>>>
+BlobModulePersistorPropertyId() noexcept {
+  static const winrt::Microsoft::ReactNative::ReactPropertyId<
+      winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IBlobPersistor>>>
+      prop{L"Blob.Persistor"};
+  return prop;
+}
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IWebSocketModuleProxy>>>
+WebSocketModuleProxyPropertyId() noexcept {
+  static const winrt::Microsoft::ReactNative::ReactPropertyId<
+      winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IWebSocketModuleProxy>>>
+      prop{L"WebSocketModule.Proxy"};
+  return prop;
+}
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IHttpModuleProxy>>>
+HttpModuleProxyPropertyId() noexcept {
+  static const winrt::Microsoft::ReactNative::ReactPropertyId<
+      winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IHttpModuleProxy>>>
+      prop{L"HttpModule.Proxy"};
+  return prop;
+}
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<Networking::IBlobResource>>>
+BlobResourcePropertyId() noexcept {
+  static const winrt::Microsoft::ReactNative::ReactPropertyId<
+      winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<Networking::IBlobResource>>>
+      prop{L"Blob.Resource"};
+  return prop;
+}
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<winrt::hstring> DefaultUserAgentPropertyId() noexcept {
+  static const winrt::Microsoft::ReactNative::ReactPropertyId<winrt::hstring> prop{L"ReactNative", L"UserAgent"};
+  return prop;
+}
+
+} // namespace Microsoft::React

--- a/vnext/Shared/Networking/NetworkPropertyIds.h
+++ b/vnext/Shared/Networking/NetworkPropertyIds.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <ReactPropertyBag.h>
+
+namespace Microsoft::React {
+
+struct IWebSocketModuleContentHandler;
+struct IBlobPersistor;
+struct IWebSocketModuleProxy;
+struct IHttpModuleProxy;
+
+namespace Networking {
+struct IBlobResource;
+}
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IWebSocketModuleContentHandler>>>
+BlobModuleContentHandlerPropertyId() noexcept;
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IBlobPersistor>>>
+BlobModulePersistorPropertyId() noexcept;
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IWebSocketModuleProxy>>>
+WebSocketModuleProxyPropertyId() noexcept;
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<IHttpModuleProxy>>>
+HttpModuleProxyPropertyId() noexcept;
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::weak_ptr<Networking::IBlobResource>>>
+BlobResourcePropertyId() noexcept;
+
+const winrt::Microsoft::ReactNative::ReactPropertyId<winrt::hstring> DefaultUserAgentPropertyId() noexcept;
+
+} // namespace Microsoft::React

--- a/vnext/Shared/Networking/RedirectHttpFilter.h
+++ b/vnext/Shared/Networking/RedirectHttpFilter.h
@@ -31,18 +31,21 @@ class RedirectHttpFilter : public winrt::implements<
   winrt::com_ptr<Microsoft::React::Networking::IRedirectEventSource> m_redirEventSrc;
   bool m_allowAutoRedirect{true};
   size_t m_maximumRedirects;
+  winrt::hstring m_defaultUserAgent;
 
  public:
   RedirectHttpFilter(
       size_t maxRedirects,
       winrt::Windows::Web::Http::Filters::IHttpFilter &&innerFilter,
-      winrt::Windows::Web::Http::Filters::IHttpFilter &&innerFilterWithNoCredentials) noexcept;
+      winrt::Windows::Web::Http::Filters::IHttpFilter &&innerFilterWithNoCredentials,
+      winrt::hstring defaultUserAgent) noexcept;
 
   RedirectHttpFilter(
       winrt::Windows::Web::Http::Filters::IHttpFilter &&innerFilter,
-      winrt::Windows::Web::Http::Filters::IHttpFilter &&innerFilterWithNoCredentials) noexcept;
+      winrt::Windows::Web::Http::Filters::IHttpFilter &&innerFilterWithNoCredentials,
+      winrt::hstring defaultUserAgent) noexcept;
 
-  RedirectHttpFilter() noexcept;
+  RedirectHttpFilter(winrt::hstring defaultUserAgent) noexcept;
 
   void SetRequestFactory(std::weak_ptr<IWinRTHttpRequestFactory> factory) noexcept;
 

--- a/vnext/Shared/Networking/WinRTHttpResource.h
+++ b/vnext/Shared/Networking/WinRTHttpResource.h
@@ -5,6 +5,7 @@
 
 #include "IHttpResource.h"
 
+#include "HttpSettings.g.h"
 #include <Modules/IHttpModuleProxy.h>
 #include "IWinRTHttpRequestFactory.h"
 #include "WinRTTypes.h"
@@ -108,3 +109,19 @@ class WinRTHttpResource : public IHttpResource,
 };
 
 } // namespace Microsoft::React::Networking
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct HttpSettings {
+  HttpSettings() = default;
+
+  static void SetDefaultUserAgent(
+      const winrt::Microsoft::ReactNative::ReactInstanceSettings &settings,
+      const winrt::hstring &userAgent) noexcept;
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+struct HttpSettings : HttpSettingsT<HttpSettings, implementation::HttpSettings> {};
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -251,6 +251,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\StatusBarManagerModule.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\WebSocketModule.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\DefaultBlobResource.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Networking\NetworkPropertyIds.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\OriginPolicyHttpFilter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\RedirectHttpFilter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\WinRTHttpResource.cpp" />
@@ -613,6 +614,7 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\componentregistry\native\NativeComponentRegistryBinding.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\HttpSettings.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IJSValueReader.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IJSValueWriter.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IReactContext.idl" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -322,6 +322,7 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsinspector-modern\ExecutionContext.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\utils\jsi-utils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\TextDrawing.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Networking\NetworkPropertyIds.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -822,6 +823,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\HttpSettings.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IJSValueReader.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IJSValueWriter.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IReactContext.idl" />


### PR DESCRIPTION
## Description
Port of #13285 to 0.74

Some slight modifications to the original PR to deal with the fact that in 0.74 the fabric code didn't include the ImageErrorInfo struct, or report those errors to JS.

I basically replaced the uses of ImageErrorInfo with a std::string. -- It is not passed to JS in 0.74.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13296)