### PR TITLE
[Fabric] Touch pointer moved was being reported to richedit as a pointerup

### DIFF
--- a/change/react-native-windows-19b2b7f6-5882-42a5-8aee-a661b0c11fd2.json
+++ b/change/react-native-windows-19b2b7f6-5882-42a5-8aee-a661b0c11fd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Touch pointer moved was being reported to richedit as a pointerup",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -736,7 +736,7 @@ void WindowsTextInputComponentView::OnPointerMoved(
     msg = WM_MOUSEMOVE;
     wParam = PointerRoutedEventArgsToMouseWParam(args);
   } else {
-    msg = WM_POINTERUP;
+    msg = WM_POINTERUPDATE;
     wParam = PointerPointToPointerWParam(pp);
   }
 


### PR DESCRIPTION
## Description
Fix incorrect input mapping when forwarding input to richedit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13313)