### PR TITLE
[0.74] Upgrade Desktop solution/projects to Win SDK 10.0.22621.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -76,6 +76,7 @@
         PlatformToolset;
         SolutionPath;
         SolutionDir;
+        SolutionName;
         IntDir;
         OutDir;
         TargetDir;

--- a/change/react-native-windows-c0453516-9b94-4cbc-8aeb-b6ae47ac22ba.json
+++ b/change/react-native-windows-c0453516-9b94-4cbc-8aeb-b6ae47ac22ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Upgrade Desktop solution/projects to Win SDK 10.0.22621.0",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -32,6 +32,7 @@
     <TargetName>react-native-win32</TargetName>
     <UseV8>true</UseV8>
     <V8AppPlatform>win32</V8AppPlatform>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -54,6 +54,7 @@
     <HermesCompileRtti>false</HermesCompileRtti>
     <IncludeFabricInterface Condition="'$(IncludeFabricInterface)' == ''">true</IncludeFabricInterface>
     <UseWinUI3 Condition="'$(UseWinUI3)' == ''">true</UseWinUI3>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Permissive">
     <ENABLEPermissive>true</ENABLEPermissive>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
     <EnableSourceLink>true</EnableSourceLink>


### PR DESCRIPTION
## Description
Upgrades Windows SDK for Desktop projects to version `10.0.22621.0`.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Building the Desktop DLL on ARM64EC requires a minimum Windows SDK version of `10.0.22000.0`.

Note, version `10.0.22621.0` is now installed by default with the UWP workflow so using it instead of `10.0.22000.0` reduces the number of SDK dependencies installed in the developer machine.

Note, this change is not plainly backported from `main` to reduce impact on consumers of a stable branch.\
At the same time, main consumers of `react-native-win32.dll` currently need to stick with `0.74-stable` **and** they also need `ARM64EC` support.


### What
- Set WinSDK version to `10.0.22621.0` when The `$(SolutionName)` MSBuild variable is set to `ReactWindows-Desktop`.
- Set WinSDK version to `10.0.22621.0` for Desktop.vcxproj and Desktop.DLL.vcxproj.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13326)