### PR TITLE
fix: fix `codegen-windows` being run from the wrong directory

### DIFF
--- a/change/react-native-windows-ec20474f-348e-471b-b524-d59d85123ea5.json
+++ b/change/react-native-windows-ec20474f-348e-471b-b524-d59d85123ea5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix `codegen-windows` being run from the wrong directory",
+  "packageName": "react-native-windows",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/Codegen.props
+++ b/vnext/PropertySheets/Codegen.props
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
   Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the MIT License.. 
+  Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <RunCodegenWindows Condition="'$(RunCodegenWindows)' == ''">true</RunCodegenWindows>
     <CodegenCommand Condition="'$(CodegenCommand)' == ''">npx react-native codegen-windows</CodegenCommand>
-    <CodegenCommandWorkingDir Condition="'$(CodegenCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(ProjectDir), 'package.json'))</CodegenCommandWorkingDir>
+    <CodegenCommandWorkingDir Condition="'$(CodegenCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'package.json'))</CodegenCommandWorkingDir>
     <CodegenCommandArgs Condition="'$(CodegenCommandArgs)' == ''">--logging</CodegenCommandArgs>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Fix `codegen-windows` being run from the wrong directory.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

`codegen-windows` is currently sensitive to hoisting and might be run from the wrong directory:

```
 × Build failed with message 6:10>EXEC : error : unknown command 'codegen-windows' [D:\~\node_module
s\@react-native-webapis\web-storage\windows\ReactNativeWebStorage.vcxproj]. Check your build configuration.
```

### What

We should start searching for `package.json` from `$(SolutionDir)` instead of `$(ProjectDir)`.

## Screenshots

n/a

## Testing

Verified locally.

## Changelog

Should this change be included in the release notes: yes

Fix `codegen-windows` being run from the wrong directory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13344)