### PR TITLE
Updating native WebSocket header logic to match RN

### DIFF
--- a/change/react-native-windows-57ec7c25-bda3-4d67-92a7-18b67b31fbd0.json
+++ b/change/react-native-windows-57ec7c25-bda3-4d67-92a7-18b67b31fbd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updating native WebSocket header logic to match RN",
+  "packageName": "react-native-windows",
+  "email": "sawalker@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -416,9 +416,8 @@ void WebSocketTurboModule::Connect(
   auto &optHeaders = options.headers;
   if (optHeaders.has_value()) {
     auto &headersVal = optHeaders.value();
-    for (const auto &headerVal : headersVal.AsArray()) {
+    for (const auto &entry : headersVal.AsObject()) {
       // Each header JSValueObject should only contain one key-value pair
-      const auto &entry = *headerVal.AsObject().cbegin();
       rcOptions.emplace(winrt::to_hstring(entry.first), entry.second.AsString());
     }
   }

--- a/vnext/Shared/Networking/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/Networking/WinRTWebSocketResource.cpp
@@ -384,7 +384,7 @@ void WinRTWebSocketResource::Connect(string &&url, const Protocols &protocols, c
 
       // Only add a port if a port is defined
       winrt::hstring originPort = port != 0 ? L":" + winrt::to_hstring(port) : L"";
-      auto origin = winrt::hstring{ scheme + L"://" + host + originPort };
+      auto origin = winrt::hstring{scheme + L"://" + host + originPort};
 
       m_socket.SetRequestHeader(L"Origin", std::move(origin));
     }

--- a/vnext/Shared/Networking/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/Networking/WinRTWebSocketResource.cpp
@@ -382,7 +382,10 @@ void WinRTWebSocketResource::Connect(string &&url, const Protocols &protocols, c
         scheme = L"https";
       }
 
-      auto origin = winrt::hstring{scheme + L"://" + host + L":" + winrt::to_hstring(port)};
+      // Only add a port if a port is defined
+      winrt::hstring originPort = port != 0 ? L":" + winrt::to_hstring(port) : L"";
+      auto origin = winrt::hstring{ scheme + L"://" + host + originPort };
+
       m_socket.SetRequestHeader(L"Origin", std::move(origin));
     }
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
There are two bugs at play. This fixes both bugs, allowing headers to be properly used with web socket requests.

Bug #1
In `Libraries/WebSocket/WebSocket.js`, the expected type for `headers` is an object. This is passed down as-is to the native layer in the call `NativeWebSocketModule.connect(url, protocols, {headers}, this._socketId);`. The turbo module implementation attempts to iterative over this box type by using `.AsArray()`, which immediately continues past the for-loop. The result is that any headers passed down from Javascript are ignored.

Bug #2
React Native WebSocket implementations do not put a port on the Origin header when a port is not provided. RNW does, which results in adding a port of 0 to every default Origin header. Port 0 is reserved and is not meant to be used.

The combination of both of these bugs means every web socket request will only have one header and it will be a improperly constructed Origin header.

Resolves [Add Relevant Issue Here]
While I don't know which version of RNW this was introduced in, when Xbox updated an app from RNW 0.69 to 0.73, all web socket requests broke due to services rejecting origin headers wiht port 0. This works fine on mobile apps due.

### What
- `WebSocketModule.cpp`: Changed the usage of `.AsArray()` to `.AsObject()` to match expectations of headers type that is passed down by Javascript
- `WinRTWebSocketResource.cpp`: Changed default origin header construction to only add a port if it is not 0.


## Testing
Xbox is currently using a patch that applies both of these changes.

## Changelog
yes?

WebSocket headers are now properly applied when using Turbo Modules
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13366)