### PR TITLE
Introduce ReactNativeAppBuilder

### DIFF
--- a/packages/sample-app-fabric/windows/SampleAppFabric/packages.lock.json
+++ b/packages/sample-app-fabric/windows/SampleAppFabric/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.1.18, )",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "requested": "[0.1.21, )",
+        "resolved": "0.1.21",
+        "contentHash": "5njCh+3eXTLOv7+8nOnp6nJ5C0r6it5ze54c0nuWleeDptuK8t3dEDB79XTU4D5DKNvAPlqJpgXRDOak5nYIug=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -61,7 +61,7 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.21, )",
           "Microsoft.WindowsAppSDK": "[1.5.240227000, )",
           "ReactCommon": "[1.0.0, )",
           "boost": "[1.76.0, )"

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -310,6 +310,14 @@
       <DependentUpon>ReactNativeHost.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+	<ClInclude Include="ReactNativeAppBuilder.h">
+      <DependentUpon>ReactNativeAppBuilder.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+	<ClInclude Include="ReactInstanceSettingsBuilder.h">
+      <DependentUpon>ReactNativeAppBuilder.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="Timer.h">
       <DependentUpon>Timer.idl</DependentUpon>
       <SubType>Code</SubType>

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettingsBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettingsBuilder.cpp
@@ -1,0 +1,58 @@
+#include "pch.h"
+#include "ReactInstanceSettings.h"
+#include "ReactInstanceSettingsBuilder.h"
+#include "ReactInstanceSettingsBuilder.g.cpp"
+
+namespace winrt::ReactNative
+{
+    using namespace winrt::Microsoft::ReactNative;
+}
+
+namespace winrt::UI
+{
+    using namespace winrt::Microsoft::UI;
+}
+
+namespace winrt::Microsoft::ReactNative::implementation
+{
+    ReactInstanceSettingsBuilder::ReactInstanceSettingsBuilder()
+    {
+        m_reactInstanceSettings = winrt::make<winrt::ReactNative::implementation::ReactInstanceSettings>();
+
+#if _DEBUG
+        m_reactInstanceSettings.UseDirectDebugger(true);
+        m_reactInstanceSettings.UseDeveloperSupport(true);
+#else
+        m_reactInstanceSettings.UseDirectDebugger(false);
+        m_reactInstanceSettings.UseDeveloperSupport(false);
+#endif
+    }
+
+    winrt::ReactNative::ReactInstanceSettings ReactInstanceSettingsBuilder::ReactInstanceSettings()
+    {
+        return m_reactInstanceSettings;
+    }
+
+    winrt::ReactNative::ReactInstanceSettingsBuilder ReactInstanceSettingsBuilder::SetBundleRootPath(hstring const& path)
+    {
+#if BUNDLE
+        m_reactInstanceSettings.BundleRootPath(path.c_str());
+#endif
+        return *this;
+    }
+
+    winrt::ReactNative::ReactInstanceSettingsBuilder ReactInstanceSettingsBuilder::SetJavaScriptBundleFile(hstring const& file)
+    {
+        m_reactInstanceSettings.JavaScriptBundleFile(file.c_str());
+
+        return *this;
+    }
+
+    winrt::ReactNative::ReactInstanceSettingsBuilder ReactInstanceSettingsBuilder::SetUseFastRefresh(
+        bool const &state)
+    {
+        m_reactInstanceSettings.UseFastRefresh(state);
+
+        return *this;
+    }
+}

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettingsBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettingsBuilder.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "ReactInstanceSettingsBuilder.g.h"
+
+namespace winrt::Microsoft::ReactNative::implementation
+{
+    struct ReactInstanceSettingsBuilder : ReactInstanceSettingsBuilderT<ReactInstanceSettingsBuilder>
+    {
+        ReactInstanceSettingsBuilder();
+
+        winrt::Microsoft::ReactNative::ReactInstanceSettings ReactInstanceSettings();
+        winrt::Microsoft::ReactNative::ReactInstanceSettingsBuilder SetBundleRootPath(hstring const& path);
+        winrt::Microsoft::ReactNative::ReactInstanceSettingsBuilder SetJavaScriptBundleFile(hstring const& file);
+        winrt::Microsoft::ReactNative::ReactInstanceSettingsBuilder SetUseFastRefresh(bool const &state);
+    private:
+        winrt::Microsoft::ReactNative::ReactInstanceSettings m_reactInstanceSettings{nullptr};
+    };
+}
+namespace winrt::Microsoft::ReactNative::factory_implementation
+{
+    struct ReactInstanceSettingsBuilder : ReactInstanceSettingsBuilderT<ReactInstanceSettingsBuilder, implementation::ReactInstanceSettingsBuilder>
+    {
+    };
+}

--- a/vnext/Microsoft.ReactNative/ReactNativeAppBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeAppBuilder.cpp
@@ -1,0 +1,72 @@
+#include "pch.h"
+#include "ReactNativeAppBuilder.h"
+#include "ReactNativeAppBuilder.g.cpp"
+#include "ReactNativeHost.h"
+#include "winrt/Microsoft.UI.Windowing.h"
+#include "winrt/microsoft.UI.Interop.h"
+#include "winrt/Microsoft.UI.Composition.h"
+
+namespace winrt::ReactNative
+{
+    using namespace winrt::Microsoft::ReactNative;
+}
+
+namespace winrt::UI
+{
+    using namespace winrt::Microsoft::UI;
+}
+
+namespace winrt::Microsoft::ReactNative::implementation
+{
+    ReactNativeAppBuilder::ReactNativeAppBuilder()
+    {
+        m_host = winrt::make<winrt::ReactNative::implementation::ReactNativeHost>();
+    }
+
+    winrt::ReactNative::ReactNativeAppBuilder ReactNativeAppBuilder::AddPackageProviders(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::IReactPackageProvider> const& packageProviders)
+    {
+        for (auto const& provider : packageProviders)
+        {
+            m_host.PackageProviders().Append(provider);
+        }
+
+        return *this;
+    }
+
+    winrt::ReactNative::ReactNativeAppBuilder ReactNativeAppBuilder::SetReactInstanceSettings(winrt::Microsoft::ReactNative::ReactInstanceSettings const& settings)
+    {
+        m_host.InstanceSettings(settings);
+
+        return *this;
+    }
+
+    winrt::ReactNative::ReactNativeAppBuilder ReactNativeAppBuilder::SetCompositor(winrt::Microsoft::UI::Composition::Compositor const& compositor)
+    {
+        m_compositor = compositor;
+
+        return *this;
+    }
+
+    winrt::ReactNative::ReactNativeAppBuilder ReactNativeAppBuilder::SetAppWindow(winrt::Microsoft::UI::Windowing::AppWindow const& appWindow)
+    {
+        m_appWindow = appWindow;
+
+        return *this;
+    }
+
+    winrt::ReactNative::ReactNativeHost ReactNativeAppBuilder::Start()
+    {
+        auto hwnd{winrt::UI::GetWindowFromWindowId(m_appWindow.Id())};
+
+        winrt::ReactNative::ReactCoreInjection::SetTopLevelWindowId(
+            m_host.InstanceSettings().Properties(), reinterpret_cast<uint64_t>(hwnd));
+
+        winrt::ReactNative::Composition::CompositionUIService::SetCompositor(
+            m_host.InstanceSettings(), m_compositor);
+
+        // Start the react-native instance, which will create a JavaScript runtime and load the applications bundle.
+        m_host.ReloadInstance();
+
+        return m_host;
+    }
+}

--- a/vnext/Microsoft.ReactNative/ReactNativeAppBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactNativeAppBuilder.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "ReactNativeAppBuilder.g.h"
+
+namespace winrt::Microsoft::ReactNative::implementation
+{
+    struct ReactNativeAppBuilder : ReactNativeAppBuilderT<ReactNativeAppBuilder>
+    {
+        ReactNativeAppBuilder();
+
+        winrt::Microsoft::ReactNative::ReactNativeAppBuilder AddPackageProviders(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::IReactPackageProvider> const& packageProviders);
+        winrt::Microsoft::ReactNative::ReactNativeAppBuilder SetReactInstanceSettings(winrt::Microsoft::ReactNative::ReactInstanceSettings const& settings);
+        winrt::Microsoft::ReactNative::ReactNativeAppBuilder SetCompositor(winrt::Microsoft::UI::Composition::Compositor const& compositor);
+        winrt::Microsoft::ReactNative::ReactNativeAppBuilder SetAppWindow(winrt::Microsoft::UI::Windowing::AppWindow const& appWindow);
+        winrt::Microsoft::ReactNative::ReactNativeHost Start();
+
+    private:
+        winrt::Microsoft::UI::Windowing::AppWindow m_appWindow{nullptr};
+        winrt::Microsoft::UI::Composition::Compositor m_compositor{};
+        winrt::Microsoft::ReactNative::ReactNativeHost m_host{};
+    };
+}
+namespace winrt::Microsoft::ReactNative::factory_implementation
+{
+    struct ReactNativeAppBuilder : ReactNativeAppBuilderT<ReactNativeAppBuilder, implementation::ReactNativeAppBuilder>
+    {
+    };
+}

--- a/vnext/Microsoft.ReactNative/ReactNativeAppBuilder.idl
+++ b/vnext/Microsoft.ReactNative/ReactNativeAppBuilder.idl
@@ -1,0 +1,43 @@
+
+import "ReactNativeHost.idl";
+import "ReactInstanceSettings.idl";
+import "IReactPackageProvider.idl";
+
+#include "DocString.h"
+
+namespace Microsoft.ReactNative
+{
+    [experimental]
+    DOC_STRING("This is the builder for creating ReactInstanceSettings.")
+    runtimeclass ReactInstanceSettingsBuilder
+    {
+        ReactInstanceSettingsBuilder();
+
+        // Properties
+        ReactInstanceSettings ReactInstanceSettings {get;};
+
+        // Set Methods
+        ReactInstanceSettingsBuilder SetBundleRootPath(String path);
+
+        ReactInstanceSettingsBuilder SetJavaScriptBundleFile(String file);
+
+        ReactInstanceSettingsBuilder SetUseFastRefresh(Boolean state);
+    }
+
+    [experimental]
+    DOC_STRING("ReactNativeAppBuilder initializes and manages the ReactNativeHost component for a Win32 Fabric Application.")
+    runtimeclass ReactNativeAppBuilder
+    {
+        ReactNativeAppBuilder();
+
+        ReactNativeAppBuilder AddPackageProviders(Windows.Foundation.Collections.IVector<Microsoft.ReactNative.IReactPackageProvider> packageProviders);
+
+        ReactNativeAppBuilder SetReactInstanceSettings(ReactInstanceSettings settings);
+
+        ReactNativeAppBuilder SetCompositor(Microsoft.UI.Composition.Compositor compositor);
+
+        ReactNativeAppBuilder SetAppWindow(Microsoft.UI.Windowing.AppWindow appWindow);
+
+        ReactNativeHost Start();
+    }
+}

--- a/vnext/Microsoft.ReactNative/packages.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.lock.json
@@ -14,45 +14,25 @@
         "resolved": "0.1.21",
         "contentHash": "5njCh+3eXTLOv7+8nOnp6nJ5C0r6it5ze54c0nuWleeDptuK8t3dEDB79XTU4D5DKNvAPlqJpgXRDOak5nYIug=="
       },
-      "Microsoft.SourceLink.GitHub": {
-        "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
-        "dependencies": {
-          "Microsoft.Build.Tasks.Git": "1.1.1",
-          "Microsoft.SourceLink.Common": "1.1.1"
-        }
-      },
-      "Microsoft.UI.Xaml": {
-        "type": "Direct",
-        "requested": "[2.8.0, )",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",
         "requested": "[2.0.230706.1, )",
         "resolved": "2.0.230706.1",
         "contentHash": "l0D7oCw/5X+xIKHqZTi62TtV+1qeSz7KVluNFdrJ9hXsst4ghvqQ/Yhura7JqRdZWBXAuDS0G0KwALptdoxweQ=="
       },
-      "Microsoft.Build.Tasks.Git": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       },
-      "Microsoft.SourceLink.Common": {
+      "Microsoft.Windows.SDK.BuildTools": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
-      },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+        "resolved": "10.0.22621.756",
+        "contentHash": "7ZL2sFSioYm1Ry067Kw1hg0SCcW5kuVezC2SwjGbcPE61Nn+gTbH86T73G3LcEOVj0S3IZzNuE/29gZvOLS7VA=="
       },
       "common": {
         "type": "Project",
@@ -66,8 +46,8 @@
       "folly": {
         "type": "Project",
         "dependencies": {
-          "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.76.0, )",
+          "fmt": "[1.0.0, )"
         }
       },
       "reactcommon": {
@@ -79,52 +59,80 @@
       }
     },
     "native,Version=v0.0/win10-arm": {
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       }
     },
     "native,Version=v0.0/win10-arm-aot": {
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       }
     },
     "native,Version=v0.0/win10-arm64-aot": {
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       }
     },
     "native,Version=v0.0/win10-x64": {
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       }
     },
     "native,Version=v0.0/win10-x64-aot": {
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       }
     },
     "native,Version=v0.0/win10-x86": {
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       }
     },
     "native,Version=v0.0/win10-x86-aot": {
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.5.240227000, )",
+        "resolved": "1.5.240227000",
+        "contentHash": "6rESOsREi8534J7IDpNfFYPvxQaSleXKt4A7ZYPeQyckNMQ0o1W0jZ420bJbEMz9Cw/S/8IbpPftLLZ9w/GTCQ==",
+        "dependencies": {
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       }
     }
   }

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -336,6 +336,12 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeHost.cpp">
       <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeHost.idl</DependentUpon>
     </ClCompile>
+	<ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeAppBuilder.cpp">
+      <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeAppBuilder.idl</DependentUpon>
+    </ClCompile>
+	<ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactInstanceSettingsBuilder.cpp">
+      <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeAppBuilder.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\RedBoxHandler.cpp">
       <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\RedBoxHandler.idl</DependentUpon>
     </ClCompile>
@@ -636,6 +642,7 @@
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactCoreInjection.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactInstanceSettings.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeHost.idl" />
+	<Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeAppBuilder.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\RedBoxHandler.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Timer.idl" />
   </ItemGroup>


### PR DESCRIPTION
## Description

### Why
Today's fabric sample app generates a lot of bootstrapping code. There is a need for abstracting most of the react native initialization management from the developer so the developer can focus on developing the app itself.

### What
Introduced ReactNativeAppBuilder and ReactInstanceSettingsBuilder to abstract away RNW Functionality

## Changelog
no