### PR TITLE
Fix RNW Dependencies Command to Check for Valid WinGet Version

### DIFF
--- a/change/react-native-windows-e1112cd5-a192-4668-87a1-f31ef842c4c3.json
+++ b/change/react-native-windows-e1112cd5-a192-4668-87a1-f31ef842c4c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Dependency Script",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -520,9 +520,9 @@ $requirements = @(
 
 function InstallWinGet {
     Write-Verbose "Updating WinGet version...";
-    Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile winget.msixbundle;
-    Add-AppPackage -ForceApplicationShutdown .\winget.msixbundle;
-    del .\winget.msixbundle;
+    Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile "$env:TEMP\winget.msixbundle";
+    Add-AppPackage -ForceApplicationShutdown $env:TEMP\winget.msixbundle;
+    Remove-Item $env:TEMP\winget.msixbundle;
 }
 
 function EnsureWinGetForInstall {

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -1,3 +1,4 @@
+
 # Troubleshoot RNW dependencies
 param(
     [switch]$Install = $false,
@@ -78,6 +79,9 @@ $vsWorkloads = @('Microsoft.VisualStudio.Workload.ManagedDesktop',
     'Microsoft.VisualStudio.Workload.Universal');
 
 $vsAll = ($vsComponents + $vsWorkloads);
+
+# The minimum winget version to check for
+$wingetver = "1.7.11261";
 
 # The minimum VS version to check for
 # Note: For install to work, whatever min version you specify here must be met by the current package available on winget.
@@ -238,7 +242,7 @@ function CheckNode {
         Write-Verbose "Node version found: $nodeVersion";
         $major = $nodeVersion.Major;
         $minor = $nodeVersion.Minor;
-        return ($major -ge 18) -and ($minor -ge 18);
+        return ($major -gt 18) -or (($major -eq 18) -and ($minor -ge 18));
     } catch { Write-Debug $_ }
 
     Write-Verbose "Node not found.";
@@ -514,18 +518,30 @@ $requirements = @(
     }
 );
 
+function InstallWinGet {
+    Write-Verbose "Updating WinGet version...";
+    Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile winget.msixbundle;
+    Add-AppPackage -ForceApplicationShutdown .\winget.msixbundle;
+    del .\winget.msixbundle;
+}
+
 function EnsureWinGetForInstall {
     Write-Verbose "Checking for WinGet...";
     try {
         # Check if winget.exe is in PATH
         if (Get-Command "winget.exe" -CommandType Application -ErrorAction Ignore) {
             Write-Verbose "WinGet found in PATH.";
-            return;
+            Write-Verbose "Validating WinGet version...";
+            $wingetverfound = & winget -v;
+            if ([System.Version]$wingetverfound.Substring(1) -ge [System.Version]$wingetver ){
+                Write-Verbose "WinGet version found: $wingetverfound";
+                return;
+            }
         }
+        InstallWinGet;
+        $installedwingetver = & winget -v;
+        Write-Verbose "WinGet version installed: $installedwingetver";
     } catch { Write-Debug $_ }
-
-    Write-Host "WinGet is required to install dependencies. See https://learn.microsoft.com/en-us/windows/package-manager/winget/ for more information.";
-    throw "WinGet needed to install.";
 }
 
 function WinGetInstall {


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
New installations of Windows 11 come with a version of WinGet that is broken/unable to install dependencies. See https://github.com/microsoft/winget-cli/issues/3832#issuecomment-1872387214 for more information on the issue. 

Resolves #13336
### What
Adjusted the rnw dependencies script to check the version of WinGet installed and make sure it is at least 1.7.11261. If the no version is installed or the version installed is below this version, we should update/install WinGet. Then we can proceed with the rest of the script. 

While working on this bug I also ran into another break in the script. Following script fix in #13211, having Node 20 installed caused the script to incorrectly fail and claim the version on Node installed was not valid. Adjusted script to resolve this error as well. 

## Testing
Tested on device with 1.3.XXXX version of WinGet installed. 

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13372)