### PR TITLE
Added `MinimumVisualStudioVersion` env variable to force `run-windows` to use a particular version of VS installed

### DIFF
--- a/change/@react-native-windows-cli-5ac25fa2-32bd-477c-a499-01c579f6cd37.json
+++ b/change/@react-native-windows-cli-5ac25fa2-32bd-477c-a499-01c579f6cd37.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bug with specifying min VS versions for run-windows",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
@@ -200,7 +200,7 @@ export default class MSBuildTools {
       'Microsoft.Component.MSBuild',
       getVCToolsByArch(buildArch),
     ];
-    const minVersion = process.env.VisualStudioVersion || '17.0';
+    const minVersion = process.env.MinimumVisualStudioVersion || process.env.VisualStudioVersion || '17.0';
     const vsInstallation = findLatestVsInstall({
       requires,
       minVersion,
@@ -209,7 +209,13 @@ export default class MSBuildTools {
     });
 
     if (!vsInstallation) {
-      if (process.env.VisualStudioVersion != null) {
+      if (process.env.MinimumVisualStudioVersion != null) {
+        throw new CodedError(
+          'NoMSBuild',
+          `MSBuild tools not found for version ${process.env.MinimumVisualStudioVersion} (from environment). Make sure all required components have been installed`,
+          {MinimumVisualStudioVersionFromEnv: process.env.MinimumVisualStudioVersion},
+        );
+      } else if (process.env.VisualStudioVersion != null) {
         throw new CodedError(
           'NoMSBuild',
           `MSBuild tools not found for version ${process.env.VisualStudioVersion} (from environment). Make sure all required components have been installed`,

--- a/packages/@react-native-windows/cli/src/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/utils/vsInstalls.ts
@@ -82,10 +82,10 @@ export function enumerateVsInstalls(opts: {
 
     if (minVersionSemVer) {
       minVersion = minVersionSemVer.toString();
-      maxVersion = (minVersionSemVer.major + 1).toFixed(1);
+      maxVersion = `${(minVersionSemVer.major + 1)}.0`;
     } else if (!Number.isNaN(minVersionNum)) {
-      minVersion = minVersionNum.toFixed(1);
-      maxVersion = (Math.floor(minVersionNum) + 1).toFixed(1);
+      minVersion = Number.isInteger(minVersionNum) ? `${minVersionNum}.0` : minVersionNum.toString();
+      maxVersion = `${(Math.floor(minVersionNum) + 1)}.0`;
     } else {
       // Unable to parse minVersion and determine maxVersion,
       // caller will throw error that version couldn't be found.


### PR DESCRIPTION
## Description

Fixes a bug in `run-windows` where we truncate the minimum VS version number so it only allows for one digit minor versions.

We try to detect when building inside a VS command prompt by looking for the `VisualStudioVersion` environment variable. In this way we can make sure to use specific (usually prerelease/preview) versions of VS.

However, we can also set this env variable manually, which I was trying to do. However, there are lots of other places in VS that read this value, and it always expects a major version with a 0 minor version (i.e. `17.0`, `18.0`). When setting `17.11`, (the version I'm trying to test for has fixes to #13339) the code was truncating it to `17.1`. Even fixing the truncation meant that the build would later fail anyway, since it wasn't a  `X.0` number.

So this PR not only fixes the truncating code to keep `17.11` as `17.11`, but also adds a *new* env variable to check for, i.e. `MinimumVisualStudioVersion`, so that we can safely override that without breaking the build.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Trying to test with VS 17.11 preview, the number kept getting truncated to 17.1. I need a way of specify the version I want without breaking the build

### What
Fixes the version range calculating code to not truncate the digits, adds new `MinimumVisualStudioVersion` env variable.

## Screenshots
N/A

## Testing
Verified run-windows could fine the preview 17.11 over the regular 17.10 installed.

## Changelog
Should this change be included in the release notes: yes

Added `MinimumVisualStudioVersion` env variable to force `run-windows` to use a particular version of VS installed
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13373)