### PR TITLE
Fixed typos and improved uniformity of RNW CLI command help text

### DIFF
--- a/change/@react-native-windows-cli-c8cf5aba-fcbc-427e-ab3c-29511f9ab8e9.json
+++ b/change/@react-native-windows-cli-c8cf5aba-fcbc-427e-ab3c-29511f9ab8e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed typos and improved uniformity of RNW CLI command help",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/README.md
+++ b/packages/@react-native-windows/cli/README.md
@@ -4,7 +4,7 @@ CLI to build and run React Native for Windows apps.
 
 ## `autolink-windows`
 
-`autolink-windows` is the CLI command provided by `@react-native-windows/cli` which is used to link the native code and build systems for a React Native for Windows app with any native community modules it uses.
+The `autolink-windows` CLI command is used to link the native code and build systems for a React Native for Windows app with any native community modules it uses.
 
 **Note:** Autolinking runs automatically as part of running the `run-windows` CLI command, unless the `--no-autolink` argument is used.
 
@@ -28,7 +28,7 @@ Here are the options that `react-native autolink-windows` takes:
 
 ## `codegen-windows`
 
-`codegen-windows` is the CLI command provided by `@react-native-windows/cli` which is used to generate some necessary Windows-specific native code for native modules.
+The `codegen-windows` CLI command is used to generate some necessary Windows-specific native code for native modules.
 
 ### Usage
 Runs Windows-specific codegen for native modules.
@@ -48,7 +48,7 @@ Here are the options that `react-native codegen-windows` takes:
 
 ## `init-windows`
 
-`init-windows` is the CLI command provided by `@react-native-windows/cli` which is used to initialize a new React Native for Windows project inside an existing React Native project. 
+The `init-windows` CLI command is used to initialize a new React Native for Windows project inside an existing React Native project. 
 
 ### Usage
 Initializes a new RNW project from a given template.
@@ -71,7 +71,7 @@ Here are the options that `react-native init-windows` takes:
 
 ## `run-windows`
 
-`run-windows` is the CLI command provided by `@react-native-windows/cli` which is used to build and run React Native for Windows apps. 
+The `run-windows` CLI command is used to build and run React Native for Windows apps. 
 
 ### Usage
 Builds your RNW app and starts it on a connected Windows desktop, emulator or device.

--- a/packages/@react-native-windows/cli/README.md
+++ b/packages/@react-native-windows/cli/README.md
@@ -4,7 +4,7 @@ CLI to build and run React Native for Windows apps.
 
 ## `autolink-windows`
 
-`autolink-windows` is the CLI command provided by `@react-native-windows/cli` which is used to "autolink" the native code and build systems for a React Native for Windows app with any native community modules it uses.
+`autolink-windows` is the CLI command provided by `@react-native-windows/cli` which is used to link the native code and build systems for a React Native for Windows app with any native community modules it uses.
 
 **Note:** Autolinking runs automatically as part of running the `run-windows` CLI command, unless the `--no-autolink` argument is used.
 
@@ -64,7 +64,7 @@ Here are the options that `react-native init-windows` takes:
 | `--logging`           | boolean    | Verbose output logging                           |
 | `--template`          | string     | Specify the template to use                      |
 | `--name`              | string     | The native project name. Defaults to the name property in `app.json` or `package.json` |
-| `--namespace`         | string     | The native project namespace, expressed using dots as separators, i.e. 'Level1.Level2.Level3'. Defaults to the same as name |
+| `--namespace`         | string     | The native project namespace, expressed using dots as separators, i.e. `Level1.Level2.Level3`. Defaults to the same as name |
 | `--overwrite`         | boolean    | Overwrite and existing files without prompting  |
 | `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
 | `-h`, `--help`        | boolean    | display help for command                         |

--- a/packages/@react-native-windows/cli/README.md
+++ b/packages/@react-native-windows/cli/README.md
@@ -24,7 +24,7 @@ Here are the options that `react-native autolink-windows` takes:
 | `--sln`               | string     | Override the app solution file determined by 'react-native config', i.e. `windows\myApp.sln` |
 | `--proj`              | string     | Override the app project file determined by 'react-native config', i.e. `windows\myApp\myApp.vcxproj` |
 | `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
-| `-h`, `--help`        | boolean    | display help for command                         |
+| `-h`, `--help`        | boolean    | Display help for command                         |
 
 ## `codegen-windows`
 
@@ -44,7 +44,7 @@ Here are the options that `react-native codegen-windows` takes:
 | `--logging`           | boolean    | Verbose output logging                           |
 | `--check`             | boolean    | Only check whether any codegen files need to change |
 | `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
-| `-h`, `--help`        | boolean    | display help for command                         |
+| `-h`, `--help`        | boolean    | Display help for command                         |
 
 ## `init-windows`
 
@@ -65,9 +65,9 @@ Here are the options that `react-native init-windows` takes:
 | `--template`          | string     | Specify the template to use                      |
 | `--name`              | string     | The native project name. Defaults to the name property in `app.json` or `package.json` |
 | `--namespace`         | string     | The native project namespace, expressed using dots as separators, i.e. `Level1.Level2.Level3`. Defaults to the same as name |
-| `--overwrite`         | boolean    | Overwrite and existing files without prompting  |
+| `--overwrite`         | boolean    | Overwrite any existing files without prompting  |
 | `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
-| `-h`, `--help`        | boolean    | display help for command                         |
+| `-h`, `--help`        | boolean    | Display help for command                         |
 
 ## `run-windows`
 
@@ -87,7 +87,7 @@ Here are the options that `react-native run-windows` takes:
 | Option                | Input Type | Description                                      |
 |-----------------------|------------|--------------------------------------------------|
 | `--release`           | boolean    | Specifies a Release build                        |
-| `--root`              | string     | Override the root directory for the windows build which contains the windows folder (default: `E:\\test63`) |
+| `--root`              | string     | Override the root directory for the project which contains the `windows` folder |
 | `--arch`              | string     | The build architecture, i.e. `ARM64`, `x86`, `x64`. Defaults to system architecture |
 | `--singleproc`        | boolean    | Disables multi-proc build                        |
 | `--emulator`          | boolean    | Deploys the app to an emulator                   |
@@ -101,7 +101,7 @@ Here are the options that `react-native run-windows` takes:
 | `--no-autolink`       | boolean    | Do not run autolinking                           |
 | `--no-build`          | boolean    | Do not build the solution                        |
 | `--no-deploy`         | boolean    | Do not deploy the app                            |
-| `--deploy-from-layout`| boolean    | Force deploy from layout, even in release builds |
+| `--deploy-from-layout`| boolean    | Force deploy from layout even in Release builds |
 | `--sln`               | string     | Override the app solution file determined by 'react-native config', i.e. `windows\myApp.sln` |
 | `--proj`              | string     | Override the app project file determined by 'react-native config', i.e. `windows\myApp\myApp.vcxproj` |
 | `--msbuildprops`      | string     | Comma separated props to pass to MSBuild, i.e. `prop1=value1,prop2=value2` |
@@ -109,7 +109,7 @@ Here are the options that `react-native run-windows` takes:
 | `--info`              | boolean    | Dump environment information                     |
 | `--direct-debugging`  | number     | Enable direct debugging on specified port        |
 | `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
-| `-h`, `--help`        | boolean    | display help for command                         |
+| `-h`, `--help`        | boolean    | Display help for command                         |
 
 ## Data Collection
 The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/packages/@react-native-windows/cli/README.md
+++ b/packages/@react-native-windows/cli/README.md
@@ -1,47 +1,117 @@
 # @react-native-windows/cli
 
-CLI to build and run React Native for  Windows apps.
+CLI to build and run React Native for Windows apps.
 
-## Usage
+## `autolink-windows`
 
-Run this from an existing `react-native` project with React Native Windows to build and deploy apps.
+`autolink-windows` is the CLI command provided by `@react-native-windows/cli` which is used to "autolink" the native code and build systems for a React Native for Windows app with any native community modules it uses.
 
+**Note:** Autolinking runs automatically as part of running the `run-windows` CLI command, unless the `--no-autolink` argument is used.
 
-Example usage
+### Usage
+Runs Windows-specific autolinking for your RNW project.
+  
+```bat
+npx react-native autolink-windows
 ```
+### Options
+
+Here are the options that `react-native autolink-windows` takes:
+| Option                | Input Type | Description                                      |
+|-----------------------|------------|--------------------------------------------------|
+| `--logging`           | boolean    | Verbose output logging                           |
+| `--check`             | boolean    | Only check whether any autolinked files need to change |
+| `--sln`               | string     | Override the app solution file determined by 'react-native config', i.e. `windows\myApp.sln` |
+| `--proj`              | string     | Override the app project file determined by 'react-native config', i.e. `windows\myApp\myApp.vcxproj` |
+| `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
+| `-h`, `--help`        | boolean    | display help for command                         |
+
+## `codegen-windows`
+
+`codegen-windows` is the CLI command provided by `@react-native-windows/cli` which is used to generate some necessary Windows-specific native code for native modules.
+
+### Usage
+Runs Windows-specific codegen for native modules.
+  
+```bat
+npx react-native codegen-windows
+```
+### Options
+
+Here are the options that `react-native codegen-windows` takes:
+| Option                | Input Type | Description                                      |
+|-----------------------|------------|--------------------------------------------------|
+| `--logging`           | boolean    | Verbose output logging                           |
+| `--check`             | boolean    | Only check whether any codegen files need to change |
+| `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
+| `-h`, `--help`        | boolean    | display help for command                         |
+
+## `init-windows`
+
+`init-windows` is the CLI command provided by `@react-native-windows/cli` which is used to initialize a new React Native for Windows project inside an existing React Native project. 
+
+### Usage
+Initializes a new RNW project from a given template.
+  
+```bat
+npx react-native init-windows
+```
+### Options
+
+Here are the options that `react-native init-windows` takes:
+| Option                | Input Type | Description                                      |
+|-----------------------|------------|--------------------------------------------------|
+| `--logging`           | boolean    | Verbose output logging                           |
+| `--template`          | string     | Specify the template to use                      |
+| `--name`              | string     | The native project name. Defaults to the name property in `app.json` or `package.json` |
+| `--namespace`         | string     | The native project namespace, expressed using dots as separators, i.e. 'Level1.Level2.Level3'. Defaults to the same as name |
+| `--overwrite`         | boolean    | Overwrite and existing files without prompting  |
+| `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
+| `-h`, `--help`        | boolean    | display help for command                         |
+
+## `run-windows`
+
+`run-windows` is the CLI command provided by `@react-native-windows/cli` which is used to build and run React Native for Windows apps. 
+
+### Usage
+Builds your RNW app and starts it on a connected Windows desktop, emulator or device.
+  
+```bat
 npx react-native run-windows
 ```
+### Options
 
-Options:
-| option                | description                          | type                                             |
-|-----------------------|--------------------------------------|--------------------------------------------------|
-| `--release`           | Specifies a Release build | [boolean] |
-| `--root`              | Override the root directory for the windows build which contains the windows folder. (default: "E:\\test63") | [string] |
-| `--arch`              | The build architecture (ARM64, x86, x64). defaults to system architecture | [string] |
-| `--singleproc`        | Disables multi-proc build | [boolean] |
-| `--emulator`          | Deploys the app to an emulator | [boolean] |
-| `--device`            | Deploys the app to a connected device | [boolean] |
-| `--target`            | Deploys the app to the specified GUID for a device | [string] |
-| `--remote-debugging`  | Deploys the app in remote debugging mode. | [boolean] |
-| `--logging`           | Enables logging | [boolean] | 
-| `--no-packager`       | Do not launch packager while building | [boolean] |
-| `--bundle`            | Enable Bundle configuration and it would be ReleaseBundle/DebugBundle other than Release/Debug | [boolean] | 
-| `--no-launch`         | Do not launch the app after deployment | [boolean] | 
-| `--no-autolink`       | Do not run autolinking | [boolean] | 
-| `--no-build`          | Do not build the solution | [boolean] |
-| `--no-deploy`         | Do not deploy the app | [boolean] |
-| `--deploy-from-layout`| Force deploy from layout, even in release builds | [boolean] |
-| `--sln`               | Override the app solution file determined by 'react-native config', e.g. windows\myApp.sln | [string] | 
-| `--proj`              | Override the app project file determined by 'react-native config', e.g. windows\myApp\myApp.vcxproj | [string] |
-| `--msbuildprops`      | Comma separated props to pass to MSBuild, eg: prop1=value1,prop2=value2 | [string] |
-| `--buildLogDirectory` | Optional directory where MSBuild log files should be stored | [string] |
-| `--info`              | Dump environment information | [boolean] |
-| `--direct-debugging`  | Enable direct debugging on specified port | [number] |
-| `--no-telemetry`      | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI | [boolean] |
-| `-h`, `--help`        | output usage information | [boolean] |
+> **Note:** Remote Debugging was officially marked as [deprecated](https://github.com/react-native-community/discussions-and-proposals/discussions/734) in RN 0.73 and will be removed in a later release.
 
+Here are the options that `react-native run-windows` takes:
+| Option                | Input Type | Description                                      |
+|-----------------------|------------|--------------------------------------------------|
+| `--release`           | boolean    | Specifies a Release build                        |
+| `--root`              | string     | Override the root directory for the windows build which contains the windows folder (default: `E:\\test63`) |
+| `--arch`              | string     | The build architecture, i.e. `ARM64`, `x86`, `x64`. Defaults to system architecture |
+| `--singleproc`        | boolean    | Disables multi-proc build                        |
+| `--emulator`          | boolean    | Deploys the app to an emulator                   |
+| `--device`            | boolean    | Deploys the app to a connected device            |
+| `--target`            | string     | Deploys the app to the specified `GUID` for a device |
+| `--remote-debugging`  | boolean    | **(Deprecated)** Deploys the app in remote debugging mode |
+| `--logging`           | boolean    | Verbose output logging                           |
+| `--no-packager`       | boolean    | Do not launch the packager while building        |
+| `--bundle`            | boolean    | Enable Bundle configuration, i.e. `ReleaseBundle`/`DebugBundle` rather than `Release`/`Debug` |
+| `--no-launch`         | boolean    | Do not launch the app after deployment           |
+| `--no-autolink`       | boolean    | Do not run autolinking                           |
+| `--no-build`          | boolean    | Do not build the solution                        |
+| `--no-deploy`         | boolean    | Do not deploy the app                            |
+| `--deploy-from-layout`| boolean    | Force deploy from layout, even in release builds |
+| `--sln`               | string     | Override the app solution file determined by 'react-native config', i.e. `windows\myApp.sln` |
+| `--proj`              | string     | Override the app project file determined by 'react-native config', i.e. `windows\myApp\myApp.vcxproj` |
+| `--msbuildprops`      | string     | Comma separated props to pass to MSBuild, i.e. `prop1=value1,prop2=value2` |
+| `--buildLogDirectory` | string     | Optional directory where MSBuild log files should be stored |
+| `--info`              | boolean    | Dump environment information                     |
+| `--direct-debugging`  | number     | Enable direct debugging on specified port        |
+| `--no-telemetry`      | boolean    | Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI |
+| `-h`, `--help`        | boolean    | display help for command                         |
 
 ## Data Collection
 The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
 
-This data collection notice only applies to the process of running the react-native-windows CLI (run-windows and related tools like autolinking).
+This data collection notice only applies to the process of running the react-native-windows CLI (i.e. the commands above).

--- a/packages/@react-native-windows/cli/src/commands/autolinkWindows/autolinkWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/autolinkWindows/autolinkWindows.ts
@@ -1012,7 +1012,7 @@ export async function autolinkWindowsInternal(
  */
 export const autolinkCommand: Command = {
   name: 'autolink-windows',
-  description: 'Runs Windows-specific autolinking',
+  description: 'Runs Windows-specific autolinking for your RNW project',
   func: autolinkWindows,
   options: autolinkOptions,
 };

--- a/packages/@react-native-windows/cli/src/commands/autolinkWindows/autolinkWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/autolinkWindows/autolinkWindowsOptions.ts
@@ -26,13 +26,13 @@ export const autolinkOptions: CommandOption[] = [
   {
     name: '--sln [string]',
     description:
-      "Override the app solution file determined by 'react-native config', e.g. windows\\myApp.sln",
+      "Override the app solution file determined by 'react-native config', i.e. windows\\myApp.sln",
     default: undefined,
   },
   {
     name: '--proj [string]',
     description:
-      "Override the app project file determined by 'react-native config', e.g. windows\\myApp\\myApp.vcxproj",
+      "Override the app project file determined by 'react-native config', i.e. windows\\myApp\\myApp.vcxproj",
     default: undefined,
   },
   {

--- a/packages/@react-native-windows/cli/src/commands/codegenWindows/codegenWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/codegenWindows/codegenWindows.ts
@@ -315,7 +315,7 @@ export async function codegenWindowsInternal(
  */
 export const codegenCommand: Command = {
   name: 'codegen-windows',
-  description: 'Runs Windows-specific codegen',
+  description: 'Runs Windows-specific codegen for native modules',
   func: codegenWindows,
   options: codegenOptions,
 };

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
@@ -323,7 +323,7 @@ export async function initWindowsInternal(
  */
 export const initCommand: Command = {
   name: 'init-windows',
-  description: 'Initializes a new RNW project from a given template.',
+  description: 'Initializes a new RNW project from a given template',
   func: initWindows,
   options: initOptions,
 };

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -28,13 +28,13 @@ export const initOptions: CommandOption[] = [
   {
     name: '--name [string]',
     description:
-      'The native project name. Defaults to the name property iin app.json or package.json',
+      'The native project name. Defaults to the name property in app.json or package.json',
     default: undefined,
   },
   {
     name: '--namespace [string]',
     description:
-      "The native project namespace. This should be expressed using dots as separators. i.e. 'Level1.Level2.Level3'. The generator will apply the correct syntax for the target language.",
+      "The native project namespace, expressed using dots as separators, i.e. 'Level1.Level2.Level3'. Defaults to the same as name",
     default: undefined,
   },
   {

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -34,7 +34,7 @@ export const initOptions: CommandOption[] = [
   {
     name: '--namespace [string]',
     description:
-      "The native project namespace, expressed using dots as separators, i.e. 'Level1.Level2.Level3'. Defaults to the same as name",
+      "The native project namespace expressed using dots as separators, i.e. 'Level1.Level2.Level3'. Defaults to the same as name",
     default: undefined,
   },
   {

--- a/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
@@ -396,7 +396,7 @@ runWindows({
 export const runWindowsCommand: Command = {
   name: 'run-windows',
   description:
-    'Builds your app and starts it on a connected Windows desktop, emulator or device',
+    'Builds your RNW app and starts it on a connected Windows desktop, emulator or device',
   func: runWindows,
   options: runWindowsOptions,
 };

--- a/packages/@react-native-windows/cli/src/commands/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/runWindows/runWindowsOptions.ts
@@ -61,17 +61,17 @@ export interface RunWindowsOptions {
 export const runWindowsOptions: CommandOption[] = [
   {
     name: '--release',
-    description: 'Specifies a release build',
+    description: 'Specifies a Release build',
   },
   {
     name: '--root [string]',
     description:
-      'Override the root directory for the windows build which contains the windows folder.',
+      'Override the root directory for the windows build which contains the windows folder',
     default: config => config.root,
   },
   {
     name: '--arch [string]',
-    description: 'The build architecture (ARM64, x86, x64)',
+    description: 'The build architecture, i.e. ARM64, x86, x64',
     default: parseBuildArch(deviceArchitecture()),
     parse: parseBuildArch,
   },
@@ -89,24 +89,24 @@ export const runWindowsOptions: CommandOption[] = [
   },
   {
     name: '--target [string]',
-    description: 'Deploys the app to the specified GUID for a device.',
+    description: 'Deploys the app to the specified GUID for a device',
   },
   {
     name: '--remote-debugging',
-    description: 'Deploys the app in remote debugging mode.',
+    description: '(Deprecated) Deploys the app in remote debugging mode',
   },
   {
     name: '--logging',
-    description: 'Enables logging',
+    description: 'Verbose output logging',
   },
   {
     name: '--no-packager',
-    description: 'Do not launch packager while building',
+    description: 'Do not launch the packager while building',
   },
   {
     name: '--bundle',
     description:
-      'Enable Bundle configuration and it would be ReleaseBundle/DebugBundle other than Release/Debug',
+      'Enable Bundle configuration, i.e. ReleaseBundle/DebugBundle rather than Release/Debug',
   },
   {
     name: '--no-launch',
@@ -126,28 +126,28 @@ export const runWindowsOptions: CommandOption[] = [
   },
   {
     name: '--deploy-from-layout',
-    description: 'Force deploy from layout',
+    description: 'Force deploy from layout, even in release builds',
   },
   {
     name: '--sln [string]',
     description:
-      "Override the app solution file determined by 'react-native config', e.g. windows\\myApp.sln",
+      "Override the app solution file determined by 'react-native config', i.e. windows\\myApp.sln",
     default: undefined,
   },
   {
     name: '--proj [string]',
     description:
-      "Override the app project file determined by 'react-native config', e.g. windows\\myApp\\myApp.vcxproj",
+      "Override the app project file determined by 'react-native config', i.e. windows\\myApp\\myApp.vcxproj",
     default: undefined,
   },
   {
     name: '--msbuildprops [string]',
     description:
-      'Comma separated props to pass to msbuild, eg: prop1=value1,prop2=value2',
+      'Comma separated props to pass to MSBuild, eg: prop1=value1,prop2=value2',
   },
   {
     name: '--buildLogDirectory [string]',
-    description: 'Optional directory where msbuild log files should be stored',
+    description: 'Optional directory where MSBuild log files should be stored',
   },
   {
     name: '--info',

--- a/packages/@react-native-windows/cli/src/commands/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/runWindows/runWindowsOptions.ts
@@ -66,7 +66,7 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--root [string]',
     description:
-      'Override the root directory for the windows build which contains the windows folder',
+      'Override the root directory for the project which contains the windows folder',
     default: config => config.root,
   },
   {
@@ -126,7 +126,7 @@ export const runWindowsOptions: CommandOption[] = [
   },
   {
     name: '--deploy-from-layout',
-    description: 'Force deploy from layout, even in release builds',
+    description: 'Force deploy from layout even in Release builds',
   },
   {
     name: '--sln [string]',


### PR DESCRIPTION
## Description

This PR fixes some typos in the help for RNW CLI commands.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To clarify the CLI command options.

### What
See above.

## Screenshots
N/A

## Testing
Nothing functional was changed.

## Changelog
Should this change be included in the release notes: _yes_

Fixed typos and improved uniformity of RNW CLI command help text
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13386)