### PR TITLE
[0.74] Change create-react-native-library version to allow Fabric CLI tests to pass

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -46,7 +46,7 @@ steps:
 
   - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
-        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages java-objc --type module-new --react-native-version $(reactNativeDevDependency) testcli
+        npx --yes create-react-native-library@0.36.0 --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages java-objc --type module-new --react-native-version $(reactNativeDevDependency) testcli
       displayName: Init new lib project with create-react-native-library
       workingDirectory: $(Agent.BuildDirectory)
 


### PR DESCRIPTION
## Description
Backport https://github.com/microsoft/react-native-windows/pull/13346/commits/7a1577c2b9d473f0e67c97a085cd5a2aa5edf793

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Unblock Fabric CLI checks on CI

### What
Change `create-react-native-library` version used in init command part of CLI check.

## Screenshots
N/A

## Testing
N/A

## Changelog
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13413)