### PR TITLE
[Fabric] Handle changes to BorderRadius

### DIFF
--- a/change/react-native-windows-0e7a6537-e72d-4a1b-a499-cdbcc09561fb.json
+++ b/change/react-native-windows-0e7a6537-e72d-4a1b-a499-cdbcc09561fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Handle changes to borderradius",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -602,6 +602,8 @@ void SetBorderLayerPropertiesCommon(
     facebook::react::BorderStyle borderStyle) {
   layer.Offset({anchorOffset.x, anchorOffset.y, 0}, {anchorPoint.x, anchorPoint.y, 0});
   layer.RelativeSizeWithOffset(size, relativeSizeAdjustment);
+  layer.as<::Microsoft::ReactNative::Composition::Experimental::IVisualInterop>()->SetClippingPath(nullptr);
+
   if ((textureRect.right - textureRect.left) <= 0 || (textureRect.bottom - textureRect.top) <= 0)
     return;
 
@@ -703,7 +705,7 @@ void SetBorderLayerProperties(
     // if (VisualVersion::IsUseWinCompClippingRegionEnabled())
     {
       layer.Offset({anchorOffset.x, anchorOffset.y, 0}, {anchorPoint.x, anchorPoint.y, 0});
-      layer.Size({textureRect.right - textureRect.left, textureRect.bottom - textureRect.top});
+      layer.RelativeSizeWithOffset({ textureRect.right - textureRect.left, textureRect.bottom - textureRect.top }, { 0.0f, 0.0f });
 
       layer.Brush(theme->Brush(*borderColor));
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -705,7 +705,8 @@ void SetBorderLayerProperties(
     // if (VisualVersion::IsUseWinCompClippingRegionEnabled())
     {
       layer.Offset({anchorOffset.x, anchorOffset.y, 0}, {anchorPoint.x, anchorPoint.y, 0});
-      layer.RelativeSizeWithOffset({ textureRect.right - textureRect.left, textureRect.bottom - textureRect.top }, { 0.0f, 0.0f });
+      layer.RelativeSizeWithOffset(
+          {textureRect.right - textureRect.left, textureRect.bottom - textureRect.top}, {0.0f, 0.0f});
 
       layer.Brush(theme->Brush(*borderColor));
 


### PR DESCRIPTION
## Description
When changing border radius from non-zero to zero the clipping path and relative size adjustment do not get reset to null / 0, causing an incorrect border render.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13422)