### PR TITLE
Use scrollEnabled flag to enable/disable the ScrollView

### DIFF
--- a/change/react-native-windows-addbcde3-c802-4b1b-b6e6-970118e11819.json
+++ b/change/react-native-windows-addbcde3-c802-4b1b-b6e6-970118e11819.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix scrollview",
+  "packageName": "react-native-windows",
+  "email": "10109130+sharath2727@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -106,6 +106,7 @@ namespace Microsoft.ReactNative.Composition.Experimental
   interface IScrollVisual requires IVisual
   {
     void Brush(IBrush brush);
+    void ScrollEnabled(Boolean isScrollEnabled);
     event Windows.Foundation.EventHandler<IScrollPositionChangedArgs> ScrollPositionChanged;
     void ContentSize(Windows.Foundation.Numerics.Vector2 size);
     Windows.Foundation.Numerics.Vector3 ScrollPosition { get; };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -795,15 +795,11 @@ struct CompScrollerVisual : winrt::implements<
     m_visual.Brush(TTypeRedirects::CompositionContextHelper::InnerBrush(brush));
   }
 
-  void ScrollEnabled(bool isScrollEnabled)
-  {
-    if (isScrollEnabled)
-    {
+  void ScrollEnabled(bool isScrollEnabled) noexcept {
+    if (isScrollEnabled) {
       m_visualInteractionSource.ManipulationRedirectionMode(
           TTypeRedirects::VisualInteractionSourceRedirectionMode::CapableTouchpadAndPointerWheel);
-    }
-    else
-    {
+    } else {
       m_visualInteractionSource.ManipulationRedirectionMode(
           TTypeRedirects::VisualInteractionSourceRedirectionMode::Off);
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -795,6 +795,20 @@ struct CompScrollerVisual : winrt::implements<
     m_visual.Brush(TTypeRedirects::CompositionContextHelper::InnerBrush(brush));
   }
 
+  void ScrollEnabled(bool isScrollEnabled)
+  {
+    if (isScrollEnabled)
+    {
+      m_visualInteractionSource.ManipulationRedirectionMode(
+          TTypeRedirects::VisualInteractionSourceRedirectionMode::CapableTouchpadAndPointerWheel);
+    }
+    else
+    {
+      m_visualInteractionSource.ManipulationRedirectionMode(
+          TTypeRedirects::VisualInteractionSourceRedirectionMode::Off);
+    }
+  }
+
   void Opacity(float opacity) noexcept {
     m_visual.Opacity(opacity);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -925,7 +925,7 @@ void ScrollViewComponentView::OnKeyDown(
 
 bool ScrollViewComponentView::scrollToEnd(bool animate) noexcept {
   if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return true;
+    return false;
   }
 
   if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
@@ -941,7 +941,7 @@ bool ScrollViewComponentView::scrollToEnd(bool animate) noexcept {
 
 bool ScrollViewComponentView::scrollToStart(bool animate) noexcept {
   if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return true;
+    return false;
   }
 
   m_scrollVisual.TryUpdatePosition({0.0f, 0.0f, 0.0f}, animate);
@@ -974,7 +974,7 @@ bool ScrollViewComponentView::lineRight(bool animate) noexcept {
 
 bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
   if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return true;
+    return false;
   }
 
   if (((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
@@ -989,7 +989,7 @@ bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
 
 bool ScrollViewComponentView::scrollUp(float delta, bool animate) noexcept {
   if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return true;
+    return false;
   }
 
   if (m_scrollVisual.ScrollPosition().y <= 0.0f) {
@@ -1002,7 +1002,7 @@ bool ScrollViewComponentView::scrollUp(float delta, bool animate) noexcept {
 
 bool ScrollViewComponentView::scrollLeft(float delta, bool animate) noexcept {
   if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return true;
+    return false;
   }
 
   if (m_scrollVisual.ScrollPosition().x <= 0.0f) {
@@ -1015,7 +1015,7 @@ bool ScrollViewComponentView::scrollLeft(float delta, bool animate) noexcept {
 
 bool ScrollViewComponentView::scrollRight(float delta, bool animate) noexcept {
   if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return true;
+    return false;
   }
 
   if (((m_contentSize.width - m_layoutMetrics.frame.size.width) * m_layoutMetrics.pointScaleFactor) -

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -65,10 +65,10 @@ struct ScrollBarComponent {
 
     updateShy(true);
     onScaleChanged();
-    OnThemeChanged();
+    UpdateColorForScrollBarRegions();
   }
 
-  void OnThemeChanged() noexcept {
+  void UpdateColorForScrollBarRegions() noexcept {
     updateHighlight(ScrollbarHitRegion::ArrowFirst);
     updateHighlight(ScrollbarHitRegion::ArrowLast);
     updateHighlight(ScrollbarHitRegion::Thumb);
@@ -732,8 +732,8 @@ void ScrollViewComponentView::updateProps(
   // to avoid scrollbarcomponents reading outdated scrollEnabled value.
   if (!oldProps || oldViewProps.scrollEnabled != newViewProps.scrollEnabled) {
     m_scrollVisual.ScrollEnabled(newViewProps.scrollEnabled);
-    m_horizontalScrollbarComponent->OnThemeChanged();
-    m_verticalScrollbarComponent->OnThemeChanged();
+    m_horizontalScrollbarComponent->UpdateColorForScrollBarRegions();
+    m_verticalScrollbarComponent->UpdateColorForScrollBarRegions();
   }
 }
 
@@ -834,8 +834,8 @@ void ScrollViewComponentView::OnPointerDown(const winrt::Windows::UI::Input::Poi
 
 void ScrollViewComponentView::onThemeChanged() noexcept {
   updateBackgroundColor(std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->backgroundColor);
-  m_verticalScrollbarComponent->OnThemeChanged();
-  m_horizontalScrollbarComponent->OnThemeChanged();
+  m_verticalScrollbarComponent->UpdateColorForScrollBarRegions();
+  m_horizontalScrollbarComponent->UpdateColorForScrollBarRegions();
   Super::onThemeChanged();
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -725,12 +725,16 @@ void ScrollViewComponentView::updateProps(
     updateBackgroundColor(newViewProps.backgroundColor);
   }
 
-  if (!oldProps || oldViewProps.scrollEnabled != newViewProps.scrollEnabled) {
-    m_scrollVisual.ScrollEnabled(newViewProps.scrollEnabled);
-  }
-
   // update BaseComponentView props
   base_type::updateProps(props, oldProps);
+
+  // Update the color only after updating the m_props in BaseComponentView
+  // to avoid scrollbarcomponents reading outdated scrollEnabled value.
+  if (!oldProps || oldViewProps.scrollEnabled != newViewProps.scrollEnabled) {
+    m_scrollVisual.ScrollEnabled(newViewProps.scrollEnabled);
+    m_horizontalScrollbarComponent->OnThemeChanged();
+    m_verticalScrollbarComponent->OnThemeChanged();
+  }
 }
 
 void ScrollViewComponentView::updateState(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -72,6 +72,12 @@ struct ScrollBarComponent {
     updateHighlight(ScrollbarHitRegion::ArrowFirst);
     updateHighlight(ScrollbarHitRegion::ArrowLast);
     updateHighlight(ScrollbarHitRegion::Thumb);
+
+    winrt::get_self<ScrollViewComponentView>(m_outer)->ScrollEnabled(
+        std::static_pointer_cast<const facebook::react::ScrollViewProps>(
+            winrt::get_self<ScrollViewComponentView>(m_outer)->viewProps())
+            ->scrollEnabled);
+
     m_trackVisual.Brush(
         winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(m_outer.Theme())
             ->InternalPlatformBrush(L"ScrollBarTrackFill"));
@@ -919,6 +925,10 @@ void ScrollViewComponentView::OnKeyDown(
 }
 
 bool ScrollViewComponentView::scrollToEnd(bool animate) noexcept {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
+    return true;
+  }
+
   if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
        m_scrollVisual.ScrollPosition().y) < 1.0f) {
     return false;
@@ -931,6 +941,10 @@ bool ScrollViewComponentView::scrollToEnd(bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::scrollToStart(bool animate) noexcept {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
+    return true;
+  }
+
   m_scrollVisual.TryUpdatePosition({0.0f, 0.0f, 0.0f}, animate);
   return true;
 }
@@ -960,6 +974,11 @@ bool ScrollViewComponentView::lineRight(bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled)
+  {
+    return true;
+  }
+
   if (((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
           m_scrollVisual.ScrollPosition().y <
       1.0f) {
@@ -971,6 +990,10 @@ bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::scrollUp(float delta, bool animate) noexcept {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
+    return true;
+  }
+
   if (m_scrollVisual.ScrollPosition().y <= 0.0f) {
     return false;
   }
@@ -980,6 +1003,10 @@ bool ScrollViewComponentView::scrollUp(float delta, bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::scrollLeft(float delta, bool animate) noexcept {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
+    return true;
+  }
+
   if (m_scrollVisual.ScrollPosition().x <= 0.0f) {
     return false;
   }
@@ -989,6 +1016,10 @@ bool ScrollViewComponentView::scrollLeft(float delta, bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::scrollRight(float delta, bool animate) noexcept {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
+    return true;
+  }
+
   if (((m_contentSize.width - m_layoutMetrics.frame.size.width) * m_layoutMetrics.pointScaleFactor) -
           m_scrollVisual.ScrollPosition().x <
       1.0f) {
@@ -1025,6 +1056,10 @@ void ScrollViewComponentView::HandleCommand(
 }
 
 void ScrollViewComponentView::scrollTo(winrt::Windows::Foundation::Numerics::float3 offset, bool animate) noexcept {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
+    return;
+  }
+
   m_scrollVisual.TryUpdatePosition(offset, animate);
 }
 
@@ -1097,7 +1132,8 @@ void ScrollViewComponentView::StartBringIntoView(
     scrollToHorizontal = options.TargetRect->getMidX() - (viewerWidth * options.HorizontalAlignmentRatio);
   }
 
-  if (needsScroll) {
+  if (needsScroll && std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled)
+  {
     m_scrollVisual.TryUpdatePosition(
         {static_cast<float>(scrollToHorizontal), static_cast<float>(scrollToVertical), 0.0f}, options.AnimationDesired);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -73,11 +73,6 @@ struct ScrollBarComponent {
     updateHighlight(ScrollbarHitRegion::ArrowLast);
     updateHighlight(ScrollbarHitRegion::Thumb);
 
-    winrt::get_self<ScrollViewComponentView>(m_outer)->ScrollEnabled(
-        std::static_pointer_cast<const facebook::react::ScrollViewProps>(
-            winrt::get_self<ScrollViewComponentView>(m_outer)->viewProps())
-            ->scrollEnabled);
-
     m_trackVisual.Brush(
         winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(m_outer.Theme())
             ->InternalPlatformBrush(L"ScrollBarTrackFill"));
@@ -730,6 +725,10 @@ void ScrollViewComponentView::updateProps(
     updateBackgroundColor(newViewProps.backgroundColor);
   }
 
+  if (!oldProps || oldViewProps.scrollEnabled != newViewProps.scrollEnabled) {
+    m_scrollVisual.ScrollEnabled(newViewProps.scrollEnabled);
+  }
+
   // update BaseComponentView props
   base_type::updateProps(props, oldProps);
 }
@@ -974,8 +973,7 @@ bool ScrollViewComponentView::lineRight(bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
-  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled)
-  {
+  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
     return true;
   }
 
@@ -1132,8 +1130,7 @@ void ScrollViewComponentView::StartBringIntoView(
     scrollToHorizontal = options.TargetRect->getMidX() - (viewerWidth * options.HorizontalAlignmentRatio);
   }
 
-  if (needsScroll && std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled)
-  {
+  if (needsScroll && std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
     m_scrollVisual.TryUpdatePosition(
         {static_cast<float>(scrollToHorizontal), static_cast<float>(scrollToVertical), 0.0f}, options.AnimationDesired);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -105,11 +105,6 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
-  void ScrollEnabled(bool status)
-  {
-    m_scrollVisual.ScrollEnabled(status);
-  }
-
   bool pageUp(bool animate) noexcept;
   bool pageDown(bool animate) noexcept;
   bool lineUp(bool animate) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -105,6 +105,11 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
+  void ScrollEnabled(bool status)
+  {
+    m_scrollVisual.ScrollEnabled(status);
+  }
+
   bool pageUp(bool animate) noexcept;
   bool pageDown(bool animate) noexcept;
   bool lineUp(bool animate) noexcept;

--- a/vnext/Microsoft.ReactNative/packages.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.lock.json
@@ -14,6 +14,16 @@
         "resolved": "0.1.21",
         "contentHash": "5njCh+3eXTLOv7+8nOnp6nJ5C0r6it5ze54c0nuWleeDptuK8t3dEDB79XTU4D5DKNvAPlqJpgXRDOak5nYIug=="
       },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",
         "requested": "[2.0.230706.1, )",
@@ -28,6 +38,16 @@
         "dependencies": {
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "Microsoft.Windows.SDK.BuildTools": {
         "type": "Transitive",


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Setting the scrollEnabled attribute is not taking any effect on the scrollview visual in fabric.

Resolves #12717 

### What
1. Check for scrollEnabled status before updating the scroll to position.
2. Toggle visualInteractionSourceRedirectionMode based on the scrollEnabled status.

## Screenshots

## Changelog
Yes

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13427)