### PR TITLE
[Fabric] [Win32] Add image response APIs to win32 exports

### DIFF
--- a/change/react-native-windows-759b1fea-b751-4ff5-8448-61302a4756e5.json
+++ b/change/react-native-windows-759b1fea-b751-4ff5-8448-61302a4756e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add image response APIs to win32 exports",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -31,6 +31,15 @@ void* winrt_make_facebook_react_NativeLogEventSource();
 void* winrt_make_facebook_react_NativeTraceEventSource();
 
 #ifndef USE_FABRIC
+void *winrt_make_Microsoft_ReactNative_Composition_ImageFailedResponse() {
+    winrt::throw_hresult(E_NOTIMPL);
+}
+void *winrt_make_Microsoft_ReactNative_Composition_StreamImageResponse() {
+    winrt::throw_hresult(E_NOTIMPL);
+}
+void *winrt_make_Microsoft_ReactNative_Composition_Experimental_UriBrushFactoryImageResponse() {
+    winrt::throw_hresult(E_NOTIMPL);
+}
 void* winrt_make_Microsoft_ReactNative_ReactNativeIsland() {
     winrt::throw_hresult(E_NOTIMPL);
 }

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -8,6 +8,9 @@
 void* winrt_make_Microsoft_Internal_TestController();
 void* winrt_make_Microsoft_ReactNative_ReactNativeIsland();
 #ifdef USE_WINUI3
+void *winrt_make_Microsoft_ReactNative_Composition_ImageFailedResponse();
+void *winrt_make_Microsoft_ReactNative_Composition_StreamImageResponse();
+void *winrt_make_Microsoft_ReactNative_Composition_Experimental_UriBrushFactoryImageResponse();
 void *winrt_make_Microsoft_ReactNative_Composition_Experimental_MicrosoftCompositionContextHelper();
 #endif
 void *winrt_make_Microsoft_ReactNative_Composition_Experimental_SystemCompositionContextHelper();
@@ -65,6 +68,15 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
       return winrt_make_Microsoft_ReactNative_ReactNativeIsland();
     }
 #ifdef USE_WINUI3
+    if (requal(name, L"Microsoft.ReactNative.Composition.ImageFailedResponse")) {
+      return winrt_make_Microsoft_ReactNative_Composition_ImageFailedResponse();
+    }
+    if (requal(name, L"Microsoft.ReactNative.Composition.StreamImageResponse")) {
+      return winrt_make_Microsoft_ReactNative_Composition_StreamImageResponse();
+    }
+    if (requal(name, L"Microsoft.ReactNative.Composition.Experimental.UriBrushFactoryImageResponse")) {
+      return winrt_make_Microsoft_ReactNative_Composition_Experimental_UriBrushFactoryImageResponse();
+    }
     if (requal(name, L"Microsoft.ReactNative.Composition.Experimental.MicrosoftCompositionContextHelper")) {
       return winrt_make_Microsoft_ReactNative_Composition_Experimental_MicrosoftCompositionContextHelper();
     }


### PR DESCRIPTION
## Description
Runtime classes annoyingly currently need to be manually added to this file to be properly exported to rn-win32.
Add some missing ones.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13428)