### PR TITLE
[Fabric] Move to WinAppSDK types for KeyStatus, and ensure usages account for locked flag

### DIFF
--- a/change/react-native-windows-57c6b08e-a6a6-4d04-a58f-b79dd5b9afcc.json
+++ b/change/react-native-windows-57c6b08e-a6a6-4d04-a58f-b79dd5b9afcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Move to WinAppSDK types for KeyStatus, and ensure usages account for locked flag",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Composition.Input.idl
+++ b/vnext/Microsoft.ReactNative/Composition.Input.idl
@@ -8,7 +8,7 @@ namespace Microsoft.ReactNative.Composition.Input
 {
   interface KeyboardSource
   {
-    Windows.UI.Core.CoreVirtualKeyStates GetKeyState(Windows.System.VirtualKey key);
+    Microsoft.UI.Input.VirtualKeyStates GetKeyState(Windows.System.VirtualKey key);
   }
 
   interface RoutedEventArgs
@@ -21,14 +21,14 @@ namespace Microsoft.ReactNative.Composition.Input
     String DeviceId { get; };
     Boolean Handled { get; set; };
     Windows.System.VirtualKey Key { get; };
-    Windows.UI.Core.CorePhysicalKeyStatus KeyStatus { get; };
+    Microsoft.UI.Input.PhysicalKeyStatus KeyStatus { get; };
     Windows.System.VirtualKey OriginalKey { get; };
   }
 
   interface CharacterReceivedRoutedEventArgs requires RoutedEventArgs
   {
     Boolean Handled { get; set; };
-    Windows.UI.Core.CorePhysicalKeyStatus KeyStatus { get; };
+    Microsoft.UI.Input.PhysicalKeyStatus KeyStatus { get; };
     Int32 KeyCode { get; };
   };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
@@ -68,7 +68,7 @@ winrt::Windows::System::VirtualKey KeyRoutedEventArgs::Key() noexcept {
   return m_key;
 }
 
-winrt::Windows::UI::Core::CorePhysicalKeyStatus KeyRoutedEventArgs::KeyStatus() noexcept {
+winrt::Microsoft::UI::Input::PhysicalKeyStatus KeyRoutedEventArgs::KeyStatus() noexcept {
   return m_keyStatus;
 }
 
@@ -118,7 +118,7 @@ void CharacterReceivedRoutedEventArgs::Handled(bool value) noexcept {
 int32_t CharacterReceivedRoutedEventArgs::KeyCode() noexcept {
   return m_keycode;
 }
-winrt::Windows::UI::Core::CorePhysicalKeyStatus CharacterReceivedRoutedEventArgs::KeyStatus() noexcept {
+winrt::Microsoft::UI::Input::PhysicalKeyStatus CharacterReceivedRoutedEventArgs::KeyStatus() noexcept {
   return m_keyStatus;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.h
@@ -31,14 +31,14 @@ struct KeyRoutedEventArgs : winrt::implements<
   bool Handled() noexcept;
   void Handled(bool value) noexcept;
   winrt::Windows::System::VirtualKey Key() noexcept;
-  winrt::Windows::UI::Core::CorePhysicalKeyStatus KeyStatus() noexcept;
+  winrt::Microsoft::UI::Input::PhysicalKeyStatus KeyStatus() noexcept;
   winrt::Windows::System::VirtualKey OriginalKey() noexcept;
 
  private:
   facebook::react::Tag m_tag{-1};
   bool m_handled{false};
   winrt::Windows::System::VirtualKey m_key;
-  winrt::Windows::UI::Core::CorePhysicalKeyStatus m_keyStatus;
+  winrt::Microsoft::UI::Input::PhysicalKeyStatus m_keyStatus;
 };
 
 struct CharacterReceivedRoutedEventArgs
@@ -57,13 +57,13 @@ struct CharacterReceivedRoutedEventArgs
   bool Handled() noexcept;
   void Handled(bool value) noexcept;
   int32_t KeyCode() noexcept;
-  winrt::Windows::UI::Core::CorePhysicalKeyStatus KeyStatus() noexcept;
+  winrt::Microsoft::UI::Input::PhysicalKeyStatus KeyStatus() noexcept;
 
  private:
   facebook::react::Tag m_tag{-1};
   bool m_handled{false};
   int32_t m_keycode;
-  winrt::Windows::UI::Core::CorePhysicalKeyStatus m_keyStatus;
+  winrt::Microsoft::UI::Input::PhysicalKeyStatus m_keyStatus;
 };
 
 struct Pointer : PointerT<Pointer> {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -101,9 +101,9 @@ struct CompositionKeyboardSource
     : winrt::implements<CompositionKeyboardSource, winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource> {
   CompositionKeyboardSource(CompositionEventHandler *outer) : m_outer(outer) {}
 
-  winrt::Windows::UI::Core::CoreVirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept {
+  winrt::Microsoft::UI::Input::VirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept {
     if (!m_outer)
-      return winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
+      return winrt::Microsoft::UI::Input::VirtualKeyStates::None;
     return m_outer->GetKeyState(key);
   }
 
@@ -121,23 +121,11 @@ struct CompositionInputKeyboardSource : winrt::implements<
                                             winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource> {
   CompositionInputKeyboardSource(winrt::Microsoft::UI::Input::InputKeyboardSource source) : m_source(source) {}
 
-  winrt::Windows::UI::Core::CoreVirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept {
+  winrt::Microsoft::UI::Input::VirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept {
     if (!m_source)
-      return winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
+      return winrt::Microsoft::UI::Input::VirtualKeyStates::None;
 
-    static_assert(
-        static_cast<winrt::Windows::UI::Core::CoreVirtualKeyStates>(
-            winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
-        winrt::Windows::UI::Core::CoreVirtualKeyStates::Down);
-    static_assert(
-        static_cast<winrt::Windows::UI::Core::CoreVirtualKeyStates>(
-            winrt::Microsoft::UI::Input::VirtualKeyStates::Locked) ==
-        winrt::Windows::UI::Core::CoreVirtualKeyStates::Locked);
-    static_assert(
-        static_cast<winrt::Windows::UI::Core::CoreVirtualKeyStates>(
-            winrt::Microsoft::UI::Input::VirtualKeyStates::None) ==
-        winrt::Windows::UI::Core::CoreVirtualKeyStates::None);
-    return static_cast<winrt::Windows::UI::Core::CoreVirtualKeyStates>(m_source.GetKeyState(key));
+    return m_source.GetKeyState(key);
   }
 
   void Disconnect() noexcept {
@@ -360,16 +348,15 @@ void CompositionEventHandler::onPointerWheelChanged(
   }
 }
 
-winrt::Windows::UI::Core::CoreVirtualKeyStates CompositionEventHandler::GetKeyState(
+winrt::Microsoft::UI::Input::VirtualKeyStates CompositionEventHandler::GetKeyState(
     winrt::Windows::System::VirtualKey key) noexcept {
-  winrt::Windows::UI::Core::CoreVirtualKeyStates coreKeyState = winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
+  winrt::Microsoft::UI::Input::VirtualKeyStates coreKeyState = winrt::Microsoft::UI::Input::VirtualKeyStates::None;
   SHORT keyState = ::GetKeyState(static_cast<int>(key));
   if (keyState & 0x01) {
-    coreKeyState = winrt::Windows::UI::Core::CoreVirtualKeyStates::Locked;
+    coreKeyState = winrt::Microsoft::UI::Input::VirtualKeyStates::Locked;
   }
   if (keyState & 0x8000) {
-    coreKeyState = static_cast<winrt::Windows::UI::Core::CoreVirtualKeyStates>(
-        static_cast<int>(coreKeyState) | static_cast<int>(winrt::Windows::UI::Core::CoreVirtualKeyStates::Down));
+    coreKeyState = coreKeyState | winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
   }
 
   return coreKeyState;
@@ -510,10 +497,12 @@ void CompositionEventHandler::onKeyDown(
       return;
   }
 
-  bool fShift = source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) ==
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
-  bool fCtrl = source.GetKeyState(winrt::Windows::System::VirtualKey::Control) ==
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
+  bool fShift =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+  bool fCtrl =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
 
   if (fShift && fCtrl && args.Key() == static_cast<winrt::Windows::System::VirtualKey>(VkKeyScanA('d')) &&
       Mso::React::ReactOptions::UseDeveloperSupport(m_context.Properties().Handle())) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -36,7 +36,7 @@ class CompositionEventHandler {
 
   int64_t SendMessage(HWND hwnd, uint32_t msg, uint64_t wParam, int64_t lParam) noexcept;
   void RemoveTouchHandlers();
-  winrt::Windows::UI::Core::CoreVirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept;
+  winrt::Microsoft::UI::Input::VirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept;
 
   bool CapturePointer(
       const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -16,6 +16,7 @@
 #include <Utils/ValueUtils.h>
 #include <Views/FrameworkElementTransferProperties.h>
 #include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
+#include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.UI.Composition.h>
 #include "CompositionContextHelper.h"
 #include "CompositionDynamicAutomationProvider.h"
@@ -1617,7 +1618,10 @@ inline winrt::Windows::System::VirtualKey GetLeftOrRightModifiedKey(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     winrt::Windows::System::VirtualKey leftKey,
     winrt::Windows::System::VirtualKey rightKey) {
-  return (source.GetKeyState(leftKey) == winrt::Windows::UI::Core::CoreVirtualKeyStates::Down) ? leftKey : rightKey;
+  return ((source.GetKeyState(leftKey) & winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
+          winrt::Microsoft::UI::Input::VirtualKeyStates::Down)
+      ? leftKey
+      : rightKey;
 }
 
 std::string CodeFromVirtualKey(
@@ -1650,16 +1654,20 @@ void ViewComponentView::OnKeyDown(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
   auto eventCode = CodeFromVirtualKey(source, args.Key());
-  bool fShift = source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) !=
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
-  bool fAlt = source.GetKeyState(winrt::Windows::System::VirtualKey::Menu) !=
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
-  bool fCtrl = source.GetKeyState(winrt::Windows::System::VirtualKey::Control) !=
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
-  bool fMeta = (source.GetKeyState(winrt::Windows::System::VirtualKey::LeftWindows) !=
-                winrt::Windows::UI::Core::CoreVirtualKeyStates::None) ||
-      (source.GetKeyState(winrt::Windows::System::VirtualKey::RightWindows) !=
-       winrt::Windows::UI::Core::CoreVirtualKeyStates::None);
+  bool fShift =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+  bool fAlt =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Menu) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+  bool fCtrl =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+  bool fMeta =
+      ((source.GetKeyState(winrt::Windows::System::VirtualKey::LeftWindows) &
+        winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ||
+      ((source.GetKeyState(winrt::Windows::System::VirtualKey::RightWindows) &
+        winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down);
 
   if (args.OriginalSource() == Tag() && !args.Handled()) {
     facebook::react::KeyEvent event;
@@ -1668,7 +1676,12 @@ void ViewComponentView::OnKeyDown(
     event.altKey = fAlt;
     event.metaKey = fMeta;
 
-    event.key = ::Microsoft::ReactNative::FromVirtualKey(args.Key(), event.shiftKey, !!(GetKeyState(VK_CAPITAL) & 1));
+    event.key = ::Microsoft::ReactNative::FromVirtualKey(
+        args.Key(),
+        event.shiftKey,
+        !!((source.GetKeyState(winrt::Windows::System::VirtualKey::CapitalLock) &
+            winrt::Microsoft::UI::Input::VirtualKeyStates::Locked) ==
+           winrt::Microsoft::UI::Input::VirtualKeyStates::Locked));
     event.code = eventCode;
     m_eventEmitter->onKeyDown(event);
   }
@@ -1689,16 +1702,20 @@ void ViewComponentView::OnKeyUp(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
   auto eventCode = CodeFromVirtualKey(source, args.Key());
-  bool fShift = source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) !=
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
-  bool fAlt = source.GetKeyState(winrt::Windows::System::VirtualKey::Menu) !=
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
-  bool fCtrl = source.GetKeyState(winrt::Windows::System::VirtualKey::Control) !=
-      winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
-  bool fMeta = (source.GetKeyState(winrt::Windows::System::VirtualKey::LeftWindows) !=
-                winrt::Windows::UI::Core::CoreVirtualKeyStates::None) ||
-      (source.GetKeyState(winrt::Windows::System::VirtualKey::RightWindows) !=
-       winrt::Windows::UI::Core::CoreVirtualKeyStates::None);
+  bool fShift =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+  bool fAlt =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Menu) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+  bool fCtrl =
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+  bool fMeta =
+      ((source.GetKeyState(winrt::Windows::System::VirtualKey::LeftWindows) &
+        winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ||
+      ((source.GetKeyState(winrt::Windows::System::VirtualKey::RightWindows) &
+        winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down);
 
   if (args.OriginalSource() == Tag()) {
     facebook::react::KeyEvent event;
@@ -1707,7 +1724,12 @@ void ViewComponentView::OnKeyUp(
     event.altKey = fAlt;
     event.metaKey = fMeta;
 
-    event.key = ::Microsoft::ReactNative::FromVirtualKey(args.Key(), event.shiftKey, !!(GetKeyState(VK_CAPITAL) & 1));
+    event.key = ::Microsoft::ReactNative::FromVirtualKey(
+        args.Key(),
+        event.shiftKey,
+        !!((source.GetKeyState(winrt::Windows::System::VirtualKey::CapitalLock) &
+            winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
+           winrt::Microsoft::UI::Input::VirtualKeyStates::Down));
     event.code = eventCode;
     m_eventEmitter->onKeyUp(event);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -11,6 +11,7 @@
 #include <Utils/ValueUtils.h>
 #include <tom.h>
 #include <unicode.h>
+#include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.h>
 #include "../CompositionHelpers.h"
@@ -754,8 +755,8 @@ void WindowsTextInputComponentView::OnKeyDown(
   // Do not forward tab keys into the TextInput, since we want that to do the tab loop instead.  This aligns with WinUI
   // behavior We do forward Ctrl+Tab to the textinput.
   if (args.Key() != winrt::Windows::System::VirtualKey::Tab ||
-      source.GetKeyState(winrt::Windows::System::VirtualKey::Control) ==
-          winrt::Windows::UI::Core::CoreVirtualKeyStates::Down) {
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down) {
     WPARAM wParam = static_cast<WPARAM>(args.Key());
     LPARAM lParam = 0;
     lParam = args.KeyStatus().RepeatCount; // bits 0-15
@@ -784,8 +785,8 @@ void WindowsTextInputComponentView::OnKeyUp(
   // Do not forward tab keys into the TextInput, since we want that to do the tab loop instead.  This aligns with WinUI
   // behavior We do forward Ctrl+Tab to the textinput.
   if (args.Key() != winrt::Windows::System::VirtualKey::Tab ||
-      source.GetKeyState(winrt::Windows::System::VirtualKey::Control) ==
-          winrt::Windows::UI::Core::CoreVirtualKeyStates::Down) {
+      (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+       winrt::Microsoft::UI::Input::VirtualKeyStates::Down) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down) {
     WPARAM wParam = static_cast<WPARAM>(args.Key());
     LPARAM lParam = 1;
     lParam = args.KeyStatus().RepeatCount; // bits 0-15
@@ -823,16 +824,21 @@ bool WindowsTextInputComponentView::ShouldSubmit(
       // If 'submitKeyEvents' are supplied, use them to determine whether to emit onSubmitEditing' for either
       // single-line or multi-line TextInput
       if (args.KeyCode() == '\r') {
-        bool shiftDown = source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) ==
-            winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
-        bool ctrlDown = source.GetKeyState(winrt::Windows::System::VirtualKey::Control) ==
-            winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
-        bool altDown = source.GetKeyState(winrt::Windows::System::VirtualKey::Control) ==
-            winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
-        bool metaDown = source.GetKeyState(winrt::Windows::System::VirtualKey::LeftWindows) ==
-                winrt::Windows::UI::Core::CoreVirtualKeyStates::Down ||
-            source.GetKeyState(winrt::Windows::System::VirtualKey::RightWindows) ==
-                winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
+        bool shiftDown = (source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) &
+                          winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
+            winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+        bool ctrlDown = (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+                         winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
+            winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+        bool altDown = (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+                        winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
+            winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
+        bool metaDown = (source.GetKeyState(winrt::Windows::System::VirtualKey::LeftWindows) &
+                         winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
+                winrt::Microsoft::UI::Input::VirtualKeyStates::Down ||
+            (source.GetKeyState(winrt::Windows::System::VirtualKey::RightWindows) &
+             winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
+                winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
         return (submitKeyEvent.shiftKey && shiftDown) || (submitKeyEvent.ctrlKey && ctrlDown) ||
             (submitKeyEvent.altKey && altDown) || (submitKeyEvent.metaKey && metaDown) ||
             (!submitKeyEvent.shiftKey && !submitKeyEvent.altKey && !submitKeyEvent.metaKey && !submitKeyEvent.altKey &&
@@ -853,8 +859,8 @@ void WindowsTextInputComponentView::OnCharacterReceived(
   // Do not forward tab keys into the TextInput, since we want that to do the tab loop instead.  This aligns with WinUI
   // behavior We do forward Ctrl+Tab to the textinput.
   if ((args.KeyCode() == '\t') &&
-      (source.GetKeyState(winrt::Windows::System::VirtualKey::Control) !=
-       winrt::Windows::UI::Core::CoreVirtualKeyStates::Down)) {
+      ((source.GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+        winrt::Microsoft::UI::Input::VirtualKeyStates::Down) != winrt::Microsoft::UI::Input::VirtualKeyStates::Down)) {
     return;
   }
 


### PR DESCRIPTION
## Description
Prefer WinAppSDK types in RNW input types:
`Windows.UI.Core.CorePhysicalKeyStatus` -> `Microsoft.UI.Input.VirtualKeyStates`

Also go through our usage of CorePhysicalKeyStatus which is often used to check if a key is down and fix the tests to account for the Locked state, which is currently causing many of our keyboard shortcuts to only work half the time.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13435)