### PR TITLE
[Fabric] Fix image component reference cycle

### DIFF
--- a/change/react-native-windows-d68e4c7a-72b0-4475-8aea-5b88fa568ee6.json
+++ b/change/react-native-windows-d68e4c7a-72b0-4475-8aea-5b88fa568ee6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix image component reference cycle",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
@@ -120,7 +120,8 @@ void ComponentViewRegistry::enqueueComponentViewWithComponentHandle(
     ComponentViewDescriptor componentViewDescriptor) noexcept {
   assert(m_registry.find(tag) != m_registry.end());
 
-  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(componentViewDescriptor.view)->prepareForRecycle();
+  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(componentViewDescriptor.view)
+      ->prepareForRecycle();
 
   m_registry.erase(tag);
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
@@ -120,6 +120,8 @@ void ComponentViewRegistry::enqueueComponentViewWithComponentHandle(
     ComponentViewDescriptor componentViewDescriptor) noexcept {
   assert(m_registry.find(tag) != m_registry.end());
 
+  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(componentViewDescriptor.view)->prepareForRecycle();
+
   m_registry.erase(tag);
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -182,6 +182,10 @@ void ImageComponentView::setStateAndResubscribeImageResponseObserver(
   }
 }
 
+void ImageComponentView::prepareForRecycle() noexcept {
+  setStateAndResubscribeImageResponseObserver(nullptr);
+}
+
 winrt::Microsoft::ReactNative::ImageProps ImageComponentView::ImageProps() noexcept {
   // We do not currently support custom ImageComponentView's
   // If we did we would need to create a AbiImageProps and possibly return them here

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -44,7 +44,7 @@ void ImageComponentView::WindowsImageResponseObserver::didReceiveImage(
   if (auto imgComponentView{m_wkImage.get()}) {
     auto imageResponseImage = std::static_pointer_cast<ImageResponseImage>(imageResponse.getImage());
     imgComponentView->m_reactContext.UIDispatcher().Post([imageResponseImage, wkImage = m_wkImage]() {
-      if (auto image{m_wkImage.get()}) {
+      if (auto image{wkImage.get()}) {
         image->didReceiveImage(imageResponseImage);
       }
     });

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -43,8 +43,11 @@ void ImageComponentView::WindowsImageResponseObserver::didReceiveImage(
     facebook::react::ImageResponse const &imageResponse) const {
   if (auto imgComponentView{m_wkImage.get()}) {
     auto imageResponseImage = std::static_pointer_cast<ImageResponseImage>(imageResponse.getImage());
-    imgComponentView->m_reactContext.UIDispatcher().Post(
-        [imageResponseImage, imgComponentView]() { imgComponentView->didReceiveImage(imageResponseImage); });
+    imgComponentView->m_reactContext.UIDispatcher().Post([imageResponseImage, wkImage = m_wkImage]() {
+      if (auto image{m_wkImage.get()}) {
+        image->didReceiveImage(imageResponseImage);
+      }
+    });
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -47,6 +47,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ViewComponen
       override;
   void updateState(facebook::react::State::Shared const &state, facebook::react::State::Shared const &oldState) noexcept
       override;
+  void prepareForRecycle() noexcept override;
   void OnRenderingDeviceLost() noexcept override;
   void onThemeChanged() noexcept override;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -69,13 +69,14 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ViewComponen
  private:
   struct WindowsImageResponseObserver : facebook::react::ImageResponseObserver {
    public:
-    WindowsImageResponseObserver(ImageComponentView &image);
+    WindowsImageResponseObserver(
+        winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::implementation::ImageComponentView> wkImage);
     void didReceiveProgress(float progress, int64_t loaded, int64_t total) const override;
     void didReceiveImage(const facebook::react::ImageResponse &imageResponse) const override;
     void didReceiveFailure(const facebook::react::ImageLoadError &error) const override;
 
    private:
-    winrt::com_ptr<ImageComponentView> m_image;
+    winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::implementation::ImageComponentView> m_wkImage;
   };
 
   void ensureDrawingSurface() noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -200,20 +200,21 @@ void FabricUIManager::RCTPerformMountInstructions(
       }
 
       case facebook::react::ShadowViewMutation::Delete: {
-#ifdef DEBUG
+// #define DETECT_COMPONENT_OUTLIVE_DELETE_MUTATION
+#ifdef DETECT_COMPONENT_OUTLIVE_DELETE_MUTATION
         winrt::weak_ref<winrt::Microsoft::ReactNative::ComponentView> wkView;
 #endif
         {
           auto &oldChildShadowView = mutation.oldChildShadowView;
           auto &oldChildViewDescriptor = m_registry.componentViewDescriptorWithTag(oldChildShadowView.tag);
           // observerCoordinator.unregisterViewComponentDescriptor(oldChildViewDescriptor, surfaceId);
-#ifdef DEBUG
+#ifdef DETECT_COMPONENT_OUTLIVE_DELETE_MUTATION
           wkView = winrt::make_weak(oldChildViewDescriptor.view);
 #endif
           m_registry.enqueueComponentViewWithComponentHandle(
               oldChildShadowView.componentHandle, oldChildShadowView.tag, oldChildViewDescriptor);
         }
-#ifdef DEBUG
+#ifdef DETECT_COMPONENT_OUTLIVE_DELETE_MUTATION
         // After handling a delete mutation, nothing should be holding on to the view.  If there is thats an indication
         // of a leak, or at least something holding on to a view longer than it should
         assert(!wkView.get());

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -200,11 +200,24 @@ void FabricUIManager::RCTPerformMountInstructions(
       }
 
       case facebook::react::ShadowViewMutation::Delete: {
-        auto &oldChildShadowView = mutation.oldChildShadowView;
-        auto &oldChildViewDescriptor = m_registry.componentViewDescriptorWithTag(oldChildShadowView.tag);
-        // observerCoordinator.unregisterViewComponentDescriptor(oldChildViewDescriptor, surfaceId);
-        m_registry.enqueueComponentViewWithComponentHandle(
-            oldChildShadowView.componentHandle, oldChildShadowView.tag, oldChildViewDescriptor);
+#ifdef DEBUG
+        winrt::weak_ref<winrt::Microsoft::ReactNative::ComponentView> wkView;
+#endif
+        {
+          auto &oldChildShadowView = mutation.oldChildShadowView;
+          auto &oldChildViewDescriptor = m_registry.componentViewDescriptorWithTag(oldChildShadowView.tag);
+          // observerCoordinator.unregisterViewComponentDescriptor(oldChildViewDescriptor, surfaceId);
+#ifdef DEBUG
+          wkView = winrt::make_weak(oldChildViewDescriptor.view);
+#endif
+          m_registry.enqueueComponentViewWithComponentHandle(
+              oldChildShadowView.componentHandle, oldChildShadowView.tag, oldChildViewDescriptor);
+        }
+#ifdef DEBUG
+        // After handling a delete mutation, nothing should be holding on to the view.  If there is thats an indication of a leak,
+        // or at least something holding on to a view longer than it should
+        assert(!wkView.get());
+#endif
         break;
       }
 

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -214,8 +214,8 @@ void FabricUIManager::RCTPerformMountInstructions(
               oldChildShadowView.componentHandle, oldChildShadowView.tag, oldChildViewDescriptor);
         }
 #ifdef DEBUG
-        // After handling a delete mutation, nothing should be holding on to the view.  If there is thats an indication of a leak,
-        // or at least something holding on to a view longer than it should
+        // After handling a delete mutation, nothing should be holding on to the view.  If there is thats an indication
+        // of a leak, or at least something holding on to a view longer than it should
         assert(!wkView.get());
 #endif
         break;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -337,7 +337,7 @@ void ReactInstanceWin::LoadModules(
   };
 
 #ifdef USE_FABRIC
-  if (!m_options.UseWebDebugger()) {
+  if (Microsoft::ReactNative::IsFabricEnabled(m_reactContext->Properties())) {
     registerTurboModule(
         L"FabricUIManagerBinding",
         winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::FabricUIManager>());
@@ -602,7 +602,8 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
 
             m_jsMessageThread.Load()->runOnQueueSync([&]() {
               ::SetThreadDescription(GetCurrentThread(), L"React-Native JavaScript Thread");
-              auto timerRegistry = ::Microsoft::ReactNative::TimerRegistry::CreateTimerRegistry(m_options.Properties);
+              auto timerRegistry =
+                  ::Microsoft::ReactNative::TimerRegistry::CreateTimerRegistry(m_reactContext->Properties());
               auto timerRegistryRaw = timerRegistry.get();
 
               auto timerManager = std::make_shared<facebook::react::TimerManager>(std::move(timerRegistry));


### PR DESCRIPTION
## Description
`ImageComponentView`'s currently have a reference cycle with the `WindowsImageResponseObserver` which caused leaks of every `ImageComponentView`.

This makes the `WindowsImageResponseObserver` have a weak ref to resolve the cycle.

Added some debug code to detect leaks of ComponentView's.  This debug code maybe to too aggressive - we'll see.
 -- left the leak detection code #ifdef'd out for now.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13440)