### PR TITLE
[Fabric] call reportMount to implement UIManagerMountHook support

### DIFF
--- a/change/react-native-windows-24c5a09a-7492-4f70-9a80-a82c358fb058.json
+++ b/change/react-native-windows-24c5a09a-7492-4f70-9a80-a82c358fb058.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] call reportMount to implement UIManagerMountHook support",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -182,7 +182,17 @@ void FabricUIManager::constraintSurfaceLayout(
   m_surfaceManager->constraintSurfaceLayout(surfaceId, layoutConstraints, layoutContext);
 }
 
-void FabricUIManager::didMountComponentsWithRootTag(facebook::react::SurfaceId surfaceId) noexcept {}
+winrt::Microsoft::ReactNative::ReactNotificationId<facebook::react::SurfaceId>
+FabricUIManager::NotifyMountedId() noexcept {
+  return {L"ReactNative.Fabric", L"Mounted"};
+}
+
+void FabricUIManager::didMountComponentsWithRootTag(facebook::react::SurfaceId surfaceId) noexcept {
+  m_context.UIDispatcher().Post([context = m_context, self = shared_from_this(), surfaceId]() {
+    self->m_scheduler->reportMount(surfaceId);
+    context.Notifications().SendNotification(NotifyMountedId(), surfaceId);
+  });
+}
 
 void FabricUIManager::RCTPerformMountInstructions(
     facebook::react::ShadowViewMutationList const &mutations,

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
@@ -52,6 +52,8 @@ struct FabricUIManager final : public std::enable_shared_from_this<FabricUIManag
   winrt::Microsoft::ReactNative::ReactNativeIsland GetReactNativeIsland(
       facebook::react::SurfaceId surfaceId) const noexcept;
 
+  static winrt::Microsoft::ReactNative::ReactNotificationId<facebook::react::SurfaceId> NotifyMountedId() noexcept;
+
  private:
   void installFabricUIManager() noexcept;
   void initiateTransaction(facebook::react::MountingCoordinator::Shared mountingCoordinator);


### PR DESCRIPTION
## Description
`scheduler.reportMount` call will call into any `UIManagerMountHook` that has been registered with the `UIManager`.  This will include `IntersectionObserver` in the future.  This aligns with code in core version of `didMountComponentsWithRootTag`.  

This also provides a notification to the `ReactNotificationService` at the same time which can be used to track rootview mounts for performance analysis etc.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13443)