### PR TITLE
Increase Desktop job timeouts due to #13442

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -109,7 +109,7 @@ jobs:
                 (FullyQualifiedName!~PreparedJavaScriptSourceTest)
 
           pool: ${{ parameters.AgentPool.Medium }}
-          timeoutInMinutes: 60 # how long to run the job before automatically cancelling
+          timeoutInMinutes: 80 # how long to run the job before automatically cancelling - Issue 13442
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
           steps:


### PR DESCRIPTION
Temporarily increase the timeout of the Desktop jobs to avoid manual re-runs. 

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13444)