### PR TITLE
Bump minimum VS version to 17.11.0

### DIFF
--- a/.ado/image/rnw-img-vs2022-node18.json
+++ b/.ado/image/rnw-img-vs2022-node18.json
@@ -28,7 +28,7 @@
             "parameters": {
                 "Workloads": "--add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.Universal --add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.UWP.Support --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Component.Windows10SDK.19041 Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.UWP.VC --includeRecommended --includeOptional",
                 "SKU": "Enterprise",
-                "VSBootstrapperURL": "https://aka.ms/vs/17/release/180911598_-255012421/vs_Enterprise.exe"
+                "VSBootstrapperURL": "https://aka.ms/vs/17/release/vs_Enterprise.exe"
             }
         },
         {

--- a/.ado/image/rnw-img-vs2022.json
+++ b/.ado/image/rnw-img-vs2022.json
@@ -28,7 +28,7 @@
             "parameters": {
                 "Workloads": "--add Microsoft.VisualStudio.Workload.ManagedDesktop --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.Universal --add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.UWP.Support --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Component.Windows10SDK.19041 Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.UWP.VC --includeRecommended --includeOptional",
                 "SKU": "Enterprise",
-                "VSBootstrapperURL": "https://aka.ms/vs/17/release/180911598_-255012421/vs_Enterprise.exe"
+                "VSBootstrapperURL": "https://aka.ms/vs/17/release/vs_Enterprise.exe"
             }
         },
         {

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -201,7 +201,7 @@ steps:
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   # Temporarily disabling due to spurios failures in CI, see https://github.com/microsoft/react-native-windows/issues/13578
-  - ${{ if (and(false, eq(parameters.runWack, true)) }}:
+  - ${{ if and(false, eq(parameters.runWack, true)) }}:
     - template: ../templates/run-wack.yml
       parameters:
         packageName: ReactNative.InitTest

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -200,7 +200,7 @@ steps:
       displayName: Create bundle testcli
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  # Temporarily disabling due to spurios failures in CI, see https://github.com/microsoft/react-native-windows/issues/13578
+  # Temporarily disabling due to spurious failures in CI, see https://github.com/microsoft/react-native-windows/issues/13578
   - ${{ if and(false, eq(parameters.runWack, true)) }}:
     - template: ../templates/run-wack.yml
       parameters:

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -200,7 +200,8 @@ steps:
       displayName: Create bundle testcli
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  - ${{ if eq(parameters.runWack, true) }}:
+  # Temporarily disabling due to spurios failures in CI, see https://github.com/microsoft/react-native-windows/issues/13578
+  - ${{ if (and(false, eq(parameters.runWack, true)) }}:
     - template: ../templates/run-wack.yml
       parameters:
         packageName: ReactNative.InitTest

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -16,13 +16,13 @@ parameters:
     default:
       Small:
         name: rnw-pool-2
-        demands: ImageOverride -equals rnw-img-test
+        demands: ImageOverride -equals rnw-img-vs2022-node18
       Medium:
         name: rnw-pool-4
-        demands: ImageOverride -equals rnw-img-test
+        demands: ImageOverride -equals rnw-img-vs2022-node18
       Large:
         name: rnw-pool-8
-        demands: ImageOverride -equals rnw-img-test
+        demands: ImageOverride -equals rnw-img-vs2022-node18
 
 stages:
   - template: stages.yml

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -16,13 +16,13 @@ parameters:
     default:
       Small:
         name: rnw-pool-2
-        demands: ImageOverride -equals rnw-img-vs2022-node18
+        demands: ImageOverride -equals rnw-img-test
       Medium:
         name: rnw-pool-4
-        demands: ImageOverride -equals rnw-img-vs2022-node18
+        demands: ImageOverride -equals rnw-img-test
       Large:
         name: rnw-pool-8
-        demands: ImageOverride -equals rnw-img-vs2022-node18
+        demands: ImageOverride -equals rnw-img-test
 
 stages:
   - template: stages.yml

--- a/change/@react-native-windows-cli-43e4c71b-04c9-455c-a70d-68bf8968074c.json
+++ b/change/@react-native-windows-cli-43e4c71b-04c9-455c-a70d-68bf8968074c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump minimum VS version to 17.11.0",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-5db66c4d-8de8-4f82-8f09-7feba85c9359.json
+++ b/change/react-native-windows-5db66c4d-8de8-4f82-8f09-7feba85c9359.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump minimum VS version to 17.11.0",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/healthCheck/healthCheckList.ts
+++ b/packages/@react-native-windows/cli/src/commands/healthCheck/healthCheckList.ts
@@ -11,7 +11,7 @@ export const HealthCheckList = [
   [true, 'WindowsVersion', 'Windows version >= 10.0.17763.0'],
   [true, 'DeveloperMode', 'Developer mode is on'],
   [true, 'LongPath', 'Long path support is enabled'],
-  [true, 'VSUWP', 'Visual Studio 2022 (>= 17.9) & req. components'],
+  [true, 'VSUWP', 'Visual Studio 2022 (>= 17.11.0) & req. components'],
   [true, 'Node', 'Node.js (LTS, >= 18.18)'],
   [true, 'Yarn', 'Yarn'],
   [true, 'DotNetCore', '.NET SDK (LTS, = 6.0)'],

--- a/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
@@ -200,7 +200,7 @@ export default class MSBuildTools {
       'Microsoft.Component.MSBuild',
       getVCToolsByArch(buildArch),
     ];
-    const minVersion = process.env.MinimumVisualStudioVersion || process.env.VisualStudioVersion || '17.0';
+    const minVersion = process.env.MinimumVisualStudioVersion || process.env.VisualStudioVersion || '17.11.0';
     const vsInstallation = findLatestVsInstall({
       requires,
       minVersion,

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -172,7 +172,7 @@
     <JsBundleEntry Include="..\Microsoft.ReactNative.IntegrationTests\ReactNativeHostTests.js" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -227,7 +227,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="boost" Version="1.83.0.0" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -160,7 +160,7 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxHandler.idl" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.4" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -174,7 +174,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.83.0.0" />
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -170,7 +170,7 @@
     <None Include="future\futureTest.tt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" '$(UseFabric)' == 'true' AND '$(UseWinUI3)' == 'true' ">

--- a/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
+++ b/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
@@ -179,7 +179,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.83.0.0" />
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.4" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -85,7 +85,7 @@ $wingetver = "1.7.11261";
 
 # The minimum VS version to check for
 # Note: For install to work, whatever min version you specify here must be met by the current package available on winget.
-$vsver = "17.9";
+$vsver = "17.11.0";
 
 # The exact .NET SDK version to check for
 $dotnetver = "6.0";


### PR DESCRIPTION
## Description

This PR bumps the minimum version of VS that RNW expects to 17.11.0.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To make sure users don't use the regressed builds of VS 2022.

Resolves #13339
Resolves #13374 

### What
Bumped VS version checks for `run-windows` and `rnw-dependencies.ps1`. Updated ADO image to reflect updated images are no longer locked to VS v17.9.4.

## Screenshots
N/A

## Testing
`run-windows` now works with 17.11.0.

## Changelog
Should this change be included in the release notes: _yes_

Require Visual Studio 2022 >= v17.11.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13455)