### PR TITLE
Add warnings and deprecations for react-native-windows-init

### DIFF
--- a/change/react-native-windows-init-df92456d-ba5e-4a0a-aa54-bf2373b4c9d9.json
+++ b/change/react-native-windows-init-df92456d-ba5e-4a0a-aa54-bf2373b4c9d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add warnings and deprecations for react-native-windows-init",
+  "packageName": "react-native-windows-init",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -298,6 +298,24 @@ function installReactNativeWindows(
     );
   }
 
+  const parsedVersion = semver.parse(version);
+  if (parsedVersion) {
+    const newSteps = "Please see https://microsoft.github.io/react-native-windows/docs/getting-started for the latest method for adding RNW to your project.";
+    if (parsedVersion.minor > 75
+      || (parsedVersion.minor === 0
+          && parsedVersion.prerelease.length > 1
+          && parsedVersion.prerelease[0] === 'canary'
+          && typeof parsedVersion.prerelease[1] === 'number'
+          && parsedVersion.prerelease[1] > 843)
+      ) {
+      // Full-stop, you can't use the command anymore.
+      throw new CodedError('UnsupportedReactNativeVersion', `react-native-windows-init only supports react-native-windows <= 0.75. ${newSteps}`);
+    } else if (parsedVersion.minor === 75) {
+      // You can use the command for now, but it will be deprecated soon.
+      console.warn(chalk.yellow(`Warning: react-native-windows-init will be deprecated for RNW > 0.75. ${newSteps}`));
+    }
+  }
+
   console.log(
     `Installing ${chalk.green('react-native-windows')}@${chalk.cyan(
       version,


### PR DESCRIPTION
## Description

This PR adds version checking to `react-native-windows-init` to give a deprecation warning if the user tries to use it for RNW 0.75 and an error if they use it on a newer version.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We will be deprecating `react-native-windows-init` in favor of newer methods for adding RNW projects.

Resolves #13461

### What
See above.

## Screenshots
N/A

## Testing
Verified I could se the warning/error when using it with 

## Changelog
Should this change be included in the release notes: _yes_

Add warnings and deprecations for react-native-windows-init
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13488)