### PR TITLE
Don't override Hermes platform for ARM64EC

### DIFF
--- a/change/react-native-windows-04d234ac-4d36-4621-aa06-dbc4b67a5e0a.json
+++ b/change/react-native-windows-04d234ac-4d36-4621-aa06-dbc4b67a5e0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Don't override Hermes platform for ARM64EC",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/packages.lock.json
+++ b/vnext/Desktop.DLL/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.1.21, )",
-        "resolved": "0.1.21",
-        "contentHash": "5njCh+3eXTLOv7+8nOnp6nJ5C0r6it5ze54c0nuWleeDptuK8t3dEDB79XTU4D5DKNvAPlqJpgXRDOak5nYIug=="
+        "requested": "[0.1.23, )",
+        "resolved": "0.1.23",
+        "contentHash": "cA9t1GjY4Yo0JD1AfA//e1lOwk48hLANfuX6GXrikmEBNZVr2TIX5ONJt5tqCnpZyLz6xGiPDgTfFNKbSfb21g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -81,7 +81,7 @@
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
           "FollyWin32": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.21, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.23, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.5.240227000, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop/packages.lock.json
+++ b/vnext/Desktop/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.1.21, )",
-        "resolved": "0.1.21",
-        "contentHash": "5njCh+3eXTLOv7+8nOnp6nJ5C0r6it5ze54c0nuWleeDptuK8t3dEDB79XTU4D5DKNvAPlqJpgXRDOak5nYIug=="
+        "requested": "[0.1.23, )",
+        "resolved": "0.1.23",
+        "contentHash": "cA9t1GjY4Yo0JD1AfA//e1lOwk48hLANfuX6GXrikmEBNZVr2TIX5ONJt5tqCnpZyLz6xGiPDgTfFNKbSfb21g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -72,8 +72,8 @@
       "folly": {
         "type": "Project",
         "dependencies": {
-          "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.76.0, )",
+          "fmt": "[1.0.0, )"
         }
       },
       "follywin32": {

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -14,7 +14,6 @@
     <HermesNoLink Condition="'$(HermesNoLink)' == '' and '$(Configuration)' == 'Release' and '$(EnableHermesInspectorInReleaseFlavor)' != 'true'">true</HermesNoLink>
     <!-- Use Hermes bytecode bundles provided by metro hermes compiler when available -->
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
-    <HermesPlatform Condition="'$(Platform)' == 'ARM64EC'">x64</HermesPlatform>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
     <V8Version Condition="'$(V8Version)' == ''">0.71.8</V8Version>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -6,7 +6,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">true</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.21</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.23</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgMicrosoft_JavaScript_Hermes)')">$(PkgMicrosoft_JavaScript_Hermes)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\Microsoft.JavaScript.Hermes\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>


### PR DESCRIPTION
## Description

Have ARM64EC react-native-win32.dll consume ARM64EC Hermes.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Loading x64 dependencies on ARM64EC processes has a performance overhead.


### What
Stop overriding the `HermesPlatform` MSBuild property when building under ARM64EC.

Hermes should now provide a native ARM64EC variant.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13490)