### PR TITLE
Fix Alerts and Flyouts crashing on Windows 10 1809 (RS5)

### DIFF
--- a/change/react-native-windows-3ffe8770-fba2-4468-a7a7-63d1d7257102.json
+++ b/change/react-native-windows-3ffe8770-fba2-4468-a7a7-63d1d7257102.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add version checks for uses of XamlRoot",
+  "packageName": "react-native-windows",
+  "email": "julie@vendora.io",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -117,7 +117,9 @@ void Alert::ProcessPendingAlertRequestsXaml() noexcept {
   // https://github.com/microsoft/microsoft-ui-xaml/issues/2331
   dialog.Opened([useXamlRootForThemeBugWorkaround](winrt::IInspectable const &sender, auto &&) {
     auto contentDialog = sender.as<xaml::Controls::ContentDialog>();
-    auto popups = xaml::Media::VisualTreeHelper::GetOpenPopupsForXamlRoot(contentDialog.XamlRoot());
+    auto popups = useXamlRootForThemeBugWorkaround
+        ? xaml::Media::VisualTreeHelper::GetOpenPopupsForXamlRoot(contentDialog.XamlRoot())
+        : xaml::Media::VisualTreeHelper::GetOpenPopups(xaml::Window::Current());
 
     auto contentAsFrameworkElement = useXamlRootForThemeBugWorkaround
         ? contentDialog.XamlRoot().Content().try_as<xaml::FrameworkElement>()


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Opening Alerts and Flyouts crashes on Windows 10 1809 

Resolves #13502

### What
Adds more version checks around uses of XamlRoot, which was added in the next version 19H1. There were a few uses of `is19H1OrHigher`, but not all XamlRoot related code was wrapped.

## Changelog
Should this change be included in the release notes: yes

Fix alerts and flyouts crashing on Windows 10 1809
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13505)