### PR TITLE
Fix Fabric cli CI jobs

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -50,7 +50,7 @@ steps:
 
   - ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
     - script: | # Change version of react-native from 'next' to '$(reactNativeDevDependency)' and remove upgrade commands - Windows #13446
-        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages java-objc --type module-new --react-native-version next --example vanilla testcli
+        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type module-new --react-native-version next --example vanilla testcli
         cd testcli && call yarn upgrade react-native@$(reactNativeDevDependency) --dev
         cd example && call yarn upgrade react-native@$(reactNativeDevDependency)
       displayName: Init new lib project with create-react-native-library


### PR DESCRIPTION
## Description
create-react-native-library deleted the java-objc template. Doesn't matter which one we use since we're only building windows, so updating it to use kotlin-objc. 

https://github.com/callstack/react-native-builder-bob/pull/601

### Why
![image](https://github.com/user-attachments/assets/869619cf-d1c7-41db-8eb9-ee05f844c1e6)

### What
Changed cli job from `java-objc` to `kotlin-objc`

## Testing
CI

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13506)