### PR TITLE
Create self-signed certificates programatically rather than from keyvault

### DIFF
--- a/.ado/templates/write-certificate.yml
+++ b/.ado/templates/write-certificate.yml
@@ -4,12 +4,14 @@ parameters:
 
 steps:
   - powershell: |
-      Write-Host "Using certificate named ${{ parameters.certificateName }}"
-      Write-Host "##vso[task.setvariable variable=EncodedKey]$(${{ parameters.certificateName }})"
-    displayName: Determining certificate
+      $certStoreRoot = "cert:\CurrentUser\My"
+      $rootFolder = $(Build.SourcesDirectory)
+      [System.Security.SecureString] $password = ConvertTo-SecureString -String "pwd" -Force -AsPlainText
 
-  - powershell: |
-      $PfxBytes = [System.Convert]::FromBase64String("$(EncodedKey)")
-      $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $(Build.SourcesDirectory) -ChildPath EncodedKey.pfx) )
-      [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
-    displayName: Write certificate
+      $cert = New-SelfSignedCertificate -KeyExportPolicy Exportable -CertStoreLocation $certStoreRoot -DnsName "Development Root CA" -NotAfter (Get-Date).AddYears(5) -Type CodeSigningCert -KeyUsage DigitalSignature
+      [String] $pfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $rootFolder -ChildPath EncodedKey.pfx) )
+      [String] $certPath = "$certStoreRoot\$($cert.Thumbprint)"
+      write-host "$certPath"
+      Export-PfxCertificate -Cert $certPath -FilePath $pfxPath -Password $password
+
+    displayName: Create self-signed certificate


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
SFI

### What
Generate the self-signed certs for testing programmatically on the fly, rather than use a fixed one.

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13517)