### PR TITLE
Fix Password passing and path for certs

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -8,6 +8,9 @@ parameters:
       - Continuous
   - name: AgentPool
     type: object
+  - name: certificatePassword
+    type: string
+    default: 'pwd'
   - name: buildMatrix
     type: object
     default:
@@ -135,7 +138,9 @@ jobs:
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/write-certificate.yml
-
+                parameters:
+                  certificatePassword: ${{ parameters.certificatePassword }}
+        
             - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
               - template:  ../templates/set-experimental-feature.yml
                 parameters:
@@ -174,6 +179,7 @@ jobs:
                 ${{if eq(config.BuildEnvironment, 'Continuous')}}:
                   msbuildArgs:
                     /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
+                    /p:PackageCertificatePassword=${{ parameters.certificatePassword }}
 
             - ${{if and(endsWith(matrix.Name, 'Universal'), eq(matrix.BuildConfiguration, 'Debug')) }}:
               # Execute debug feature tests (skip this step for the Win32 Playground app and for release builds)

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -29,7 +29,10 @@ parameters:
   - name: moreMSBuildProps
     type: string
     default: ''
-
+  - name: certificatePassword
+    type: string
+    default: 'pwd'
+  
 steps:
   - ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
     - script: >
@@ -58,6 +61,8 @@ steps:
 
   - ${{ if and(eq(parameters.buildConfiguration, 'Release'), eq(parameters.buildEnvironment, 'Continuous')) }}:
     - template: ../templates/write-certificate.yml
+      parameters:
+        certificatePassword: ${{ parameters.certificatePassword }}
 
     - script: >
         yarn react-native run-windows
@@ -66,7 +71,7 @@ steps:
         --no-launch
         --logging
         --buildLogDirectory ${{ parameters.buildLogDirectory }}
-        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }},PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx${{ parameters.moreMSBuildProps }}
+        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }},PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx,PackageCertificatePassword=${{ parameters.certificatePassword }}${{ parameters.moreMSBuildProps }}
         ${{ parameters.deployOption }}
       displayName: run-windows (Release) - CI
       workingDirectory: ${{ parameters.workingDirectory }}

--- a/.ado/templates/write-certificate.yml
+++ b/.ado/templates/write-certificate.yml
@@ -1,13 +1,20 @@
+parameters:
+  - name: certificatePassword
+    type: string
+    default: 'pwd'
+
 steps:
   - powershell: |
-      $certStoreRoot = "cert:\CurrentUser\My"
-      $rootFolder = $(Build.SourcesDirectory)
-      [System.Security.SecureString] $password = ConvertTo-SecureString -String "pwd" -Force -AsPlainText
+      $certStoreRoot="cert:\CurrentUser\My"
+      $rootFolder="$(Build.SourcesDirectory)"
+
+      # the following two lines must match
+      [System.Security.SecureString] $password = ConvertTo-SecureString -String "${{ parameters.certificatePassword }}" -Force -AsPlainText
 
       $cert = New-SelfSignedCertificate -KeyExportPolicy Exportable -CertStoreLocation $certStoreRoot -DnsName "Development Root CA" -NotAfter (Get-Date).AddYears(5) -Type CodeSigningCert -KeyUsage DigitalSignature
       [String] $pfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $rootFolder -ChildPath EncodedKey.pfx) )
       [String] $certPath = "$certStoreRoot\$($cert.Thumbprint)"
-      write-host "$certPath"
+
       Export-PfxCertificate -Cert $certPath -FilePath $pfxPath -Password $password
 
     displayName: Create self-signed certificate


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Previous PR to update CI did not fully work

### What
Thread through the password to the generated certificate and put quotes on the path as that fails in ADO...

## Testing
Been running CI off a branch ...

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13526)