### PR TITLE
Implement REACT_EVENT_EMITTER and add to the SampleTurboModule module

### DIFF
--- a/change/react-native-windows-6a82bdc7-fdc0-4d57-bd42-cb297ef7a7ea.json
+++ b/change/react-native-windows-6a82bdc7-fdc0-4d57-bd42-cb297ef7a7ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement SampleTurboModule",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
@@ -84,6 +84,8 @@ void ReactModuleBuilderMock::AddSyncMethod(hstring const &name, SyncMethodDelega
   m_syncMethods.emplace(name, method);
 }
 
+void ReactModuleBuilderMock::AddEventEmitter(hstring const &, EventEmitterInitializerDelegate const &) noexcept {}
+
 JSValueObject ReactModuleBuilderMock::GetConstants() noexcept {
   auto constantWriter = MakeJSValueTreeWriter();
   constantWriter.WriteObjectBegin();

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -219,6 +219,7 @@ struct ReactModuleBuilderImpl : implements<ReactModuleBuilderImpl, IReactModuleB
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept;
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept;
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept;
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept;
 
  private:
   ReactModuleBuilderMock &m_mock;
@@ -351,6 +352,12 @@ inline void ReactModuleBuilderImpl::AddMethod(
 
 inline void ReactModuleBuilderImpl::AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept {
   m_mock.AddSyncMethod(name, method);
+}
+
+inline void ReactModuleBuilderImpl::AddEventEmitter(
+    hstring const &name,
+    EventEmitterInitializerDelegate const &emitter) noexcept {
+  m_mock.AddEventEmitter(name, emitter);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -73,6 +73,7 @@ struct ReactModuleBuilderMock {
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept;
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept;
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept;
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept;
 
  private:
   MethodDelegate GetMethod0(std::wstring const &methodName) const noexcept;

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -299,6 +299,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       writer.WriteArrayEnd();
       m_jsEventHandler(eventEmitterName, eventName, writer.TakeValue());
     }
+
+    public void AddEventEmitter(string name, EventEmitterInitializerDelegate emitter) { }
   }
 
   class ReactSettingsSnapshot : IReactSettingsSnapshot

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -129,7 +129,7 @@ void ReactModuleBuilder::AddSyncMethod(hstring const &name, SyncMethodDelegate c
   m_methods.push_back(std::move(cxxMethod));
 }
 
-void ReactModuleBuilder::AddEventEmitter(hstring name, EventEmitterInitializerDelegate emitter) noexcept {
+void ReactModuleBuilder::AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept {
   // No-op.  We only support auto generated EventEmitters in TurboModules
 }
 

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -129,6 +129,10 @@ void ReactModuleBuilder::AddSyncMethod(hstring const &name, SyncMethodDelegate c
   m_methods.push_back(std::move(cxxMethod));
 }
 
+void ReactModuleBuilder::AddEventEmitter(hstring name, EventEmitterInitializerDelegate emitter) noexcept {
+  // No-op.  We only support auto generated EventEmitters in TurboModules
+}
+
 /*static*/ MethodResultCallback ReactModuleBuilder::MakeMethodResultCallback(CxxModule::Callback &&callback) noexcept {
   if (callback) {
     return [callback = std::move(callback)](const IJSValueWriter &outputWriter) noexcept {

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.h
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.h
@@ -15,6 +15,7 @@ struct ReactModuleBuilder : winrt::implements<ReactModuleBuilder, IReactModuleBu
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept;
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept;
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept;
+  void AddEventEmitter(hstring name, EventEmitterInitializerDelegate emitter) noexcept;
 
  public:
   std::unique_ptr<facebook::xplat::module::CxxModule> MakeCxxModule(

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.h
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.h
@@ -15,7 +15,7 @@ struct ReactModuleBuilder : winrt::implements<ReactModuleBuilder, IReactModuleBu
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept;
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept;
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept;
-  void AddEventEmitter(hstring name, EventEmitterInitializerDelegate emitter) noexcept;
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept;
 
  public:
   std::unique_ptr<facebook::xplat::module::CxxModule> MakeCxxModule(

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
@@ -34,6 +34,12 @@ namespace Microsoft.ReactNative
       MethodResultCallback resolve,
       MethodResultCallback reject);
 
+  DOC_STRING("A delegate gets the arguments for an event emit on a EventEmitter.")
+  delegate void EmitEventSetterDelegate(JSValueArgWriter argWriter);
+
+  DOC_STRING("A delegate to call a turbo module EventEmitter.")
+  delegate void EventEmitterInitializerDelegate(EmitEventSetterDelegate emitter);
+
   DOC_STRING("A delegate to call native synchronous method.")
   delegate void SyncMethodDelegate(IJSValueReader inputReader, IJSValueWriter outputWriter);
 
@@ -62,5 +68,8 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Adds a synchronous method to the native module. See @SyncMethodDelegate.")
     void AddSyncMethod(String name, SyncMethodDelegate method);
+
+    DOC_STRING("Adds an EventEmitter to the turbo module. See @EventEmitterInitializerDelegate.")
+    void AddEventEmitter(String name, EventEmitterInitializerDelegate emitter);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "SampleTurboModule.h"
+
+namespace Microsoft::ReactNative {
+
+void SampleTurboModule::Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
+  m_reactContext = reactContext;
+}
+
+ReactNativeSpecs::SampleTurboModuleSpec_Constants SampleTurboModule::GetConstants() noexcept {
+  ReactNativeSpecs::SampleTurboModuleSpec_Constants constants;
+  constants.const1 = true;
+  constants.const2 = 375;
+  constants.const3 = "something";
+  return constants;
+}
+
+void SampleTurboModule::voidFunc() noexcept {}
+
+bool SampleTurboModule::getBool(bool arg) noexcept {
+  return arg;
+}
+
+double SampleTurboModule::getEnum(double arg) noexcept {
+  return arg;
+}
+
+double SampleTurboModule::getNumber(double arg) noexcept {
+  return arg;
+}
+
+std::string SampleTurboModule::getString(std::string arg) noexcept {
+  return std::string(arg);
+}
+
+::React::JSValueArray SampleTurboModule::getArray(::React::JSValueArray &&arg) noexcept {
+  return arg.Copy();
+}
+
+::React::JSValue SampleTurboModule::getObject(::React::JSValue &&arg) noexcept {
+  assert(arg.Type() == ::React::JSValueType::Object);
+  return arg.Copy();
+}
+
+::React::JSValue SampleTurboModule::getUnsafeObject(::React::JSValue &&arg) noexcept {
+  assert(arg.Type() == ::React::JSValueType::Object);
+  return arg.Copy();
+}
+
+double SampleTurboModule::getRootTag(double arg) noexcept {
+  // TODO: Proper impl
+  return arg;
+}
+
+::React::JSValue SampleTurboModule::getValue(double x, std::string y, ::React::JSValue &&z) noexcept {
+  return ::React::JSValueObject{
+      {"x", x},
+      {"y", y},
+      {"z", z.Copy()},
+  };
+}
+
+void SampleTurboModule::getValueWithCallback(std::function<void(std::string)> const &callback) noexcept {
+  callback("value from callback!");
+}
+
+void SampleTurboModule::getValueWithPromise(bool error, ::React::ReactPromise<std::string> &&result) noexcept {
+  if (error) {
+    result.Reject("intentional promise rejection");
+  } else {
+    result.Resolve("result!");
+  }
+}
+
+void SampleTurboModule::voidFuncThrows() noexcept {
+  // TODO: Proper impl
+}
+
+::React::JSValue SampleTurboModule::getObjectThrows(::React::JSValue &&arg) noexcept {
+  // TODO: Proper impl
+  return nullptr;
+}
+
+void SampleTurboModule::promiseThrows(::React::ReactPromise<void> &&result) noexcept {
+  // TODO: Proper impl
+}
+
+void SampleTurboModule::voidFuncAssert() noexcept {
+  // TODO: Proper impl
+}
+
+::React::JSValue SampleTurboModule::getObjectAssert(::React::JSValue &&arg) noexcept {
+  // TODO: Proper impl
+  return nullptr;
+}
+
+void SampleTurboModule::promiseAssert(::React::ReactPromise<void> &&result) noexcept {
+  // TODO: Proper impl
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
@@ -18,7 +18,32 @@ ReactNativeSpecs::SampleTurboModuleSpec_Constants SampleTurboModule::GetConstant
   return constants;
 }
 
-void SampleTurboModule::voidFunc() noexcept {}
+void SampleTurboModule::voidFunc() noexcept {
+  onPress();
+  onClick("click");
+
+  /*
+    SampleTurboModuleSpec_ObjectStruct will be added in a future version of SampleTurboModuleSpec
+    Uncomment below when we FI to that version
+  */
+  /*
+  ReactNativeSpecs::SampleTurboModuleSpec_ObjectStruct obj;
+  obj.a = 1;
+  obj.b = "two";
+  onChange(obj);
+
+  ReactNativeSpecs::SampleTurboModuleSpec_ObjectStruct obj2;
+  obj2.a = 3;
+  obj2.b = "four";
+
+  auto writer = winrt::Microsoft::ReactNative::MakeJSValueTreeWriter();
+  writer.WriteArrayBegin();
+  winrt::Microsoft::ReactNative::WriteValue(writer, obj);
+  winrt::Microsoft::ReactNative::WriteValue(writer, obj2);
+  writer.WriteArrayEnd();
+  onSubmit(winrt::Microsoft::ReactNative::TakeJSValue(writer).MoveArray());
+  */
+}
 
 bool SampleTurboModule::getBool(bool arg) noexcept {
   return arg;

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include "codegen/NativeSampleTurboModuleSpec.g.h"
+#include <NativeModules.h>
+
+namespace Microsoft::ReactNative {
+
+REACT_MODULE(SampleTurboModule)
+struct SampleTurboModule {
+  using ModuleSpec = ReactNativeSpecs::SampleTurboModuleSpec;
+
+  REACT_INIT(Initialize)
+  void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
+
+  REACT_GET_CONSTANTS(GetConstants)
+  ReactNativeSpecs::SampleTurboModuleSpec_Constants GetConstants() noexcept;
+
+  REACT_METHOD(voidFunc)
+  void voidFunc() noexcept;
+
+  REACT_SYNC_METHOD(getBool)
+  bool getBool(bool arg) noexcept;
+
+  REACT_SYNC_METHOD(getEnum)
+  double getEnum(double arg) noexcept;
+
+  REACT_SYNC_METHOD(getNumber)
+  double getNumber(double arg) noexcept;
+
+  REACT_SYNC_METHOD(getString)
+  std::string getString(std::string arg) noexcept;
+
+  REACT_SYNC_METHOD(getArray)
+  ::React::JSValueArray getArray(::React::JSValueArray &&arg) noexcept;
+
+  REACT_SYNC_METHOD(getObject)
+  ::React::JSValue getObject(::React::JSValue &&arg) noexcept;
+
+  REACT_SYNC_METHOD(getUnsafeObject)
+  ::React::JSValue getUnsafeObject(::React::JSValue &&arg) noexcept;
+
+  REACT_SYNC_METHOD(getRootTag)
+  double getRootTag(double arg) noexcept;
+
+  REACT_SYNC_METHOD(getValue)
+  ::React::JSValue getValue(double x, std::string y, ::React::JSValue &&z) noexcept;
+
+  REACT_METHOD(getValueWithCallback)
+  void getValueWithCallback(std::function<void(std::string)> const &callback) noexcept;
+
+  REACT_METHOD(getValueWithPromise)
+  void getValueWithPromise(bool error, ::React::ReactPromise<std::string> &&result) noexcept;
+
+  REACT_METHOD(voidFuncThrows)
+  void voidFuncThrows() noexcept;
+
+  REACT_SYNC_METHOD(getObjectThrows)
+  ::React::JSValue getObjectThrows(::React::JSValue &&arg) noexcept;
+
+  REACT_METHOD(promiseThrows)
+  void promiseThrows(::React::ReactPromise<void> &&result) noexcept;
+
+  REACT_METHOD(voidFuncAssert)
+  void voidFuncAssert() noexcept;
+
+  REACT_SYNC_METHOD(getObjectAssert)
+  ::React::JSValue getObjectAssert(::React::JSValue &&arg) noexcept;
+
+  REACT_METHOD(promiseAssert)
+  void promiseAssert(::React::ReactPromise<void> &&result) noexcept;
+
+ private:
+  winrt::Microsoft::ReactNative::ReactContext m_reactContext;
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
@@ -14,6 +14,24 @@ struct SampleTurboModule {
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
+  REACT_EVENT_EMITTER(onPress)
+  std::function<void()> onPress;
+
+  REACT_EVENT_EMITTER(onClick)
+  std::function<void(std::string)> onClick;
+
+  /*
+    SampleTurboModuleSpec_ObjectStruct will be added in a future version of SampleTurboModuleSpec
+    Uncomment below when we FI to that version
+  */
+  /*
+  REACT_EVENT_EMITTER(onChange)
+  std::function<void(ReactNativeSpecs::SampleTurboModuleSpec_ObjectStruct)> onChange;
+
+  REACT_EVENT_EMITTER(onSubmit)
+  std::function<void(winrt::Microsoft::ReactNative::JSValueArray)> onSubmit;
+  */
+
   REACT_GET_CONSTANTS(GetConstants)
   ReactNativeSpecs::SampleTurboModuleSpec_Constants GetConstants() noexcept;
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -39,6 +39,7 @@
 #include "Modules/ExceptionsManager.h"
 #include "Modules/PlatformConstantsWinModule.h"
 #include "Modules/ReactRootViewTagGenerator.h"
+#include "Modules/SampleTurboModule.h"
 #include "Modules/SourceCode.h"
 #include "Modules/StatusBarManager.h"
 #include "Modules/Timing.h"
@@ -410,6 +411,10 @@ void ReactInstanceWin::LoadModules(
   registerTurboModule(
       L"PlatformConstants",
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::PlatformConstants>());
+
+  registerTurboModule(
+      L"SampleTurboModule",
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::SampleTurboModule>());
 
   uint32_t hermesBytecodeVersion = 0;
 #if defined(USE_HERMES) && defined(ENABLE_DEVSERVER_HBCBUNDLES)

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -53,7 +53,7 @@ struct TurboModuleBuilder : winrt::implements<TurboModuleBuilder, IReactModuleBu
     m_methods.insert({key, {returnType, method}});
   }
 
-  void AddEventEmitter(hstring name, EventEmitterInitializerDelegate const &emitter) noexcept {
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept {
     auto key = to_string(name);
     EnsureMemberNotSet(key, true);
     m_eventEmitters.insert({key, emitter});

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -481,6 +481,7 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\PlatformConstantsWinModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ExceptionsManager.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\Timing.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SampleTurboModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SourceCode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\NativeModulesProvider.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactHost\AsyncActionQueue.cpp" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -304,6 +304,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiShadowNode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\PlatformConstantsWinModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ExceptionsManager.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SampleTurboModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SourceCode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\Timing.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\featureflags\ReactNativeFeatureFlags.cpp" />

--- a/vnext/Shared/TurboModuleManager.cpp
+++ b/vnext/Shared/TurboModuleManager.cpp
@@ -30,9 +30,6 @@ std::shared_ptr<TurboModule> TurboModuleManager::getModule(const std::string &mo
     }
   }
 
-  if (moduleName.compare("SampleTurboModule") == 0) {
-    return m_modules.emplace(moduleName, std::make_shared<SampleTurboCxxModule>(m_callInvoker)).first->second;
-  }
   return nullptr;
 }
 


### PR DESCRIPTION
## Description

This PR provides a proper implementation of the `SampleTurboModule` module, with the new EventEmitter events (coming in #13508) and removes the proxy code in `TurboModuleManager` which instead substituted the old `SampleTurboCxxModule` module.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
The APIs of `SampleTurboModule` are starting to deviate from the older `SampleTurboCxxModule`, specifically the addtion of new `EventEmitter` members. So it's time we had a implementation for both.

Closes #13531 
Partial implementation of #13532

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
Verified tests still pass and the new module is being called.

## Changelog
Should this change be included in the release notes: _yes_

Implement the SampleTurboModule module
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13533)