### PR TITLE
[Fabric] Custom ShadowNodes are never released

### DIFF
--- a/change/react-native-windows-47a010c1-a124-470a-8d55-8350642cbff5.json
+++ b/change/react-native-windows-47a010c1-a124-470a-8d55-8350642cbff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Custom ShadowNode's are never released",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.cpp
@@ -30,7 +30,9 @@ winrt::Microsoft::ReactNative::IComponentProps AbiProps::UserProps() const noexc
 ShadowNode::ShadowNode(facebook::react::ShadowNode::Shared shadowNode) noexcept : m_shadowNode(shadowNode) {}
 
 void ShadowNode::EnsureUnsealed() noexcept {
-  m_shadowNode->ensureUnsealed();
+  if (auto shadowNode = m_shadowNode.lock()) {
+    shadowNode->ensureUnsealed();
+  }
 }
 
 winrt::IInspectable ShadowNode::Tag() const noexcept {
@@ -42,20 +44,25 @@ void ShadowNode::Tag(winrt::IInspectable tag) noexcept {
 }
 
 winrt::IInspectable ShadowNode::StateData() const noexcept {
-  auto state = m_shadowNode->getState();
-  react_native_assert(state && "State must not be `nullptr`.");
-  auto abiStateData =
-      static_cast<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData> *>(state.get())
-          ->getData();
-  return abiStateData.userdata;
+  if (auto shadowNode = m_shadowNode.lock()) {
+    auto state = shadowNode->getState();
+    react_native_assert(state && "State must not be `nullptr`.");
+    auto abiStateData =
+        static_cast<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData> *>(state.get())
+            ->getData();
+    return abiStateData.userdata;
+  }
+  return nullptr;
 }
 
 void ShadowNode::StateData(winrt::IInspectable tag) noexcept {
-  m_shadowNode->ensureUnsealed();
+  if (auto shadowNode = m_shadowNode.lock()) {
+    shadowNode->ensureUnsealed();
 
-  auto &state = const_cast<facebook::react::State::Shared &>(m_shadowNode->getState());
-  state = std::make_shared<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData>>(
-      std::make_shared<const ::Microsoft::ReactNative::AbiStateData>(tag), *state);
+    auto &state = const_cast<facebook::react::State::Shared &>(shadowNode->getState());
+    state = std::make_shared<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData>>(
+        std::make_shared<const ::Microsoft::ReactNative::AbiStateData>(tag), *state);
+  }
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.h
@@ -43,7 +43,7 @@ struct ShadowNode : ShadowNodeT<ShadowNode> {
   void StateData(winrt::IInspectable tag) noexcept;
 
  protected:
-  facebook::react::ShadowNode::Shared m_shadowNode;
+  facebook::react::ShadowNode::Weak m_shadowNode;
   winrt::IInspectable m_tag;
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewShadowNode.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewShadowNode.cpp
@@ -17,11 +17,13 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(facebook::react::ShadowNode::
     : base_type(shadowNode) {}
 
 void YogaLayoutableShadowNode::Layout(winrt::Microsoft::ReactNative::LayoutContext layoutContext) noexcept {
-  std::const_pointer_cast<facebook::react::YogaLayoutableShadowNode>(
-      std::dynamic_pointer_cast<const facebook::react::YogaLayoutableShadowNode>(m_shadowNode))
-      ->facebook::react::YogaLayoutableShadowNode::layout(
-          winrt::get_self<winrt::Microsoft::ReactNative::implementation::LayoutContext>(layoutContext)
-              ->m_layoutContext);
+  if (auto shadowNode = m_shadowNode.lock()) {
+    std::const_pointer_cast<facebook::react::YogaLayoutableShadowNode>(
+        std::dynamic_pointer_cast<const facebook::react::YogaLayoutableShadowNode>(shadowNode))
+        ->facebook::react::YogaLayoutableShadowNode::layout(
+            winrt::get_self<winrt::Microsoft::ReactNative::implementation::LayoutContext>(layoutContext)
+                ->m_layoutContext);
+  }
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
## Description
There is a reference cycle between the internal facebook::react::ShadowNode objects and the ABI wrapper.
This replaces the wrappers back ref with a weak_ref, allowing the ShadowNode to be properly released.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13536)