### PR TITLE
Implement the SampleTurboModule module

### DIFF
--- a/change/react-native-windows-6a82bdc7-fdc0-4d57-bd42-cb297ef7a7ea.json
+++ b/change/react-native-windows-6a82bdc7-fdc0-4d57-bd42-cb297ef7a7ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement SampleTurboModule",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "SampleTurboModule.h"
+
+namespace Microsoft::ReactNative {
+
+void SampleTurboModule::Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
+  m_reactContext = reactContext;
+}
+
+ReactNativeSpecs::SampleTurboModuleSpec_Constants SampleTurboModule::GetConstants() noexcept {
+  ReactNativeSpecs::SampleTurboModuleSpec_Constants constants;
+  constants.const1 = true;
+  constants.const2 = 375;
+  constants.const3 = "something";
+  return constants;
+}
+
+void SampleTurboModule::voidFunc() noexcept {}
+
+bool SampleTurboModule::getBool(bool arg) noexcept {
+  return arg;
+}
+
+double SampleTurboModule::getEnum(double arg) noexcept {
+  return arg;
+}
+
+double SampleTurboModule::getNumber(double arg) noexcept {
+  return arg;
+}
+
+std::string SampleTurboModule::getString(std::string arg) noexcept {
+  return std::string(arg);
+}
+
+::React::JSValueArray SampleTurboModule::getArray(::React::JSValueArray &&arg) noexcept {
+  return arg.Copy();
+}
+
+::React::JSValue SampleTurboModule::getObject(::React::JSValue &&arg) noexcept {
+  assert(arg.Type() == ::React::JSValueType::Object);
+  return arg.Copy();
+}
+
+::React::JSValue SampleTurboModule::getUnsafeObject(::React::JSValue &&arg) noexcept {
+  assert(arg.Type() == ::React::JSValueType::Object);
+  return arg.Copy();
+}
+
+double SampleTurboModule::getRootTag(double arg) noexcept {
+  // TODO: Proper impl
+  return arg;
+}
+
+::React::JSValue SampleTurboModule::getValue(double x, std::string y, ::React::JSValue &&z) noexcept {
+  return ::React::JSValueObject{
+      {"x", x},
+      {"y", y},
+      {"z", z.Copy()},
+  };
+}
+
+void SampleTurboModule::getValueWithCallback(std::function<void(std::string)> const &callback) noexcept {
+  callback("value from callback!");
+}
+
+void SampleTurboModule::getValueWithPromise(bool error, ::React::ReactPromise<std::string> &&result) noexcept {
+  if (error) {
+    result.Reject("intentional promise rejection");
+  } else {
+    result.Resolve("result!");
+  }
+}
+
+void SampleTurboModule::voidFuncThrows() noexcept {
+  // TODO: Proper impl
+}
+
+::React::JSValue SampleTurboModule::getObjectThrows(::React::JSValue &&arg) noexcept {
+  // TODO: Proper impl
+  return nullptr;
+}
+
+void SampleTurboModule::promiseThrows(::React::ReactPromise<void> &&result) noexcept {
+  // TODO: Proper impl
+}
+
+void SampleTurboModule::voidFuncAssert() noexcept {
+  // TODO: Proper impl
+}
+
+::React::JSValue SampleTurboModule::getObjectAssert(::React::JSValue &&arg) noexcept {
+  // TODO: Proper impl
+  return nullptr;
+}
+
+void SampleTurboModule::promiseAssert(::React::ReactPromise<void> &&result) noexcept {
+  // TODO: Proper impl
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include "codegen/NativeSampleTurboModuleSpec.g.h"
+#include <NativeModules.h>
+
+namespace Microsoft::ReactNative {
+
+REACT_MODULE(SampleTurboModule)
+struct SampleTurboModule {
+  using ModuleSpec = ReactNativeSpecs::SampleTurboModuleSpec;
+
+  REACT_INIT(Initialize)
+  void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
+
+  REACT_GET_CONSTANTS(GetConstants)
+  ReactNativeSpecs::SampleTurboModuleSpec_Constants GetConstants() noexcept;
+
+  REACT_METHOD(voidFunc)
+  void voidFunc() noexcept;
+
+  REACT_SYNC_METHOD(getBool)
+  bool getBool(bool arg) noexcept;
+
+  REACT_SYNC_METHOD(getEnum)
+  double getEnum(double arg) noexcept;
+
+  REACT_SYNC_METHOD(getNumber)
+  double getNumber(double arg) noexcept;
+
+  REACT_SYNC_METHOD(getString)
+  std::string getString(std::string arg) noexcept;
+
+  REACT_SYNC_METHOD(getArray)
+  ::React::JSValueArray getArray(::React::JSValueArray &&arg) noexcept;
+
+  REACT_SYNC_METHOD(getObject)
+  ::React::JSValue getObject(::React::JSValue &&arg) noexcept;
+
+  REACT_SYNC_METHOD(getUnsafeObject)
+  ::React::JSValue getUnsafeObject(::React::JSValue &&arg) noexcept;
+
+  REACT_SYNC_METHOD(getRootTag)
+  double getRootTag(double arg) noexcept;
+
+  REACT_SYNC_METHOD(getValue)
+  ::React::JSValue getValue(double x, std::string y, ::React::JSValue &&z) noexcept;
+
+  REACT_METHOD(getValueWithCallback)
+  void getValueWithCallback(std::function<void(std::string)> const &callback) noexcept;
+
+  REACT_METHOD(getValueWithPromise)
+  void getValueWithPromise(bool error, ::React::ReactPromise<std::string> &&result) noexcept;
+
+  REACT_METHOD(voidFuncThrows)
+  void voidFuncThrows() noexcept;
+
+  REACT_SYNC_METHOD(getObjectThrows)
+  ::React::JSValue getObjectThrows(::React::JSValue &&arg) noexcept;
+
+  REACT_METHOD(promiseThrows)
+  void promiseThrows(::React::ReactPromise<void> &&result) noexcept;
+
+  REACT_METHOD(voidFuncAssert)
+  void voidFuncAssert() noexcept;
+
+  REACT_SYNC_METHOD(getObjectAssert)
+  ::React::JSValue getObjectAssert(::React::JSValue &&arg) noexcept;
+
+  REACT_METHOD(promiseAssert)
+  void promiseAssert(::React::ReactPromise<void> &&result) noexcept;
+
+ private:
+  winrt::Microsoft::ReactNative::ReactContext m_reactContext;
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -39,6 +39,7 @@
 #include "Modules/ExceptionsManager.h"
 #include "Modules/PlatformConstantsWinModule.h"
 #include "Modules/ReactRootViewTagGenerator.h"
+#include "Modules/SampleTurboModule.h"
 #include "Modules/SourceCode.h"
 #include "Modules/StatusBarManager.h"
 #include "Modules/Timing.h"
@@ -410,6 +411,10 @@ void ReactInstanceWin::LoadModules(
   registerTurboModule(
       L"PlatformConstants",
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::PlatformConstants>());
+
+  registerTurboModule(
+      L"SampleTurboModule",
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::SampleTurboModule>());
 
   uint32_t hermesBytecodeVersion = 0;
 #if defined(USE_HERMES) && defined(ENABLE_DEVSERVER_HBCBUNDLES)

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -481,6 +481,7 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\PlatformConstantsWinModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ExceptionsManager.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\Timing.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SampleTurboModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SourceCode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\NativeModulesProvider.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactHost\AsyncActionQueue.cpp" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -304,6 +304,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiShadowNode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\PlatformConstantsWinModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ExceptionsManager.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SampleTurboModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SourceCode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\Timing.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\featureflags\ReactNativeFeatureFlags.cpp" />

--- a/vnext/Shared/TurboModuleManager.cpp
+++ b/vnext/Shared/TurboModuleManager.cpp
@@ -30,9 +30,6 @@ std::shared_ptr<TurboModule> TurboModuleManager::getModule(const std::string &mo
     }
   }
 
-  if (moduleName.compare("SampleTurboModule") == 0) {
-    return m_modules.emplace(moduleName, std::make_shared<SampleTurboCxxModule>(m_callInvoker)).first->second;
-  }
   return nullptr;
 }
 


### PR DESCRIPTION
## Description

This PR provides a proper implementation of the `SampleTurboModule` module and removes the proxy code in `TurboModuleManager` which instead substituted the old `SampleTurboCxxModule` module.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
The APIs of `SampleTurboModule` are starting to deviate from the older `SampleTurboCxxModule`, specifically the addition of new `EventEmitter` members. So it's time we had a "real" implementation of `SampleTurboModule`.

Closes #13531 

### What
See above.

## Screenshots
N/A

## Testing
Verified tests still pass and the new module is being called.

## Changelog
Should this change be included in the release notes: _yes_

Implement the SampleTurboModule module
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13541)