### PR TITLE
Make Fetch integration test handle UTF-8 content

### DIFF
--- a/change/react-native-windows-b3755ae4-83be-44b9-ad2d-9f809f9aba5b.json
+++ b/change/react-native-windows-b3755ae4-83be-44b9-ad2d-9f809f9aba5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make Fetch integration test handle UTF-8 content.",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/TestWebSite/wwwroot/static/utf-8.json
+++ b/vnext/TestWebSite/wwwroot/static/utf-8.json
@@ -1,0 +1,5 @@
+{
+  "IDS_ERR_CHANGES_SAVED": "Изменения сохранены.",
+  "IDS_ERR_CHANGES_NOT_SAVED": "Ошибка при сохранении изменений.",
+  "IDS_ERR_SOMETHING_WRONG": "Что-то пошло не так :("
+}

--- a/vnext/TestWebSite/wwwroot/static/utf-8.txt
+++ b/vnext/TestWebSite/wwwroot/static/utf-8.txt
@@ -1,0 +1,1 @@
+IDS_ERR_CHANGES_SAVED : Изменения сохранены

--- a/vnext/src-win/IntegrationTests/FetchTest.js
+++ b/vnext/src-win/IntegrationTests/FetchTest.js
@@ -15,8 +15,9 @@ const {AppRegistry, View} = ReactNative;
 const {TestModule} = ReactNative.NativeModules;
 
 const uri =
-  'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml';
-const expectedContent = 'enableScripts: false';
+  'http://localhost:5555/static/utf-8.txt';
+const expectedContent = "IDS_ERR_CHANGES_SAVED : Изменения сохранены\n";
+
 
 type State = {
   uri: string,
@@ -26,8 +27,6 @@ type State = {
 
 class FetchTest extends React.Component<{...}, State> {
   state: State = {
-    uri: 'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml',
-    expected: 'enableScripts: false',
     content: '',
   };
 


### PR DESCRIPTION
## Description

Update the content and remote endpoint for the `fetch` Desktop integration test.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
- There is no current test for `fetch` / Blob implicit non-ASCII text response handling.

### What
- Validates UTF-8 non-ASCII content when using `fetch`.
- Shifts test to local web server.

## Testing
- Updated Fetch Desktop integration test.
