### PR TITLE
Add support for turbomodule eventemitters, and codegen

### DIFF
--- a/change/@react-native-windows-codegen-ae4b2a67-9881-42db-ab82-02d7d2374e43.json
+++ b/change/@react-native-windows-codegen-ae4b2a67-9881-42db-ab82-02d7d2374e43.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for turbomodule eventemitters, and codegen",
+  "packageName": "@react-native-windows/codegen",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-69671805-a682-4e35-8999-c68f20b14b74.json
+++ b/change/react-native-windows-69671805-a682-4e35-8999-c68f20b14b74.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for turbomodule eventemitters, and codegen",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -118,11 +118,11 @@ export function createNM2Generator({
         });
         let tuples = `
   static constexpr auto methods = std::tuple{
-${methods[0]}
+${methods.traversedPropertyTuples}${methods.traversedEventEmitterTuples ? '\n' : ''}${methods.traversedEventEmitterTuples}
   };`;
         let checks = `
     constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();`;
-        let errors = methods[1];
+        let errors = methods.traversedProperties + (methods.traversedEventEmitters ? '\n' : '') + methods.traversedEventEmitters;
 
         // prepare constants
         const constants = generateValidateConstants(nativeModule, aliases);

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -155,28 +155,24 @@ function translateEventEmitterArray(
   target: ParamTarget,
   options: CppCodegenOptions,
 ): string {
-  if (param.elementType) {
-    switch (target) {
-      case 'spec':
-      case 'template':
-        return `std::vector<${translateEventEmitterParam(
-          param.elementType as NativeModuleEventEmitterBaseTypeAnnotation,
-          aliases,
-          `${baseAliasName}_element`,
-          'template',
-          options,
-        )}>`;
-      default:
-        return `std::vector<${translateEventEmitterParam(
-          param.elementType as NativeModuleEventEmitterBaseTypeAnnotation,
-          aliases,
-          `${baseAliasName}_element`,
-          'template',
-          options,
-        )}> const &`;
-    }
-  } else {
-    return decorateType('::React::JSValueArray', target);
+  switch (target) {
+    case 'spec':
+    case 'template':
+      return `std::vector<${translateEventEmitterParam(
+        param.elementType as NativeModuleEventEmitterBaseTypeAnnotation,
+        aliases,
+        `${baseAliasName}_element`,
+        'template',
+        options,
+      )}>`;
+    default:
+      return `std::vector<${translateEventEmitterParam(
+        param.elementType as NativeModuleEventEmitterBaseTypeAnnotation,
+        aliases,
+        `${baseAliasName}_element`,
+        'template',
+        options,
+      )}> const &`;
   }
 }
 

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -10,6 +10,8 @@ import type {
   NamedShape,
   NativeModuleArrayTypeAnnotation,
   NativeModuleBaseTypeAnnotation,
+  NativeModuleEventEmitterBaseTypeAnnotation,
+  NativeModuleEventEmitterTypeAnnotation,
   NativeModuleEnumDeclaration,
   NativeModuleFunctionTypeAnnotation,
   NativeModuleParamTypeAnnotation,
@@ -141,6 +143,43 @@ function translateArray(
   }
 }
 
+// Hopefully eventually NativeModuleEventEmitterTypeAnnotation will align better with NativeModuleParamTypeAnnotation
+// and this method can be merged / replaced with translateArray
+function translateEventEmitterArray(
+  param: {
+    readonly type: 'ArrayTypeAnnotation';
+    readonly elementType: NativeModuleEventEmitterBaseTypeAnnotation | {type: string};
+  },
+  aliases: AliasMap,
+  baseAliasName: string,
+  target: ParamTarget,
+  options: CppCodegenOptions,
+): string {
+  if (param.elementType) {
+    switch (target) {
+      case 'spec':
+      case 'template':
+        return `std::vector<${translateEventEmitterParam(
+          param.elementType as NativeModuleEventEmitterBaseTypeAnnotation,
+          aliases,
+          `${baseAliasName}_element`,
+          'template',
+          options,
+        )}>`;
+      default:
+        return `std::vector<${translateEventEmitterParam(
+          param.elementType as NativeModuleEventEmitterBaseTypeAnnotation,
+          aliases,
+          `${baseAliasName}_element`,
+          'template',
+          options,
+        )}> const &`;
+    }
+  } else {
+    return decorateType('::React::JSValueArray', target);
+  }
+}
+
 function translateParam(
   param: NativeModuleParamTypeAnnotation,
   aliases: AliasMap,
@@ -188,6 +227,39 @@ function translateParam(
     case 'EnumDeclaration':
     case 'UnionTypeAnnotation':
       return translateUnionReturnType(param, target, options);
+    default:
+      throw new Error(`Unhandled type in translateParam: ${paramType}`);
+  }
+}
+
+// Hopefully eventually NativeModuleEventEmitterTypeAnnotation will align better with NativeModuleParamTypeAnnotation
+// and this method can be merged / replaced with translateParam
+function translateEventEmitterParam(
+  param: NativeModuleEventEmitterTypeAnnotation,
+  aliases: AliasMap,
+  baseAliasName: string,
+  target: ParamTarget,
+  options: CppCodegenOptions,
+): string {
+  // avoid: Property 'type' does not exist on type 'never'
+  const paramType = param.type;
+  switch (param.type) {
+    case 'StringTypeAnnotation':
+      return options.cppStringType;
+    case 'NumberTypeAnnotation':
+    case 'FloatTypeAnnotation':
+    case 'DoubleTypeAnnotation':
+      return 'double';
+    case 'Int32TypeAnnotation':
+      return 'int';
+    case 'BooleanTypeAnnotation':
+      return 'bool';
+    case 'ArrayTypeAnnotation':
+      return translateEventEmitterArray(param, aliases, baseAliasName, target, options);
+    case 'TypeAliasTypeAnnotation':
+      return decorateType(getAliasCppName(param.name), target);
+    case 'VoidTypeAnnotation':
+      return 'void';
     default:
       throw new Error(`Unhandled type in translateParam: ${paramType}`);
   }
@@ -278,6 +350,22 @@ export function translateSpecArgs(
     );
     return `${translatedParam}`;
   });
+}
+
+export function translateEventEmitterArgs(
+  params: NativeModuleEventEmitterTypeAnnotation,
+  aliases: AliasMap,
+  baseAliasName: string,
+  options: CppCodegenOptions,
+) {
+    const translatedParam = translateEventEmitterParam(
+      params,
+      aliases,
+      baseAliasName,
+      'spec',
+      options,
+    );
+    return `${translatedParam}`;
 }
 
 export function translateArgs(

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -7,13 +7,14 @@
 'use strict';
 
 import type {
+  NativeModuleEventEmitterShape,
   NativeModuleFunctionTypeAnnotation,
   NativeModulePropertyShape,
   NativeModuleSchema,
 } from '@react-native/codegen/lib/CodegenSchema';
 import {AliasMap} from './AliasManaging';
 import type {CppCodegenOptions} from './ObjectTypes';
-import {translateArgs, translateSpecArgs} from './ParamTypes';
+import {translateArgs, translateSpecArgs, translateEventEmitterArgs} from './ParamTypes';
 import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
 
 function isMethodSync(funcType: NativeModuleFunctionTypeAnnotation) {
@@ -91,9 +92,9 @@ function renderProperties(
   aliases: AliasMap,
   tuple: boolean,
   options: CppCodegenOptions,
-): string {
+): { code: string, numberOfProperties: number } {
   // TODO: generate code for constants
-  return methods
+  const properties = methods
     .filter(prop => prop.name !== 'getConstants')
     .map((prop, index) => {
       // TODO: prop.optional === true
@@ -151,6 +152,66 @@ function renderProperties(
             options,
           )});`;
       }
+    });
+
+    return {code: properties.join('\n'), numberOfProperties: properties.length};
+}
+
+function getPossibleEventEmitterSignatures(
+  eventEmitter: NativeModuleEventEmitterShape,
+  aliases: AliasMap,
+  options: CppCodegenOptions): string[] {
+  
+  const traversedArgs = translateEventEmitterArgs(
+    eventEmitter.typeAnnotation.typeAnnotation,
+    aliases,
+    eventEmitter.name,
+    options,
+  );
+  return [`REACT_EVENT(${eventEmitter.name}) std::function<void(${traversedArgs})> ${eventEmitter.name};`]
+}
+
+function translatePossibleEventSignatures(
+  eventEmitter: NativeModuleEventEmitterShape,
+  aliases: AliasMap,
+  options: CppCodegenOptions): string {
+  return getPossibleEventEmitterSignatures(
+    eventEmitter,
+    aliases,
+    options
+  )
+    .map(sig => `"    ${sig}\\n"`)
+    .join('\n          ');
+}
+
+function renderEventEmitters(
+  eventEmitters: ReadonlyArray<NativeModuleEventEmitterShape>,
+  indexOffset: number,
+  aliases: AliasMap,
+  tuple: boolean,
+  options: CppCodegenOptions,
+): string {
+  return eventEmitters
+    .map((eventEmitter, index) => {
+      const traversedArgs = translateEventEmitterArgs(
+        eventEmitter.typeAnnotation.typeAnnotation,
+        aliases,
+        eventEmitter.name,
+        options,
+      );
+
+      if (tuple) {
+        return `      EventEmitter<void(${traversedArgs})>{${index + indexOffset}, L"${eventEmitter.name}"},`;
+      } else {
+        return `    REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(
+          ${index + indexOffset},
+          "${eventEmitter.name}",
+          ${translatePossibleEventSignatures(
+            eventEmitter,
+            aliases,
+            options,
+      )});`;
+      }
     })
     .join('\n');
 }
@@ -159,10 +220,23 @@ export function generateValidateMethods(
   nativeModule: NativeModuleSchema,
   aliases: AliasMap,
   options: CppCodegenOptions,
-): [string, string] {
+): {
+  traversedProperties: string,
+  traversedEventEmitters: string,
+  traversedPropertyTuples: string,
+  traversedEventEmitterTuples: string,
+} {
   const methods = nativeModule.spec.methods;
+  const eventEmitters = nativeModule.spec.eventEmitters;
   const traversedProperties = renderProperties(
     methods,
+    aliases,
+    false,
+    options,
+  );
+  const traversedEventEmitters = renderEventEmitters(
+    eventEmitters,
+    traversedProperties.numberOfProperties,
     aliases,
     false,
     options,
@@ -173,5 +247,12 @@ export function generateValidateMethods(
     true,
     options,
   );
-  return [traversedPropertyTuples, traversedProperties];
+  const traversedEventEmitterTuples = renderEventEmitters(
+    eventEmitters,
+    traversedProperties.numberOfProperties,
+    aliases,
+    true,
+    options,
+  );
+  return {traversedPropertyTuples: traversedPropertyTuples.code, traversedEventEmitterTuples, traversedProperties: traversedProperties.code, traversedEventEmitters};
 }

--- a/packages/@react-native-windows/tester/src/js/examples/TurboModule/SampleTurboModuleExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TurboModule/SampleTurboModuleExample.windows.js
@@ -225,8 +225,6 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
     Windows]
     */
 
-    /*
-    [Windows Wee need to implement both a proper SampleTurboModule (issue #13531) and add EventEmitter support (issue #13532)
     this.eventSubscriptions.push(
       NativeSampleTurboModule.onPress(value => console.log('onPress: ()')),
     );
@@ -245,8 +243,6 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
         console.log(`onSubmit: (${JSON.stringify(value)})`),
       ),
     );
-    Windows]
-    */
   }
 
   componentWillUnmount() {

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
@@ -84,6 +84,8 @@ void ReactModuleBuilderMock::AddSyncMethod(hstring const &name, SyncMethodDelega
   m_syncMethods.emplace(name, method);
 }
 
+void ReactModuleBuilderMock::AddEventEmitter(hstring const &, EventEmitterInitializerDelegate const &) noexcept {}
+
 JSValueObject ReactModuleBuilderMock::GetConstants() noexcept {
   auto constantWriter = MakeJSValueTreeWriter();
   constantWriter.WriteObjectBegin();

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -219,6 +219,7 @@ struct ReactModuleBuilderImpl : implements<ReactModuleBuilderImpl, IReactModuleB
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept;
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept;
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept;
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept;
 
  private:
   ReactModuleBuilderMock &m_mock;
@@ -351,6 +352,12 @@ inline void ReactModuleBuilderImpl::AddMethod(
 
 inline void ReactModuleBuilderImpl::AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept {
   m_mock.AddSyncMethod(name, method);
+}
+
+inline void ReactModuleBuilderImpl::AddEventEmitter(
+    hstring const &name,
+    EventEmitterInitializerDelegate const &emitter) noexcept {
+  m_mock.AddEventEmitter(name, emitter);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -73,6 +73,7 @@ struct ReactModuleBuilderMock {
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept;
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept;
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept;
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept;
 
  private:
   MethodDelegate GetMethod0(std::wstring const &methodName) const noexcept;

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
@@ -17,7 +17,7 @@ ModuleRegistration::ModuleRegistration(wchar_t const *moduleName) noexcept : m_m
 
 void AddAttributedModules(IReactPackageBuilder const &packageBuilder, bool useTurboModules) noexcept {
   for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
-    if (useTurboModules)
+    if (useTurboModules || reg->ShouldRegisterAsTurboModule())
       packageBuilder.AddTurboModule(reg->ModuleName(), reg->MakeModuleProvider());
     else
       packageBuilder.AddModule(reg->ModuleName(), reg->MakeModuleProvider());
@@ -30,7 +30,7 @@ bool TryAddAttributedModule(
     bool useTurboModule) noexcept {
   for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
     if (moduleName == reg->ModuleName()) {
-      if (useTurboModule) {
+      if (useTurboModule || reg->ShouldRegisterAsTurboModule()) {
         packageBuilder.AddTurboModule(moduleName, reg->MakeModuleProvider());
       } else {
         packageBuilder.AddModule(moduleName, reg->MakeModuleProvider());

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -17,8 +17,12 @@
 // The macros below are internal implementation details for macro defined in nativeModules.h
 //
 
-template <class T>
+template <typename T>
 struct IsReactTurboModule;
+
+// Default to false if no specific override
+template <typename T>
+struct IsReactTurboModule : std::false_type {};
 
 #define INTERNAL_REACT_MODULE_REGISTRATION_AND_PROVIDER(                                                            \
     moduleStruct, moduleName, eventEmitterName, isReactTurboModule)                                                 \

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -197,17 +197,18 @@
       methodCheckResults[index].IsSignatureMatching,                                                        \
       "Method '" methodName "' does not match signature" REACT_SHOW_SYNC_METHOD_SIGNATURES(methodName, signatures));
 
-#define REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(index, methodName, signatures)                                 \
-  static_assert(                                                                                           \
-      methodCheckResults[index].IsTurboModule,                                                             \
-      "Name '" methodName                                                                                  \
-      "' requires that the module be a TurboModule.  Use REACT_TURBO_MODULE rather than REACT_MODULE");    \
-  static_assert(                                                                                           \
-      methodCheckResults[index].IsMethodFound,                                                             \
-      "Event '" methodName "' is not defined" REACT_SHOW_EVENTEMITTER_SIGNATURES(methodName, signatures)); \
-  static_assert(                                                                                           \
-      methodCheckResults[index].IsSignatureMatching,                                                       \
-      "Event '" methodName "' does not match signature" REACT_SHOW_EVENTEMITTER_SIGNATURES(methodName, signatures));
+#define REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(index, methodName, signatures)                                        \
+  static_assert(                                                                                                  \
+      methodCheckResults[index].IsTurboModule,                                                                    \
+      "EventEmitter '" methodName                                                                                 \
+      "' requires that the module be a TurboModule.  Use REACT_TURBO_MODULE rather than REACT_MODULE");           \
+  static_assert(                                                                                                  \
+      methodCheckResults[index].IsMethodFound,                                                                    \
+      "EventEmitter '" methodName "' is not defined" REACT_SHOW_EVENTEMITTER_SIGNATURES(methodName, signatures)); \
+  static_assert(                                                                                                  \
+      methodCheckResults[index].IsSignatureMatching,                                                              \
+      "EventEmitter '" methodName                                                                                 \
+      "' does not match signature" REACT_SHOW_EVENTEMITTER_SIGNATURES(methodName, signatures));
 
 //
 // Code below helps to register React Native modules and verify method signatures

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -28,12 +28,12 @@
 // It can be any struct which can be instantiated using a default constructor.
 // Note that it must be a 'struct', not 'class' because macro does a forward declaration using the 'struct' keyword.
 //
-// REACT_EVENTs within a REACT_MODULE will trigger an event on a global event emitter, such as ECTDeviceEventEmitter.
+// REACT_EVENTs within a REACT_MODULE will trigger an event on a global event emitter, such as RCTDeviceEventEmitter.
 // To use the newer EventEmitters exposed directly on this module, use REACT_TURBO_MODULE instead.
 #define REACT_MODULE(/* moduleStruct, [opt] moduleName, [opt] eventEmitterName */...) \
   INTERNAL_REACT_MODULE(__VA_ARGS__)(__VA_ARGS__)
 
-// REACT_TURBO_MODULE(moduleStruct, [opt] moduleName, [opt] eventEmitterName)
+// REACT_TURBO_MODULE(moduleStruct, [opt] moduleName)
 // Arguments:
 // - moduleStruct (required) - the struct name the macro is attached to.
 // - moduleName (optional) - the module name visible to JavaScript. Default is the moduleStruct name.
@@ -166,7 +166,7 @@
   "\" to the attribute:\n"                                                        \
   "    REACT_SYNC_METHOD(method, L\"" methodName "\")\n...\n"
 
-#define REACT_SHOW_EVENTEMITTER_SIGNATURES(eventName, signatures)                \
+#define REACT_SHOW_EVENT_SIGNATURES(eventName, signatures)                \
   " (see details below in output).\n"                                            \
   "  It must be one of the following:\n" signatures                              \
   "  The C++ member name could be different. In that case add the L\"" eventName \
@@ -204,11 +204,11 @@
       "' requires that the module be a TurboModule.  Use REACT_TURBO_MODULE rather than REACT_MODULE");           \
   static_assert(                                                                                                  \
       methodCheckResults[index].IsMethodFound,                                                                    \
-      "EventEmitter '" methodName "' is not defined" REACT_SHOW_EVENTEMITTER_SIGNATURES(methodName, signatures)); \
+      "EventEmitter '" methodName "' is not defined" REACT_SHOW_EVENT_SIGNATURES(methodName, signatures)); \
   static_assert(                                                                                                  \
       methodCheckResults[index].IsSignatureMatching,                                                              \
       "EventEmitter '" methodName                                                                                 \
-      "' does not match signature" REACT_SHOW_EVENTEMITTER_SIGNATURES(methodName, signatures));
+      "' does not match signature" REACT_SHOW_EVENT_SIGNATURES(methodName, signatures));
 
 //
 // Code below helps to register React Native modules and verify method signatures

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -166,7 +166,7 @@
   "\" to the attribute:\n"                                                        \
   "    REACT_SYNC_METHOD(method, L\"" methodName "\")\n...\n"
 
-#define REACT_SHOW_EVENT_SIGNATURES(eventName, signatures)                \
+#define REACT_SHOW_EVENT_SIGNATURES(eventName, signatures)                       \
   " (see details below in output).\n"                                            \
   "  It must be one of the following:\n" signatures                              \
   "  The C++ member name could be different. In that case add the L\"" eventName \
@@ -197,18 +197,17 @@
       methodCheckResults[index].IsSignatureMatching,                                                        \
       "Method '" methodName "' does not match signature" REACT_SHOW_SYNC_METHOD_SIGNATURES(methodName, signatures));
 
-#define REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(index, methodName, signatures)                                        \
-  static_assert(                                                                                                  \
-      methodCheckResults[index].IsTurboModule,                                                                    \
-      "EventEmitter '" methodName                                                                                 \
-      "' requires that the module be a TurboModule.  Use REACT_TURBO_MODULE rather than REACT_MODULE");           \
-  static_assert(                                                                                                  \
-      methodCheckResults[index].IsMethodFound,                                                                    \
+#define REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(index, methodName, signatures)                                 \
+  static_assert(                                                                                           \
+      methodCheckResults[index].IsTurboModule,                                                             \
+      "EventEmitter '" methodName                                                                          \
+      "' requires that the module be a TurboModule.  Use REACT_TURBO_MODULE rather than REACT_MODULE");    \
+  static_assert(                                                                                           \
+      methodCheckResults[index].IsMethodFound,                                                             \
       "EventEmitter '" methodName "' is not defined" REACT_SHOW_EVENT_SIGNATURES(methodName, signatures)); \
-  static_assert(                                                                                                  \
-      methodCheckResults[index].IsSignatureMatching,                                                              \
-      "EventEmitter '" methodName                                                                                 \
-      "' does not match signature" REACT_SHOW_EVENT_SIGNATURES(methodName, signatures));
+  static_assert(                                                                                           \
+      methodCheckResults[index].IsSignatureMatching,                                                       \
+      "EventEmitter '" methodName "' does not match signature" REACT_SHOW_EVENT_SIGNATURES(methodName, signatures));
 
 //
 // Code below helps to register React Native modules and verify method signatures

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -70,6 +70,10 @@ namespace Microsoft.ReactNative.Managed.UnitTests
       m_syncMethods.Add(name, method);
     }
 
+    public void AddEventEmitter(string name, EventEmitterInitializerDelegate emitter)
+    {
+    }
+
     public void Call0(string methodName) =>
         GetMethod0(methodName)?.Invoke(ArgReader(), ArgWriter(), null, null);
 

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -129,6 +129,11 @@ void ReactModuleBuilder::AddSyncMethod(hstring const &name, SyncMethodDelegate c
   m_methods.push_back(std::move(cxxMethod));
 }
 
+void ReactModuleBuilder::AddEventEmitter(hstring const &, EventEmitterInitializerDelegate const &) {
+  throw std::runtime_error(
+      "This module requires that it is registered as a TurboModule. If the module is being manually registered ensure you are using packageBuilder.AddTurboModule instead of packageBuilder.AddModule.");
+}
+
 /*static*/ MethodResultCallback ReactModuleBuilder::MakeMethodResultCallback(CxxModule::Callback &&callback) noexcept {
   if (callback) {
     return [callback = std::move(callback)](const IJSValueWriter &outputWriter) noexcept {

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.h
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.h
@@ -15,6 +15,7 @@ struct ReactModuleBuilder : winrt::implements<ReactModuleBuilder, IReactModuleBu
   void AddConstantProvider(ConstantProviderDelegate const &constantProvider) noexcept;
   void AddMethod(hstring const &name, MethodReturnType returnType, MethodDelegate const &method) noexcept;
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept;
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter);
 
  public:
   std::unique_ptr<facebook::xplat::module::CxxModule> MakeCxxModule(

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
@@ -34,6 +34,12 @@ namespace Microsoft.ReactNative
       MethodResultCallback resolve,
       MethodResultCallback reject);
 
+  DOC_STRING("A delegate gets the arguments for an event emit on a EventEmitter.")
+  delegate void EmitEventSetterDelegate(JSValueArgWriter argWriter);
+
+  DOC_STRING("A delegate to call a turbo module EventEmitter.")
+  delegate void EventEmitterInitializerDelegate(EmitEventSetterDelegate emitter);
+
   DOC_STRING("A delegate to call native synchronous method.")
   delegate void SyncMethodDelegate(IJSValueReader inputReader, IJSValueWriter outputWriter);
 
@@ -62,5 +68,8 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Adds a synchronous method to the native module. See @SyncMethodDelegate.")
     void AddSyncMethod(String name, SyncMethodDelegate method);
+
+    DOC_STRING("Adds an EventEmitter to the turbo module. See @EventEmitterInitializerDelegate.")
+    void AddEventEmitter(String name, EventEmitterInitializerDelegate emitter);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.cpp
@@ -18,7 +18,24 @@ ReactNativeSpecs::SampleTurboModuleSpec_Constants SampleTurboModule::GetConstant
   return constants;
 }
 
-void SampleTurboModule::voidFunc() noexcept {}
+void SampleTurboModule::voidFunc() noexcept {
+  onPress();
+  onClick("click");
+
+  ReactNativeSpecs::SampleTurboModuleSpec_ObjectStruct obj;
+  obj.a = 1;
+  obj.b = "two";
+  onChange(obj);
+  ReactNativeSpecs::SampleTurboModuleSpec_ObjectStruct obj2;
+  obj2.a = 3;
+  obj2.b = "four";
+  auto writer = winrt::Microsoft::ReactNative::MakeJSValueTreeWriter();
+  writer.WriteArrayBegin();
+  winrt::Microsoft::ReactNative::WriteValue(writer, obj);
+  winrt::Microsoft::ReactNative::WriteValue(writer, obj2);
+  writer.WriteArrayEnd();
+  onSubmit(winrt::Microsoft::ReactNative::TakeJSValue(writer).MoveArray());
+}
 
 bool SampleTurboModule::getBool(bool arg) noexcept {
   return arg;

--- a/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/SampleTurboModule.h
@@ -7,12 +7,24 @@
 
 namespace Microsoft::ReactNative {
 
-REACT_MODULE(SampleTurboModule)
+REACT_TURBO_MODULE(SampleTurboModule)
 struct SampleTurboModule {
   using ModuleSpec = ReactNativeSpecs::SampleTurboModuleSpec;
 
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
+
+  REACT_EVENT(onPress)
+  std::function<void()> onPress;
+
+  REACT_EVENT(onClick)
+  std::function<void(std::string)> onClick;
+
+  REACT_EVENT(onChange)
+  std::function<void(ReactNativeSpecs::SampleTurboModuleSpec_ObjectStruct)> onChange;
+
+  REACT_EVENT(onSubmit)
+  std::function<void(winrt::Microsoft::ReactNative::JSValueArray)> onSubmit;
 
   REACT_GET_CONSTANTS(GetConstants)
   ReactNativeSpecs::SampleTurboModuleSpec_Constants GetConstants() noexcept;

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -8,7 +8,9 @@
 #include "pch.h"
 #include "TurboModulesProvider.h"
 #include <ReactCommon/TurboModuleUtils.h>
+#include <react/bridging/EventEmitter.h>
 #include "JSDispatcherWriter.h"
+#include "JSValueWriter.h"
 #include "JsiApi.h"
 #include "JsiReader.h"
 #include "JsiWriter.h"
@@ -51,6 +53,12 @@ struct TurboModuleBuilder : winrt::implements<TurboModuleBuilder, IReactModuleBu
     m_methods.insert({key, {returnType, method}});
   }
 
+  void AddEventEmitter(hstring const &name, EventEmitterInitializerDelegate const &emitter) noexcept {
+    auto key = to_string(name);
+    EnsureMemberNotSet(key, true);
+    m_eventEmitters.insert({key, emitter});
+  }
+
   void AddSyncMethod(hstring const &name, SyncMethodDelegate const &method) noexcept {
     auto key = to_string(name);
     EnsureMemberNotSet(key, true);
@@ -70,10 +78,15 @@ struct TurboModuleBuilder : winrt::implements<TurboModuleBuilder, IReactModuleBu
     return m_constantProviders;
   }
 
+  const std::unordered_map<std::string, EventEmitterInitializerDelegate> &EventEmitters() const noexcept {
+    return m_eventEmitters;
+  }
+
  private:
   void EnsureMemberNotSet(const std::string &key, bool checkingMethod) noexcept {
     VerifyElseCrash(m_methods.find(key) == m_methods.end());
     VerifyElseCrash(m_syncMethods.find(key) == m_syncMethods.end());
+    VerifyElseCrash(m_eventEmitters.find(key) == m_eventEmitters.end());
     if (checkingMethod && key == "getConstants") {
       VerifyElseCrash(m_constantProviders.size() == 0);
     }
@@ -81,6 +94,7 @@ struct TurboModuleBuilder : winrt::implements<TurboModuleBuilder, IReactModuleBu
 
  private:
   IReactContext m_reactContext;
+  std::unordered_map<std::string, EventEmitterInitializerDelegate> m_eventEmitters;
   std::unordered_map<std::string, TurboModuleMethodInfo> m_methods;
   std::unordered_map<std::string, SyncMethodDelegate> m_syncMethods;
   std::vector<ConstantProviderDelegate> m_constantProviders;
@@ -373,6 +387,36 @@ class TurboModuleImpl : public facebook::react::TurboModule {
       }
     }
 
+    {
+      // try to find an event
+      auto it = m_moduleBuilder->EventEmitters().find(key);
+      if (it != m_moduleBuilder->EventEmitters().end()) {
+        // See if we have an existing eventEmitter
+        auto itEmitter = m_eventEmitters.find(key);
+        if (itEmitter == m_eventEmitters.end()) {
+          m_eventEmitters[key] = std::make_shared<facebook::react::AsyncEventEmitter<facebook::jsi::Value>>();
+
+          itEmitter = m_eventEmitters.find(key);
+
+          it->second([emitter = std::static_pointer_cast<facebook::react::AsyncEventEmitter<facebook::jsi::Value>>(
+                          itEmitter->second),
+                      jsInvoker = jsInvoker_](const JSValueArgWriter &eventDelegate) {
+            auto argWriter = MakeJSValueTreeWriter();
+            eventDelegate(argWriter);
+            emitter->emit(
+                [jsInvoker, eventDelegate, jsValue = std::make_shared<JSValue>(TakeJSValue(argWriter))](
+                    facebook::jsi::Runtime &rt) -> facebook::jsi::Value {
+                  auto argWriter = winrt::make<JsiWriter>(rt);
+                  WriteValue(argWriter, *jsValue);
+                  return argWriter.as<JsiWriter>()->MoveResult();
+                });
+          });
+        }
+
+        return itEmitter->second->get(runtime, jsInvoker_);
+      }
+    }
+
     // returns undefined if the expected member is not found
     return facebook::jsi::Value::undefined();
   }
@@ -408,6 +452,7 @@ class TurboModuleImpl : public facebook::react::TurboModule {
   IReactContext m_reactContext;
   winrt::com_ptr<TurboModuleBuilder> m_moduleBuilder;
   IInspectable m_providedModule;
+  std::unordered_map<std::string, std::shared_ptr<facebook::react::IAsyncEventEmitter>> m_eventEmitters;
   std::shared_ptr<implementation::HostObjectWrapper> m_hostObjectWrapper;
   std::weak_ptr<facebook::react::LongLivedObjectCollection> m_longLivedObjectCollection;
 };

--- a/vnext/codegen/NativeSampleTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeSampleTurboModuleSpec.g.h
@@ -67,6 +67,10 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void() noexcept>{15, L"voidFuncAssert"},
       SyncMethod<::React::JSValue(::React::JSValue) noexcept>{16, L"getObjectAssert"},
       Method<void(Promise<void>) noexcept>{17, L"promiseAssert"},
+      EventEmitter<void(void)>{18, L"onPress"},
+      EventEmitter<void(std::string)>{19, L"onClick"},
+      EventEmitter<void(SampleTurboModuleSpec_ObjectStruct)>{20, L"onChange"},
+      EventEmitter<void(std::vector<SampleTurboModuleSpec_ObjectStruct>)>{21, L"onSubmit"},
   };
 
   template <class TModule>
@@ -170,6 +174,22 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "promiseAssert",
           "    REACT_METHOD(promiseAssert) void promiseAssert(::React::ReactPromise<void> &&result) noexcept { /* implementation */ }\n"
           "    REACT_METHOD(promiseAssert) static void promiseAssert(::React::ReactPromise<void> &&result) noexcept { /* implementation */ }\n");
+    REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(
+          18,
+          "onPress",
+          "    REACT_EVENT(onPress) std::function<void(void)> onPress;\n");
+    REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(
+          19,
+          "onClick",
+          "    REACT_EVENT(onClick) std::function<void(std::string)> onClick;\n");
+    REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(
+          20,
+          "onChange",
+          "    REACT_EVENT(onChange) std::function<void(SampleTurboModuleSpec_ObjectStruct)> onChange;\n");
+    REACT_SHOW_EVENTEMITTER_SPEC_ERRORS(
+          21,
+          "onSubmit",
+          "    REACT_EVENT(onSubmit) std::function<void(std::vector<SampleTurboModuleSpec_ObjectStruct>)> onSubmit;\n");
   }
 };
 


### PR DESCRIPTION
## Description
In a recent integration RN core added support for module specs to have `EventEmitters`.  This modifies our REACT_EVENT macro to use the new EventEmitters.  These new EventEmitters work slightly differently than our previous REACT_EVENT macro, and only work on TurboModules. To avoid making the new behavior a breaking change, we will only use the new behavior when the module uses a new REACT_TURBO_MODULE macro instead of REACT_MODULE.  This allows us to also modify the behavior of AddAttributedModules to always register those modules as TurboModules rather than NativeModules.  Which provides a more incremental way of adopting TurboModules than the previous change of a bool param on AddAttributedModules which made all the attributed modules TurboModules.

I also updated the codegen to generate new native spec files that will verify that you have a REACT_EVENT for every EventEmitter decalred in the JS spec file.  The current implementation does not verify the arguments to the function aligns with the JS spec. That can be added in a subsequent change.

### Type of Change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves #13532

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
Uncommented the code that runs this in RNTester and verified that the events fire correctly.

## Changelog
Yes
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13555)