### PR TITLE
Enforce StatusBarManger module aligns with Spec

### DIFF
--- a/change/react-native-windows-bc48bd5b-3e22-40db-8384-1b2da3d2d09f.json
+++ b/change/react-native-windows-bc48bd5b-3e22-40db-8384-1b2da3d2d09f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enforce StatusBarManger module aligns with Spec",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/StatusBarManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/StatusBarManager.h
@@ -14,7 +14,6 @@ struct StatusBarManager {
 
   REACT_GET_CONSTANTS(GetConstants)
   static Microsoft::ReactNativeSpecs::StatusBarManagerAndroidSpec_Constants GetConstants() noexcept {
-    // return {{"HEIGHT", 0}, {"DEFAULT_BACKGROUND_COLOR": 0}};
     return {0};
   }
 

--- a/vnext/Microsoft.ReactNative/Modules/StatusBarManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/StatusBarManager.h
@@ -4,9 +4,36 @@
 
 #include <NativeModules.h>
 
+#include "codegen/NativeStatusBarManagerAndroidSpec.g.h"
+
 namespace Microsoft::ReactNative {
 
 REACT_MODULE(StatusBarManager)
-struct StatusBarManager {};
+struct StatusBarManager {
+using ModuleSpec = Microsoft::ReactNativeSpecs::StatusBarManagerAndroidSpec;
+
+REACT_GET_CONSTANTS(GetConstants)
+static Microsoft::ReactNativeSpecs::StatusBarManagerAndroidSpec_Constants GetConstants() noexcept {
+    //return {{"HEIGHT", 0}, {"DEFAULT_BACKGROUND_COLOR": 0}};
+    return {0};
+}
+ 
+REACT_METHOD(setColor)
+static void setColor(double /*color*/, bool /*animated*/) noexcept {
+}
+
+REACT_METHOD(setTranslucent)
+static void setTranslucent(bool /*translucent*/) noexcept {
+}
+
+REACT_METHOD(setStyle)
+static void setStyle(std::optional<std::string> /*statusBarStyle*/) noexcept {
+}
+
+REACT_METHOD(setHidden)
+static void setHidden(bool /*hidden*/) noexcept {
+}
+
+};
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/StatusBarManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/StatusBarManager.h
@@ -10,30 +10,25 @@ namespace Microsoft::ReactNative {
 
 REACT_MODULE(StatusBarManager)
 struct StatusBarManager {
-using ModuleSpec = Microsoft::ReactNativeSpecs::StatusBarManagerAndroidSpec;
+  using ModuleSpec = Microsoft::ReactNativeSpecs::StatusBarManagerAndroidSpec;
 
-REACT_GET_CONSTANTS(GetConstants)
-static Microsoft::ReactNativeSpecs::StatusBarManagerAndroidSpec_Constants GetConstants() noexcept {
-    //return {{"HEIGHT", 0}, {"DEFAULT_BACKGROUND_COLOR": 0}};
+  REACT_GET_CONSTANTS(GetConstants)
+  static Microsoft::ReactNativeSpecs::StatusBarManagerAndroidSpec_Constants GetConstants() noexcept {
+    // return {{"HEIGHT", 0}, {"DEFAULT_BACKGROUND_COLOR": 0}};
     return {0};
-}
- 
-REACT_METHOD(setColor)
-static void setColor(double /*color*/, bool /*animated*/) noexcept {
-}
+  }
 
-REACT_METHOD(setTranslucent)
-static void setTranslucent(bool /*translucent*/) noexcept {
-}
+  REACT_METHOD(setColor)
+  static void setColor(double /*color*/, bool /*animated*/) noexcept {}
 
-REACT_METHOD(setStyle)
-static void setStyle(std::optional<std::string> /*statusBarStyle*/) noexcept {
-}
+  REACT_METHOD(setTranslucent)
+  static void setTranslucent(bool /*translucent*/) noexcept {}
 
-REACT_METHOD(setHidden)
-static void setHidden(bool /*hidden*/) noexcept {
-}
+  REACT_METHOD(setStyle)
+  static void setStyle(std::optional<std::string> /*statusBarStyle*/) noexcept {}
 
+  REACT_METHOD(setHidden)
+  static void setHidden(bool /*hidden*/) noexcept {}
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description
The empty implementation of StatusBarManager here does not run when web debugging, as empty modules are ignored by the web debugging runtime.  This causes a StatusBarManager is missing error when web debugging, which causes the instance to not load.

This will fix #13550 when ported to 0.75
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13556)