### PR TITLE
[Fabric] Fixes a crash that happens on release builds

### DIFF
--- a/change/react-native-windows-a4b5f206-f251-4c85-b2a4-0f1aaf4e8763.json
+++ b/change/react-native-windows-a4b5f206-f251-4c85-b2a4-0f1aaf4e8763.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fixes a crash that happens on release builds",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -641,7 +641,8 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
             facebook::react::ReactInstance::JSRuntimeFlags options;
             m_bridgelessReactInstance->initializeRuntime(options, [=](facebook::jsi::Runtime &runtime) {
               auto logger = [loggingHook = GetLoggingCallback()](const std::string &message, unsigned int logLevel) {
-                loggingHook(static_cast<facebook::react::RCTLogLevel>(logLevel), message.c_str());
+                if (loggingHook)
+                  loggingHook(static_cast<facebook::react::RCTLogLevel>(logLevel), message.c_str());
               };
               facebook::react::bindNativeLogger(runtime, logger);
 


### PR DESCRIPTION
## Description
The default value of `loggingHook` ends up null on release builds, unless the app overrides the logging callback using `ReactInstanceSettings.NativeLogger`.  This adds a null check to avoid crashing if the default logger is hit in release builds.
