### PR TITLE
IAppData.TemporaryFolder with GetTempPathW

### DIFF
--- a/change/react-native-windows-2a2b1b40-5859-4ef6-9dd5-b48717b71c24.json
+++ b/change/react-native-windows-2a2b1b40-5859-4ef6-9dd5-b48717b71c24.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "replace IAppData.TemporaryFolder with GetTempPathW",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -693,11 +693,6 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
 #endif
 
 std::unique_ptr<facebook::jsi::PreparedScriptStore> CreatePreparedScriptStore() noexcept {
-
-  // if (Microsoft::ReactNative::HasPackageIdentity()) {
-  // auto local = winrt::Windows::Storage::ApplicationData::Current().TemporaryFolder().Path();
-  // return Microsoft::Common::Unicode::Utf16ToUtf8(local.c_str(), local.size()) + "\\";
-
   std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
   wchar_t tempPath[MAX_PATH];
   if (GetTempPathW(static_cast<DWORD>(std::size(tempPath)), tempPath)) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -553,6 +553,15 @@ Mso::DispatchQueueSettings CreateDispatchQueueSettings(
   return queueSettings;
 }
 
+std::unique_ptr<facebook::jsi::PreparedScriptStore> CreatePreparedScriptStore() noexcept {
+  std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
+  wchar_t tempPath[MAX_PATH];
+  if (GetTempPathW(static_cast<DWORD>(std::size(tempPath)), tempPath)) {
+    preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(winrt::to_string(tempPath));
+  }
+  return preparedScriptStore;
+}
+
 #ifdef USE_FABRIC
 void ReactInstanceWin::InitializeBridgeless() noexcept {
   InitUIQueue();
@@ -691,15 +700,6 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
   });
 }
 #endif
-
-std::unique_ptr<facebook::jsi::PreparedScriptStore> CreatePreparedScriptStore() noexcept {
-  std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
-  wchar_t tempPath[MAX_PATH];
-  if (GetTempPathW(static_cast<DWORD>(std::size(tempPath)), tempPath)) {
-    preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(winrt::to_string(tempPath));
-  }
-  return preparedScriptStore;
-}
 
 void ReactInstanceWin::FireInstanceCreatedCallback() noexcept {
   // The InstanceCreated event can be used to augment the JS environment for all JS code.  So it needs to be


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
See description in issue linked below.

Resolves [issue 13571](https://github.com/microsoft/react-native-windows/issues/13571)

### What
Replace usage of IAppData.TemporaryFolder with GetTempPathW.

## Testing
Tested change with C2R-installed version of Office client apps (high integrity level) and Centennial-installed version of Office client apps (x86, high and low integrity level).


## Changelog
Should this change be included in the release notes: Probably not, though I'm not sure what determines that - please advise.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13574)