### PR TITLE
[0.73] Update V8, Hermes, JSI for Node-API versions

### DIFF
--- a/change/react-native-windows-d20c9a86-3c19-4809-aa40-876e3cb7a227.json
+++ b/change/react-native-windows-d20c9a86-3c19-4809-aa40-876e3cb7a227.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update V8, Hermes, JSI for Node-API versions",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.ABITests/packages.lock.json
+++ b/vnext/Desktop.ABITests/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "resolved": "0.1.27",
+        "contentHash": "o4YBxD3yVaDfB7ccauyIIcUL3Q+k2C7dv3F9ODkMzUIL/lZBe44BiB2qdw/jchBD3ByUaC/kK3Lm/SW59V1A/w=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -45,13 +45,8 @@
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Transitive",
-        "resolved": "0.71.8",
-        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
-      },
-      "ReactWindows.OpenSSL.StdCall.Static": {
-        "type": "Transitive",
-        "resolved": "1.0.2-p.5",
-        "contentHash": "1tAtFgtbVpI/JgRIxy9j30R/W6B1zi9dYt0o5QwAk5V3X2mo9xrrHcbXlbczKQIftYoNHe0Mfq9ExIu9A1Cs0g=="
+        "resolved": "0.71.18",
+        "contentHash": "TLXVpgqTeyEKjPqhKR/UQFdU/t7x59uRwixMStEzCSsCoO6AMX8w9WGZWxdNg+xRLup9788MH19o9XrekZAmdA=="
       },
       "common": {
         "type": "Project",
@@ -66,7 +61,7 @@
         "type": "Project",
         "dependencies": {
           "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.83.0, )"
         }
       },
       "follywin32": {
@@ -81,23 +76,21 @@
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
           "FollyWin32": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.27, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.V8Jsi.Windows": "[0.71.8, )",
-          "ReactWindows.OpenSSL.StdCall.Static": "[1.0.2-p.5, )",
-          "boost": "[1.76.0, )"
+          "ReactNative.V8Jsi.Windows": "[0.71.18, )",
+          "boost": "[1.83.0, )"
         }
       },
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.27, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
-          "ReactNative.V8Jsi.Windows": "[0.71.8, )",
-          "ReactWindows.OpenSSL.StdCall.Static": "[1.0.2-p.5, )",
-          "boost": "[1.76.0, )"
+          "ReactNative.V8Jsi.Windows": "[0.71.18, )",
+          "boost": "[1.83.0, )"
         }
       },
       "reactcommon": {

--- a/vnext/Desktop.DLL/packages.lock.json
+++ b/vnext/Desktop.DLL/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.1.18, )",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "requested": "[0.1.27, )",
+        "resolved": "0.1.27",
+        "contentHash": "o4YBxD3yVaDfB7ccauyIIcUL3Q+k2C7dv3F9ODkMzUIL/lZBe44BiB2qdw/jchBD3ByUaC/kK3Lm/SW59V1A/w=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -26,15 +26,9 @@
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Direct",
-        "requested": "[0.71.8, )",
-        "resolved": "0.71.8",
-        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
-      },
-      "ReactWindows.OpenSSL.StdCall.Static": {
-        "type": "Direct",
-        "requested": "[1.0.2-p.5, )",
-        "resolved": "1.0.2-p.5",
-        "contentHash": "1tAtFgtbVpI/JgRIxy9j30R/W6B1zi9dYt0o5QwAk5V3X2mo9xrrHcbXlbczKQIftYoNHe0Mfq9ExIu9A1Cs0g=="
+        "requested": "[0.71.18, )",
+        "resolved": "0.71.18",
+        "contentHash": "TLXVpgqTeyEKjPqhKR/UQFdU/t7x59uRwixMStEzCSsCoO6AMX8w9WGZWxdNg+xRLup9788MH19o9XrekZAmdA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -59,7 +53,7 @@
         "type": "Project",
         "dependencies": {
           "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.83.0, )"
         }
       },
       "follywin32": {
@@ -74,12 +68,11 @@
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
           "FollyWin32": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.27, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.V8Jsi.Windows": "[0.71.8, )",
-          "ReactWindows.OpenSSL.StdCall.Static": "[1.0.2-p.5, )",
-          "boost": "[1.76.0, )"
+          "ReactNative.V8Jsi.Windows": "[0.71.18, )",
+          "boost": "[1.83.0, )"
         }
       },
       "reactcommon": {

--- a/vnext/Desktop.IntegrationTests/packages.lock.json
+++ b/vnext/Desktop.IntegrationTests/packages.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "resolved": "0.1.27",
+        "contentHash": "o4YBxD3yVaDfB7ccauyIIcUL3Q+k2C7dv3F9ODkMzUIL/lZBe44BiB2qdw/jchBD3ByUaC/kK3Lm/SW59V1A/w=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -46,8 +46,8 @@
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Transitive",
-        "resolved": "0.71.8",
-        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
+        "resolved": "0.71.18",
+        "contentHash": "TLXVpgqTeyEKjPqhKR/UQFdU/t7x59uRwixMStEzCSsCoO6AMX8w9WGZWxdNg+xRLup9788MH19o9XrekZAmdA=="
       },
       "common": {
         "type": "Project",
@@ -62,7 +62,7 @@
         "type": "Project",
         "dependencies": {
           "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.83.0, )"
         }
       },
       "follywin32": {
@@ -77,23 +77,21 @@
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
           "FollyWin32": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.27, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.V8Jsi.Windows": "[0.71.8, )",
-          "ReactWindows.OpenSSL.StdCall.Static": "[1.0.2-p.5, )",
-          "boost": "[1.76.0, )"
+          "ReactNative.V8Jsi.Windows": "[0.71.18, )",
+          "boost": "[1.83.0, )"
         }
       },
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.27, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
-          "ReactNative.V8Jsi.Windows": "[0.71.8, )",
-          "ReactWindows.OpenSSL.StdCall.Static": "[1.0.2-p.5, )",
-          "boost": "[1.76.0, )"
+          "ReactNative.V8Jsi.Windows": "[0.71.18, )",
+          "boost": "[1.83.0, )"
         }
       },
       "react.windows.integrationtests": {

--- a/vnext/Desktop.UnitTests/packages.lock.json
+++ b/vnext/Desktop.UnitTests/packages.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "resolved": "0.1.27",
+        "contentHash": "o4YBxD3yVaDfB7ccauyIIcUL3Q+k2C7dv3F9ODkMzUIL/lZBe44BiB2qdw/jchBD3ByUaC/kK3Lm/SW59V1A/w=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -46,8 +46,8 @@
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Transitive",
-        "resolved": "0.71.8",
-        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
+        "resolved": "0.71.18",
+        "contentHash": "TLXVpgqTeyEKjPqhKR/UQFdU/t7x59uRwixMStEzCSsCoO6AMX8w9WGZWxdNg+xRLup9788MH19o9XrekZAmdA=="
       },
       "common": {
         "type": "Project",
@@ -62,7 +62,7 @@
         "type": "Project",
         "dependencies": {
           "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.83.0, )"
         }
       },
       "follywin32": {
@@ -77,12 +77,11 @@
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
           "FollyWin32": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.27, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.V8Jsi.Windows": "[0.71.8, )",
-          "ReactWindows.OpenSSL.StdCall.Static": "[1.0.2-p.5, )",
-          "boost": "[1.76.0, )"
+          "ReactNative.V8Jsi.Windows": "[0.71.18, )",
+          "boost": "[1.83.0, )"
         }
       },
       "reactcommon": {

--- a/vnext/Desktop/packages.lock.json
+++ b/vnext/Desktop/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.1.18, )",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "requested": "[0.1.27, )",
+        "resolved": "0.1.27",
+        "contentHash": "o4YBxD3yVaDfB7ccauyIIcUL3Q+k2C7dv3F9ODkMzUIL/lZBe44BiB2qdw/jchBD3ByUaC/kK3Lm/SW59V1A/w=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -32,15 +32,9 @@
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Direct",
-        "requested": "[0.71.8, )",
-        "resolved": "0.71.8",
-        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
-      },
-      "ReactWindows.OpenSSL.StdCall.Static": {
-        "type": "Direct",
-        "requested": "[1.0.2-p.5, )",
-        "resolved": "1.0.2-p.5",
-        "contentHash": "1tAtFgtbVpI/JgRIxy9j30R/W6B1zi9dYt0o5QwAk5V3X2mo9xrrHcbXlbczKQIftYoNHe0Mfq9ExIu9A1Cs0g=="
+        "requested": "[0.71.18, )",
+        "resolved": "0.71.18",
+        "contentHash": "TLXVpgqTeyEKjPqhKR/UQFdU/t7x59uRwixMStEzCSsCoO6AMX8w9WGZWxdNg+xRLup9788MH19o9XrekZAmdA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -22,7 +22,7 @@
     <FmtVersion>10.1.0</FmtVersion>
     <FmtCommitHash>ca2e3685b160617d3d95fcd9e789c4e06ca88</FmtCommitHash>
     <!-- Commit hash for https://github.com/microsoft/node-api-jsi code. -->
-    <NodeApiJsiCommitHash>53b897b03c1c7e57c3372acc6234447a44e150d6</NodeApiJsiCommitHash>
+    <NodeApiJsiCommitHash>6506206ee0519da5ab688f6725cfa46441fd8650</NodeApiJsiCommitHash>
   </PropertyGroup>
 
   <!--

--- a/vnext/IntegrationTests/packages.lock.json
+++ b/vnext/IntegrationTests/packages.lock.json
@@ -20,8 +20,8 @@
       "folly": {
         "type": "Project",
         "dependencies": {
-          "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.83.0, )",
+          "fmt": "[1.0.0, )"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -16,7 +16,7 @@
     <Bridging_SourcePath Condition="'$(Bridging_SourcePath)' == '' AND '$(ReactNativeDir)' != ''">$(ReactNativeDir)\ReactCommon\react\bridging</Bridging_SourcePath>
     <Bridging_SourcePath Condition="'$(Bridging_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)ReactCommon\CallbackWrapper.h')">$(MSBuildThisFileDirectory)ReactCommon</Bridging_SourcePath>
 
-    <NodeApiJsiCommitHash>53b897b03c1c7e57c3372acc6234447a44e150d6</NodeApiJsiCommitHash>
+    <NodeApiJsiCommitHash>6506206ee0519da5ab688f6725cfa46441fd8650</NodeApiJsiCommitHash>
     <NodeApiJsiLocal Condition="Exists('$(MSBuildThisFileDirectory)NodeApiJsiRuntime.cpp')">true</NodeApiJsiLocal>
     <NodeApiJsiDir Condition="'$(NodeApiJsiDir)' == '' AND '$(NodeApiJsiLocal)' == 'true'">$(MSBuildThisFileDirectory)</NodeApiJsiDir>
     <NodeApiJsiDir Condition="'$(NodeApiJsiDir)' == '' AND '$(ReactNativeDir)' != ''">$(ReactNativeDir)\..\..\node_modules\.node-api-jsi\node-api-jsi-$(NodeApiJsiCommitHash)\</NodeApiJsiDir>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -14,7 +14,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">true</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.23</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.27</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgMicrosoft_JavaScript_Hermes)')">$(PkgMicrosoft_JavaScript_Hermes)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\Microsoft.JavaScript.Hermes\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>
@@ -24,7 +24,7 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.71.8</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.71.18</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
     <V8Package>$(NuGetPackageRoot)\$(V8PackageName).$(V8Version)</V8Package>

--- a/vnext/ReactCommon.UnitTests/packages.lock.json
+++ b/vnext/ReactCommon.UnitTests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Direct",
-        "requested": "[0.71.8, )",
-        "resolved": "0.71.8",
-        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
+        "requested": "[0.71.18, )",
+        "resolved": "0.71.18",
+        "contentHash": "TLXVpgqTeyEKjPqhKR/UQFdU/t7x59uRwixMStEzCSsCoO6AMX8w9WGZWxdNg+xRLup9788MH19o9XrekZAmdA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.1.18",
-        "contentHash": "5K8rRihGwIs2XNOTP2Jsw3T6cegxCBQXcpPS4optONU/AmFElGAfnA6XBQJ4UqlCFCl9Nf9zQrgvCUPBWYHiag=="
+        "resolved": "0.1.27",
+        "contentHash": "o4YBxD3yVaDfB7ccauyIIcUL3Q+k2C7dv3F9ODkMzUIL/lZBe44BiB2qdw/jchBD3ByUaC/kK3Lm/SW59V1A/w=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -44,11 +44,6 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
-      "ReactWindows.OpenSSL.StdCall.Static": {
-        "type": "Transitive",
-        "resolved": "1.0.2-p.5",
-        "contentHash": "1tAtFgtbVpI/JgRIxy9j30R/W6B1zi9dYt0o5QwAk5V3X2mo9xrrHcbXlbczKQIftYoNHe0Mfq9ExIu9A1Cs0g=="
-      },
       "common": {
         "type": "Project",
         "dependencies": {
@@ -62,7 +57,7 @@
         "type": "Project",
         "dependencies": {
           "Fmt": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "boost": "[1.83.0, )"
         }
       },
       "follywin32": {
@@ -77,12 +72,11 @@
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
           "FollyWin32": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.18, )",
+          "Microsoft.JavaScript.Hermes": "[0.1.27, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.V8Jsi.Windows": "[0.71.8, )",
-          "ReactWindows.OpenSSL.StdCall.Static": "[1.0.2-p.5, )",
-          "boost": "[1.76.0, )"
+          "ReactNative.V8Jsi.Windows": "[0.71.18, )",
+          "boost": "[1.83.0, )"
         }
       },
       "reactcommon": {

--- a/vnext/ReactCommon/cgmanifest.json
+++ b/vnext/ReactCommon/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Type": "git",
                 "Git": {
                   "RepositoryUrl": "https://github.com/microsoft/node-api-jsi",
-                  "CommitHash": "53b897b03c1c7e57c3372acc6234447a44e150d6"
+                  "CommitHash": "6506206ee0519da5ab688f6725cfa46441fd8650"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
## Description

- Update V8-JSI to version 0.71.18
- Update Hermes to version 0.1.27
- Update node-api-jsi to commit  https://github.com/microsoft/node-api-jsi/commit/6506206ee0519da5ab688f6725cfa46441fd8650
 
### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
New versions of V8 has update Node-API version.
New JSI for Node-API reduces memory use.
New Hermes matches to latest changes to JSI and JSI for Node-API.

### What
Only version changes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13581)