### PR TITLE
[0.72] Bump minimum VS version to 17.11.0

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -178,7 +178,8 @@ steps:
       displayName: Create bundle testcli
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  - ${{ if eq(parameters.runWack, true) }}:
+  # Temporarily disabling due to spurious failures in CI, see https://github.com/microsoft/react-native-windows/issues/13578
+  - ${{ if and(false, eq(parameters.runWack, true)) }}:
     - template: ../templates/run-wack.yml
       parameters:
         packageName: ReactNative.InitTest

--- a/change/@react-native-windows-cli-43e4c71b-04c9-455c-a70d-68bf8968074c.json
+++ b/change/@react-native-windows-cli-43e4c71b-04c9-455c-a70d-68bf8968074c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.72] Bump minimum VS version to 17.11.0",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-5db66c4d-8de8-4f82-8f09-7feba85c9359.json
+++ b/change/react-native-windows-5db66c4d-8de8-4f82-8f09-7feba85c9359.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.72] Bump minimum VS version to 17.11.0",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/healthCheckList.ts
+++ b/packages/@react-native-windows/cli/src/healthCheckList.ts
@@ -5,7 +5,7 @@ export const HealthCheckList = [
   [true, "WindowsVersion", "Windows version >= 10.0.17763.0"],
   [true, "DeveloperMode", "Developer mode is on"],
   [true, "LongPath", "Long path support is enabled"],
-  [true, "VSUWP", "Visual Studio 2022 (>= 17.3) & req. components"],
+  [true, "VSUWP", "Visual Studio 2022 (>= 17.11.0) & req. components"],
   [true, "Node", "Node.js (LTS, >= 16.0)"],
   [true, "Yarn", "Yarn"],
   [true, "DotNetCore", ".NET SDK (LTS, = 6.0)"]

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -202,7 +202,7 @@ export default class MSBuildTools {
     ];
     const minVersion =
       process.env.MinimumVisualStudioVersion ||
-      process.env.VisualStudioVersion ||
+      process.env.MinimumVisualStudioVersion || process.env.VisualStudioVersion ||
       '17.11.0';
     const vsInstallation = findLatestVsInstall({
       requires,
@@ -212,7 +212,13 @@ export default class MSBuildTools {
     });
 
     if (!vsInstallation) {
-      if (process.env.VisualStudioVersion != null) {
+      if (process.env.MinimumVisualStudioVersion != null) {
+        throw new CodedError(
+          'NoMSBuild',
+          `MSBuild tools not found for version ${process.env.MinimumVisualStudioVersion} (from environment). Make sure all required components have been installed`,
+          {MinimumVisualStudioVersionFromEnv: process.env.MinimumVisualStudioVersion},
+        );
+      } else if (process.env.VisualStudioVersion != null) {
         throw new CodedError(
           'NoMSBuild',
           `MSBuild tools not found for version ${process.env.VisualStudioVersion} (from environment). Make sure all required components have been installed`,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -200,7 +200,10 @@ export default class MSBuildTools {
       'Microsoft.Component.MSBuild',
       getVCToolsByArch(buildArch),
     ];
-    const minVersion = process.env.VisualStudioVersion || '17.0';
+    const minVersion =
+      process.env.MinimumVisualStudioVersion ||
+      process.env.VisualStudioVersion ||
+      '17.11.0';
     const vsInstallation = findLatestVsInstall({
       requires,
       minVersion,

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -202,7 +202,8 @@ export default class MSBuildTools {
     ];
     const minVersion =
       process.env.MinimumVisualStudioVersion ||
-      process.env.MinimumVisualStudioVersion || process.env.VisualStudioVersion ||
+      process.env.MinimumVisualStudioVersion ||
+      process.env.VisualStudioVersion ||
       '17.11.0';
     const vsInstallation = findLatestVsInstall({
       requires,
@@ -216,7 +217,10 @@ export default class MSBuildTools {
         throw new CodedError(
           'NoMSBuild',
           `MSBuild tools not found for version ${process.env.MinimumVisualStudioVersion} (from environment). Make sure all required components have been installed`,
-          {MinimumVisualStudioVersionFromEnv: process.env.MinimumVisualStudioVersion},
+          {
+            MinimumVisualStudioVersionFromEnv:
+              process.env.MinimumVisualStudioVersion,
+          },
         );
       } else if (process.env.VisualStudioVersion != null) {
         throw new CodedError(

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -82,10 +82,12 @@ export function enumerateVsInstalls(opts: {
 
     if (minVersionSemVer) {
       minVersion = minVersionSemVer.toString();
-      maxVersion = `${(minVersionSemVer.major + 1)}.0`;
+      maxVersion = `${minVersionSemVer.major + 1}.0`;
     } else if (!Number.isNaN(minVersionNum)) {
-      minVersion = Number.isInteger(minVersionNum) ? `${minVersionNum}.0` : minVersionNum.toString();
-      maxVersion = `${(Math.floor(minVersionNum) + 1)}.0`;
+      minVersion = Number.isInteger(minVersionNum)
+        ? `${minVersionNum}.0`
+        : minVersionNum.toString();
+      maxVersion = `${Math.floor(minVersionNum) + 1}.0`;
     } else {
       // Unable to parse minVersion and determine maxVersion,
       // caller will throw error that version couldn't be found.

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -82,10 +82,10 @@ export function enumerateVsInstalls(opts: {
 
     if (minVersionSemVer) {
       minVersion = minVersionSemVer.toString();
-      maxVersion = (minVersionSemVer.major + 1).toFixed(1);
+      maxVersion = `${(minVersionSemVer.major + 1)}.0`;
     } else if (!Number.isNaN(minVersionNum)) {
-      minVersion = minVersionNum.toFixed(1);
-      maxVersion = (Math.floor(minVersionNum) + 1).toFixed(1);
+      minVersion = Number.isInteger(minVersionNum) ? `${minVersionNum}.0` : minVersionNum.toString();
+      maxVersion = `${(Math.floor(minVersionNum) + 1)}.0`;
     } else {
       // Unable to parse minVersion and determine maxVersion,
       // caller will throw error that version couldn't be found.

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -164,7 +164,7 @@
     <JsBundleEntry Include="..\Microsoft.ReactNative.IntegrationTests\ReactNativeHostTests.js" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -226,7 +226,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="boost" Version="1.76.0.0" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -160,7 +160,7 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxHandler.idl" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.4" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -162,7 +162,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -144,7 +144,7 @@
     <None Include="future\futureTest.tt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
+++ b/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
@@ -171,7 +171,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.4" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -81,7 +81,9 @@ $vsWorkloads = @('Microsoft.VisualStudio.Workload.ManagedDesktop',
 $vsAll = ($vsComponents + $vsWorkloads);
 
 # The minimum VS version to check for
-$vsver = "17.3";
+# Note: For install to work, whatever min version you specify here must be met by the current package available on choco.
+# I.E. Do NOT specify a Preview version here because choco doesn't have VS Preview packages.
+$vsver = "17.11.0";
 
 # The exact .NET SDK version to check for
 $dotnetver = "6.0";


### PR DESCRIPTION
This PR backports #13455 to 0.72.

## Description

This PR bumps the minimum version of VS that RNW expects to 17.11.0.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To make sure users don't use the regressed builds of VS 2022.

Resolves #13339
Resolves #13374

### What
Bumped VS version checks for `run-windows` and `rnw-dependencies.ps1`. Updated ADO image to reflect updated images are no longer locked to VS v17.9.4.

## Screenshots
N/A

## Testing
`run-windows` now works with 17.11.0.

## Changelog
Should this change be included in the release notes: _yes_

Require Visual Studio 2022 >= v17.11.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13585)