### PR TITLE
[Fabric] Fix crash when running inspect

### DIFF
--- a/change/react-native-windows-061e13a1-aed7-4c50-b382-f49b0863935b.json
+++ b/change/react-native-windows-061e13a1-aed7-4c50-b382-f49b0863935b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix crash when running inspect",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -72,9 +72,12 @@ HRESULT UiaNavigateHelper(
       auto parentCV = view.Parent().as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
       if (parentCV != nullptr) {
         auto children = parentCV->Children();
-        for (auto it = children.end(); it != children.begin(); --it) {
-          if (*it == view) {
-            uiaProvider = (*it)
+        auto index = children.Size();
+
+        for (auto i = children.Size() - 1; i > 0; i--) {
+          auto child = children.GetAt(i);
+          if (child == view) {
+            uiaProvider = children.GetAt(i - 1)
                               .as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>()
                               ->EnsureUiaProvider();
             break;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -72,8 +72,6 @@ HRESULT UiaNavigateHelper(
       auto parentCV = view.Parent().as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
       if (parentCV != nullptr) {
         auto children = parentCV->Children();
-        auto index = children.Size();
-
         for (auto i = children.Size() - 1; i > 0; i--) {
           auto child = children.GetAt(i);
           if (child == view) {


### PR DESCRIPTION
## Description
Running inspect.exe, or likely a bunch of other accessibility tools causes RNW experiences to crash.

### Why
A bad iterator over the children collection would attempt to dereference the end iterator, which throws.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13592)