### PR TITLE
Linking.getInitialURL should return null by default instead of empty string

### DIFF
--- a/change/react-native-windows-1ebe3d5b-6412-4e8d-9498-191d16d1256c.json
+++ b/change/react-native-windows-1ebe3d5b-6412-4e8d-9498-191d16d1256c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Linking.getInitialURL should return null by default instead of empty string",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -113,7 +113,7 @@ void LinkingManager::HandleOpenUri(winrt::hstring const &uri) noexcept {
   if (s_initialUri) {
     result.Resolve(to_string(s_initialUri.AbsoluteUri()));
   } else {
-    result.Resolve("");
+    result.Resolve(std::nullopt);
   }
 }
 


### PR DESCRIPTION
Linking.getInitialURL should have been returning null by default.  But the spec until recently specified the return as a string so we could not return null.  I recently submitted a fix to RN to fix the spec file, so now we can return null.

This fixes a yellow box when launching RNTester.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13617)