### PR TITLE
[0.74] Switch New Architecture templates to use prebuilt NuGets

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -8,6 +8,9 @@ parameters:
       - Continuous
   - name: AgentPool
     type: object
+  - name: buildNuGetOnly
+    type: boolean
+    default: false
   - name: buildMatrix
     type: object
     default:
@@ -18,60 +21,72 @@ parameters:
             configuration: Debug
             platform: x64
             additionalRunArguments: --no-autolink
+            useNuGet: true
           - Name: FabricX64Release
             template: cpp-app
             configuration: Release
             platform: x64
             additionalRunArguments: --no-autolink
+            useNuGet: true
           - Name: FabricX86Debug
             template: cpp-app
             configuration: Debug
             platform: x86
             additionalRunArguments: --no-autolink
+            useNuGet: true
           - Name: FabricX86Release
             template: cpp-app
             configuration: Release
             platform: x86
+            useNuGet: true
           - Name: FabricArm64Debug
             template: cpp-app
             configuration: Debug
             platform: ARM64
             additionalRunArguments: --no-autolink --no-deploy
+            useNuGet: true
           - Name: FabricArm64Release
             template: cpp-app
             configuration: Release
             platform: ARM64
             additionalRunArguments: --no-autolink --no-deploy
+            useNuGet: true
           - Name: FabricLibX64Debug
             template: cpp-lib
             configuration: Debug
             platform: x64
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibX64Release
             template: cpp-lib
             configuration: Release
             platform: x64
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibX86Debug
             template: cpp-lib
             configuration: Debug
             platform: x86
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibX86Release
             template: cpp-lib
             configuration: Release
             platform: x86
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibArm64Debug
             template: cpp-lib
             configuration: Debug
             platform: ARM64
-            additionalRunArguments: --no-deploy
+            additionalRunArguments: --no-deploy --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibArm64Release
             template: cpp-lib
             configuration: Release
             platform: ARM64
-            additionalRunArguments: --no-deploy
+            additionalRunArguments: --no-deploy --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
       - BuildEnvironment: SecurePullRequest
         Matrix:
           - Name: FabricX64Release
@@ -79,6 +94,7 @@ parameters:
             configuration: Release
             platform: x64
             additionalRunArguments: --no-autolink
+            useNuGet: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: FabricX64Debug
@@ -86,66 +102,83 @@ parameters:
             configuration: Debug
             platform: x64
             additionalRunArguments: --no-autolink
+            useNuGet: true
           - Name: FabricX64Release
             template: cpp-app
             configuration: Release
             platform: x64
             additionalRunArguments: --no-autolink
+            useNuGet: true
           - Name: FabricX86Debug
             template: cpp-app
             configuration: Debug
             platform: x86
             additionalRunArguments: --no-autolink
+            useNuGet: true
           - Name: FabricX86Release
             template: cpp-app
             configuration: Release
             platform: x86
+            useNuGet: true
           - Name: FabricArm64Debug
             template: cpp-app
             configuration: Debug
             platform: ARM64
             additionalRunArguments: --no-autolink --no-deploy
+            useNuGet: true
           - Name: FabricArm64Release
             template: cpp-app
             configuration: Release
             platform: ARM64
             additionalRunArguments: --no-autolink --no-deploy
+            useNuGet: true
           - Name: FabricLibX64Debug
             template: cpp-lib
             configuration: Debug
             platform: x64
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibX64Release
             template: cpp-lib
             configuration: Release
             platform: x64
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibX86Debug
             template: cpp-lib
             configuration: Debug
             platform: x86
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibX86Release
             template: cpp-lib
             configuration: Release
             platform: x86
-            additionalRunArguments:
+            additionalRunArguments: --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibArm64Debug
             template: cpp-lib
             configuration: Debug
             platform: ARM64
-            additionalRunArguments: --no-deploy
+            additionalRunArguments: --no-deploy --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
           - Name: FabricLibArm64Release
             template: cpp-lib
             configuration: Release
             platform: ARM64
-            additionalRunArguments: --no-deploy
+            additionalRunArguments: --no-deploy --singleproc # --singleproc required to workaround issue #13599
+            useNuGet: true
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
     - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
       - ${{ each matrix in config.Matrix }}:
+        - ${{ if eq(coalesce(matrix.useNuGet, false), parameters.buildNuGetOnly) }}:
           - job: CliInitWindows${{ matrix.Name }}
             displayName: Verify CliInitWindows ${{ matrix.Name }}
+
+            ${{ if eq(matrix.useNuGet, true) }}:
+              dependsOn:
+                - UniversalBuild${{ matrix.platform }}ReleaseFabric
 
             variables: [template: ../variables/windows.yml]
 
@@ -184,3 +217,5 @@ jobs:
                   additionalRunArguments: ${{ matrix.additionalRunArguments }}
                   runWack: ${{ coalesce(matrix.runWack, false) }}
                   buildEnvironment: ${{ parameters.buildEnvironment }}
+                  useChakra: ${{ coalesce(matrix.useChakra, false) }}
+                  useNuGet: ${{ coalesce(matrix.useNuGet, false) }}

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -42,14 +42,22 @@
               BuildConfiguration: Debug
               BuildPlatform: x64
               UseFabric: true
+            - Name: X64ReleaseFabric
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              UseFabric: true
             - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
               BuildConfiguration: Release
               BuildPlatform: x86
               UseFabric: true
+            - Name: Arm64ReleaseFabric
+              BuildConfiguration: Release
+              BuildPlatform: ARM64
+              UseFabric: true
         - BuildEnvironment: SecurePullRequest
           Matrix:
-            - Name: X64DebugFabric
-              BuildConfiguration: Debug
+            - Name: X64ReleaseFabric
+              BuildConfiguration: Release
               BuildPlatform: x64
               UseFabric: true
             - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
@@ -87,9 +95,25 @@
               BuildConfiguration: Debug
               BuildPlatform: x64
               UseFabric: true
+            - Name: X64ReleaseFabric
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              UseFabric: true
+            - Name: X86DebugFabric
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              UseFabric: true
             - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
               BuildConfiguration: Release
               BuildPlatform: x86
+              UseFabric: true
+            - Name: Arm64DebugFabric
+              BuildConfiguration: Debug
+              BuildPlatform: ARM64
+              UseFabric: true
+            - Name: Arm64ReleaseFabric
+              BuildConfiguration: Release
+              BuildPlatform: ARM64
               UseFabric: true
 
   jobs:

--- a/.ado/stages.yml
+++ b/.ado/stages.yml
@@ -34,6 +34,12 @@ stages:
         parameters:
           buildEnvironment: ${{ parameters.buildEnvironment }}
           AgentPool: ${{ parameters.AgentPool }}
+      
+      - template: jobs/cli-init-windows.yml
+        parameters:
+          buildEnvironment: ${{ parameters.buildEnvironment }}
+          AgentPool: ${{ parameters.AgentPool }}
+          buildNuGetOnly: true
 
       # NuGet using tests rely on "UniversalBuild" which is done in the build stage
       - template: jobs/cli-init.yml
@@ -92,3 +98,4 @@ stages:
         parameters:
           buildEnvironment: ${{ parameters.buildEnvironment }}
           AgentPool: ${{ parameters.AgentPool }}
+          buildNuGetOnly: false

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -19,6 +19,12 @@ parameters:
   - name: additionalInitArguments
     type: string
     default: ''
+  - name: useChakra
+    type: boolean
+    default: false
+  - name: useNuGet
+    type: boolean
+    default: false
   - name: runWack
     type: boolean
     default: false
@@ -38,17 +44,46 @@ steps:
     parameters:
       buildEnvironment: ${{ parameters.buildEnvironment }}
 
+  - ${{ if eq(parameters.useNuGet, true) }}:
+    - template: prep-and-pack-nuget.yml
+      parameters:
+        artifactName: ReactWindowsFabric
+        npmVersion: $(npmVersion)-Fabric
+        packMicrosoftReactNative: true
+        packMicrosoftReactNativeCxx: true
+        slices:
+          - platform: ${{ parameters.platform }}
+            configuration: Release
+
   - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
-        npx --yes react-native@$(reactNativeDevDependency) init testcli --template react-native@$(reactNativeDevDependency)
-      displayName: Init new app project with react-native init
+        npx --yes @react-native-community/cli@latest init testcli --version $(reactNativeDevDependency)
+      displayName: Init new app project with @react-native-community/cli init
       workingDirectory: $(Agent.BuildDirectory)
 
-  - ${{ if endsWith(parameters.template, '-lib') }}:
+  - ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
     - script: |
-        npx --yes create-react-native-library@0.36.0 --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages java-objc --type module-new --react-native-version $(reactNativeDevDependency) testcli
+        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type module-new --react-native-version $(reactNativeDevDependency) --example vanilla testcli
       displayName: Init new lib project with create-react-native-library
       workingDirectory: $(Agent.BuildDirectory)
+
+  - ${{ elseif and(endsWith(parameters.template, '-lib'), startsWith(parameters.template, 'old')) }}:
+    - script: |
+        npx --yes create-react-native-module@0.20.2 --package-name "testcli" testcli
+      displayName: Init new lib project with create-react-native-module
+      workingDirectory: $(Agent.BuildDirectory)
+
+    - script: |
+        rmdir /s /q android
+      displayName: Remove broken android folder # See issue https://github.com/microsoft/react-native-windows/issues/12209
+      workingDirectory: $(Agent.BuildDirectory)\testcli
+    
+    - script: |
+        call yarn install
+        call yarn upgrade react@$(reactDevDependency) --dev
+        call yarn upgrade react-native@$(reactNativeDevDependency) --dev
+      displayName: Update lib project react and react-native dev versions
+      workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - script: |
       call yarn install
@@ -76,15 +111,14 @@ steps:
   - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
         call yarn add react-native-windows@$(npmVersion) --dev
-        call yarn add react-native-windows@* --peer
       displayName: yarn add react-native-windows dev/peer
       workingDirectory: $(Agent.BuildDirectory)\testcli
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
   - script: |
-      call yarn react-native init-windows --template ${{ parameters.template }} --overwrite --logging ${{ parameters.additionalInitArguments }}
-    displayName: Call react-native init-windows
+      call npx @react-native-community/cli init-windows --template ${{ parameters.template }} --overwrite --logging ${{ parameters.additionalInitArguments }}
+    displayName: Call @react-native-community/cli init-windows
     workingDirectory: $(Agent.BuildDirectory)\testcli
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -95,17 +129,25 @@ steps:
     workingDirectory: $(Agent.BuildDirectory)\testcli
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
-  
-  - powershell: |
-      $path = (Get-ChildItem -Filter "Package.appxmanifest" -File -Recurse).FullName;
-      [xml] $manifest = Get-Content $path
-      $manifest.Package.Identity.Name = 'ReactNative.InitTest'
-      $manifest.Save("$path")
-    displayName: Set AppX package name to "ReactNative.InitTest"
-    ${{ if endsWith(parameters.template, '-app') }}:
-      workingDirectory: $(Agent.BuildDirectory)\testcli\windows
-    ${{ if endsWith(parameters.template, '-lib') }}:
-      workingDirectory: $(Agent.BuildDirectory)\testcli\example\windows
+
+  - ${{ if eq(parameters.UseChakra, true) }}:
+    - template:  set-experimental-feature.yml
+      parameters:
+        package: ..\testcli
+        feature: UseHermes
+        value: ${{ not(parameters.UseChakra) }}
+
+  - ${{ if or(endsWith(parameters.template, '-app'), and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old')))) }}:
+    - powershell: |
+        $path = (Get-ChildItem -Filter "Package.appxmanifest" -File -Recurse).FullName;
+        [xml] $manifest = Get-Content $path
+        $manifest.Package.Identity.Name = 'ReactNative.InitTest'
+        $manifest.Save("$path")
+      displayName: Set AppX package name to "ReactNative.InitTest"
+      ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
+        workingDirectory: $(Agent.BuildDirectory)\testcli\example\windows
+      ${{ else }}:
+        workingDirectory: $(Agent.BuildDirectory)\testcli\windows
 
   # End npm test server
   - template: verdaccio-stop.yml
@@ -118,10 +160,19 @@ steps:
 
   - template: react-native-debug-info.yml
     parameters:
-      ${{ if endsWith(parameters.template, '-app') }}:
-        workingDirectory: $(Agent.BuildDirectory)\testcli
-      ${{ if endsWith(parameters.template, '-lib') }}:
+      ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
         workingDirectory: $(Agent.BuildDirectory)\testcli\example
+      ${{ else }}:
+        workingDirectory: $(Agent.BuildDirectory)\testcli
+
+  - ${{ if eq(parameters.useNuGet, true) }}:
+    - powershell: |
+        nuget.exe sources add -name TestFeed -source $(System.DefaultWorkingDirectory)\NugetTestFeed
+        nuget.exe sources remove -name react-native
+        nuget.exe sources remove -name Nuget.org
+        nuget.exe sources add -name Nuget.org -source https://api.nuget.org/v3/index.json
+      displayName: Add local NuGet test feed
+      workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - template: ../templates/run-windows-with-certificates.yml
     parameters:
@@ -131,25 +182,25 @@ steps:
       buildPlatform: ${{ parameters.platform }}
       deployOption: ${{ parameters.additionalRunArguments }}
       buildLogDirectory: $(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs
-      ${{ if endsWith(parameters.template, '-app') }}:
-        workingDirectory: $(Agent.BuildDirectory)\testcli
-      ${{ if endsWith(parameters.template, '-lib') }}:
+      ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
         workingDirectory: $(Agent.BuildDirectory)\testcli\example
+      ${{ else }}:
+        workingDirectory: $(Agent.BuildDirectory)\testcli
       restoreLockedMode: false # Allow new lockfile to be created
 
   - template: upload-build-logs.yml
     parameters:
       buildLogDirectory: '$(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs'
 
-  # Only run the following on apps
-  - ${{ if endsWith(parameters.template, '-app') }}:
+  # Only run the following on fabric apps
+  - ${{ if and(endsWith(parameters.template, '-app'), not(startsWith(parameters.template, 'old'))) }}:
     - script: call yarn test:windows
       displayName: Run jest tests with react-test-renderer
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   # Only test bundling in debug since we already bundle as part of release builds
   - ${{ if and(endsWith(parameters.template, '-app'), eq(parameters.configuration, 'Debug')) }}:
-    - script: npx react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle
+    - script: npx @react-native-community/cli bundle --entry-file index.js --platform windows --bundle-output test.bundle
       displayName: Create bundle testcli
       workingDirectory: $(Agent.BuildDirectory)\testcli
 

--- a/change/@react-native-windows-cli-bd214a76-535b-4214-aa8d-8e67b0d17c96.json
+++ b/change/@react-native-windows-cli-bd214a76-535b-4214-aa8d-8e67b0d17c96.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.74] Fix run-windows --singleproc to override high memory",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-ce719e54-ce74-4c70-a78a-f3c5a9576d73.json
+++ b/change/react-native-windows-ce719e54-ce74-4c70-a78a-f3c5a9576d73.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.74] Switch New Architecture templates to use prebuilt NuGets",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
@@ -119,7 +119,7 @@ export default class MSBuildTools {
     // doesn't lead to dramatic performance gains (See #4739). Only enable
     // parallel builds on machines with >16GB of memory to avoid OOM errors
     const highMemory = totalmem() > 16 * 1024 * 1024 * 1024;
-    const enableParallelBuilds = singleproc === false || highMemory;
+    const enableParallelBuilds = singleproc !== true && highMemory;
 
     if (enableParallelBuilds) {
       args.push('/maxCpuCount');

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Composition.Package.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Composition.Package.props
@@ -11,4 +11,5 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Common.props" />
    <!-- Fixes NuGet restore issues: -->
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\NuGet.CSharp.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Composition.Package.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Composition.Package.targets
@@ -14,5 +14,9 @@
     <!-- Needed for ucrtbased.dll when running a debug build. -->
     <SDKReference Include="Microsoft.VCLibs, Version=14.0" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(UseExperimentalNuget)' == 'true'">
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
+  </ItemGroup>
   
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.PackageReferences.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.PackageReferences.props
@@ -5,8 +5,18 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Only include Microsoft.ReactNative.* NuGet packages that C++ (app and lib) projects need when using UseExperimentalNuget. -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.ReactNative" Version="$(ReactNativeWindowsVersion)" />
-    <PackageReference Include="Microsoft.ReactNative.Cxx" Version="$(ReactNativeWindowsVersion)" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(UseFabric)' == 'true'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.ReactNative" Version="$(ReactNativeWindowsVersion)-Fabric" />
+        <PackageReference Include="Microsoft.ReactNative.Cxx" Version="$(ReactNativeWindowsVersion)-Fabric" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+       <ItemGroup>
+        <PackageReference Include="Microsoft.ReactNative" Version="$(ReactNativeWindowsVersion)" />
+        <PackageReference Include="Microsoft.ReactNative.Cxx" Version="$(ReactNativeWindowsVersion)" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
@@ -66,6 +66,8 @@
 
     <PropertyGroup>
       <_ReactNativeWindowsVersionCheckNugetVersion>$$nuGetPackageVersion$$</_ReactNativeWindowsVersionCheckNugetVersion>
+      <!-- Strip out the -Fabric qualifier from the version string if present -->
+      <_ReactNativeWindowsVersionCheckNugetVersion>$(_ReactNativeWindowsVersionCheckNugetVersion.Replace('-Fabric', ''))</_ReactNativeWindowsVersionCheckNugetVersion>
     </PropertyGroup>
    
     <!-- Validate package.json file -->

--- a/vnext/templates/cpp-app/NuGet_Config
+++ b/vnext/templates/cpp-app/NuGet_Config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+{{#addReactNativePublicAdoFeed}}
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+{{/addReactNativePublicAdoFeed}}
+    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>  
+</configuration>

--- a/vnext/templates/cpp-app/template.config.js
+++ b/vnext/templates/cpp-app/template.config.js
@@ -21,7 +21,7 @@ async function preInstall(config = {}, options = {}) {}
 
 async function getFileMappings(config = {}, options = {}) {
   const projectRoot = config?.root ?? process.cwd();
-  const {rnwPath, rnwVersion, devMode} = templateUtils.getRnwInfo(
+  const {rnwPath, rnwVersion, devMode, isCanary} = templateUtils.getRnwInfo(
     config,
     options,
   );
@@ -70,6 +70,9 @@ async function getFileMappings(config = {}, options = {}) {
     currentUser,
 
     devMode,
+
+    useNuGets: !devMode, // default is to use published NuGets except in devMode, change to true here if you want to test devMode and nugets simultaneously
+    addReactNativePublicAdoFeed: isCanary,
 
     cppNugetPackages,
   };

--- a/vnext/templates/cpp-app/windows/ExperimentalFeatures.props
+++ b/vnext/templates/cpp-app/windows/ExperimentalFeatures.props
@@ -4,6 +4,7 @@
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
     <UseFabric>true</UseFabric>
     <UseWinUI3>true</UseWinUI3>
+    <UseExperimentalNuget>{{useNuGets}}</UseExperimentalNuget>
 
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>

--- a/vnext/templates/cpp-app/windows/MyApp.sln
+++ b/vnext/templates/cpp-app/windows/MyApp.sln
@@ -6,10 +6,13 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "{{ name }}.Package", "{{ name }}.Package\{{ name }}.Package.wapproj", "{{ packageGuidUpper }}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "{{ name }}", "{{ name }}\{{ name }}.vcxproj", "{{ projectGuidUpper }}"
+{{^useNuGets}}
 	ProjectSection(ProjectDependencies) = postProject
 		{F7D32BD0-2749-483E-9A0D-1635EF7E3136} = {F7D32BD0-2749-483E-9A0D-1635EF7E3136}
 	EndProjectSection
+{{/useNuGets}}
 EndProject
+{{^useNuGets}}
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Folly", "..\{{ rnwPathFromProjectRoot }}\Folly\Folly.vcxproj", "{A990658C-CE31-4BCC-976F-0FC6B1AF693D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fmt", "..\{{ rnwPathFromProjectRoot }}\fmt\fmt.vcxproj", "{14B93DC8-FD93-4A6D-81CB-8BC96644501C}"
@@ -35,7 +38,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\{{ rnwPathFromPro
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Include", "..\{{ rnwPathFromProjectRoot }}\include\Include.vcxitems", "{EF074BA1-2D54-4D49-A28E-5E040B47CD2E}"
 EndProject
+{{/useNuGets}}
 Global
+{{^useNuGets}}
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\{{ rnwPathFromProjectRoot }}\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		..\{{ rnwPathFromProjectRoot }}\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
@@ -47,6 +52,7 @@ Global
 		..\{{ rnwPathFromProjectRoot }}\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\{{ rnwPathFromProjectRoot }}\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 	EndGlobalSection
+{{/useNuGets}}
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -92,6 +98,7 @@ Global
 		{{ projectGuidUpper }}.Release|ARM64.ActiveCfg = Release|ARM64
 		{{ projectGuidUpper }}.Release|ARM64.Build.0 = Release|ARM64
 		{{ projectGuidUpper }}.Release|ARM64.Deploy.0 = Release|ARM64
+{{^useNuGets}}
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM64.Build.0 = Debug|ARM64
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x64.ActiveCfg = Debug|x64
@@ -154,10 +161,12 @@ Global
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.ActiveCfg = Release|Win32
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.Build.0 = Release|Win32
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.Deploy.0 = Release|Win32
+{{/useNuGets}}
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+{{^useNuGets}}
 	GlobalSection(NestedProjects) = preSolution
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
@@ -170,6 +179,7 @@ Global
 		{EF074BA1-2D54-4D49-A28E-5E040B47CD2E} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 	EndGlobalSection
+{{/useNuGets}}
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D43FAD39-F619-437D-BB40-04A3982ACB6A}
 	EndGlobalSection

--- a/vnext/templates/cpp-lib/NuGet_Config
+++ b/vnext/templates/cpp-lib/NuGet_Config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+{{#addReactNativePublicAdoFeed}}
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+{{/addReactNativePublicAdoFeed}}
+    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>  
+</configuration>

--- a/vnext/templates/cpp-lib/example/NuGet_Config
+++ b/vnext/templates/cpp-lib/example/NuGet_Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- This placeholder file is reserved for future use, but also to prevent
+      using the config from the cpp-app template, allowing the lib to rely on
+      config file added to its root. -->
+</configuration>

--- a/vnext/templates/cpp-lib/template.config.js
+++ b/vnext/templates/cpp-lib/template.config.js
@@ -76,7 +76,7 @@ async function getFileMappings(config = {}, options = {}) {
   );
 
   const projectRoot = libConfig.root ?? process.cwd();
-  const {rnwPath, rnwVersion, devMode} = templateUtils.getRnwInfo(
+  const {rnwPath, rnwVersion, devMode, isCanary} = templateUtils.getRnwInfo(
     libConfig,
     libOptions,
   );
@@ -118,6 +118,9 @@ async function getFileMappings(config = {}, options = {}) {
     currentUser,
 
     devMode,
+
+    useNuGets: !devMode, // default is to use published NuGets except in devMode, change to true here if you want to test devMode and nugets simultaneously
+    addReactNativePublicAdoFeed: isCanary,
 
     cppNugetPackages,
   };

--- a/vnext/templates/cpp-lib/windows/ExperimentalFeatures.props
+++ b/vnext/templates/cpp-lib/windows/ExperimentalFeatures.props
@@ -4,6 +4,7 @@
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
     <UseFabric>true</UseFabric>
     <UseWinUI3>true</UseWinUI3>
+    <UseExperimentalNuget>{{useNuGets}}</UseExperimentalNuget>
 
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>

--- a/vnext/templates/cpp-lib/windows/MyLib.sln
+++ b/vnext/templates/cpp-lib/windows/MyLib.sln
@@ -4,10 +4,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "{{ name }}", "{{ name }}\{{ name }}.vcxproj", "{{ projectGuidUpper }}"
+{{^useNuGets}}
 	ProjectSection(ProjectDependencies) = postProject
 		{F7D32BD0-2749-483E-9A0D-1635EF7E3136} = {F7D32BD0-2749-483E-9A0D-1635EF7E3136}
 	EndProjectSection
+{{/useNuGets}}
 EndProject
+{{^useNuGets}}
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Folly", "..\{{ rnwPathFromProjectRoot }}\Folly\Folly.vcxproj", "{A990658C-CE31-4BCC-976F-0FC6B1AF693D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fmt", "..\{{ rnwPathFromProjectRoot }}\fmt\fmt.vcxproj", "{14B93DC8-FD93-4A6D-81CB-8BC96644501C}"
@@ -33,7 +36,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\{{ rnwPathFromPro
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Include", "..\{{ rnwPathFromProjectRoot }}\include\Include.vcxitems", "{EF074BA1-2D54-4D49-A28E-5E040B47CD2E}"
 EndProject
+{{/useNuGets}}
 Global
+{{^useNuGets}}
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\{{ rnwPathFromProjectRoot }}\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
 		..\{{ rnwPathFromProjectRoot }}\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
@@ -45,6 +50,7 @@ Global
 		..\{{ rnwPathFromProjectRoot }}\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\{{ rnwPathFromProjectRoot }}\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 	EndGlobalSection
+{{/useNuGets}}
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -54,24 +60,25 @@ Global
 		Release|ARM64 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{{ projectGuidUpper }}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{{ projectGuidUpper }}.Debug|ARM64.Build.0 = Debug|ARM64
-		{{ projectGuidUpper }}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{{ projectGuidUpper }}.Debug|x64.ActiveCfg = Debug|x64
 		{{ projectGuidUpper }}.Debug|x64.Build.0 = Debug|x64
 		{{ projectGuidUpper }}.Debug|x64.Deploy.0 = Debug|x64
 		{{ projectGuidUpper }}.Debug|x86.ActiveCfg = Debug|Win32
 		{{ projectGuidUpper }}.Debug|x86.Build.0 = Debug|Win32
 		{{ projectGuidUpper }}.Debug|x86.Deploy.0 = Debug|Win32
-		{{ projectGuidUpper }}.Release|ARM64.ActiveCfg = Release|ARM64
-		{{ projectGuidUpper }}.Release|ARM64.Build.0 = Release|ARM64
-		{{ projectGuidUpper }}.Release|ARM64.Deploy.0 = Release|ARM64
+		{{ projectGuidUpper }}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{{ projectGuidUpper }}.Debug|ARM64.Build.0 = Debug|ARM64
+		{{ projectGuidUpper }}.Debug|ARM64.Deploy.0 = Debug|ARM64
 		{{ projectGuidUpper }}.Release|x64.ActiveCfg = Release|x64
 		{{ projectGuidUpper }}.Release|x64.Build.0 = Release|x64
 		{{ projectGuidUpper }}.Release|x64.Deploy.0 = Release|x64
 		{{ projectGuidUpper }}.Release|x86.ActiveCfg = Release|Win32
 		{{ projectGuidUpper }}.Release|x86.Build.0 = Release|Win32
 		{{ projectGuidUpper }}.Release|x86.Deploy.0 = Release|Win32
+		{{ projectGuidUpper }}.Release|ARM64.ActiveCfg = Release|ARM64
+		{{ projectGuidUpper }}.Release|ARM64.Build.0 = Release|ARM64
+		{{ projectGuidUpper }}.Release|ARM64.Deploy.0 = Release|ARM64
+{{^useNuGets}}
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM64.Build.0 = Debug|ARM64
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x64.ActiveCfg = Debug|x64
@@ -134,10 +141,12 @@ Global
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.ActiveCfg = Release|Win32
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.Build.0 = Release|Win32
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.Deploy.0 = Release|Win32
+{{/useNuGets}}
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+{{^useNuGets}}
 	GlobalSection(NestedProjects) = preSolution
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
@@ -150,6 +159,7 @@ Global
 		{EF074BA1-2D54-4D49-A28E-5E040B47CD2E} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 		{14B93DC8-FD93-4A6D-81CB-8BC96644501C} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
 	EndGlobalSection
+{{/useNuGets}}
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D43FAD39-F619-437D-BB40-04A3982ACB6A}
 	EndGlobalSection

--- a/vnext/templates/templateUtils.js
+++ b/vnext/templates/templateUtils.js
@@ -30,6 +30,8 @@ function getRnwInfo(config = {}, options = {}) {
 
   const devMode = existsSync(path.join(rnwPath, 'src-win'));
 
+  const isCanary = rnwVersion.includes('canary');
+
   if (options?.logging) {
     console.log(
       `Found react-native-windows@${rnwVersion} at ${rnwPath}${
@@ -38,7 +40,7 @@ function getRnwInfo(config = {}, options = {}) {
     );
   }
 
-  return {rnwPath, rnwVersion, devMode};
+  return {rnwPath, rnwVersion, devMode, isCanary};
 }
 
 function getWindowsProjectConfig(root) {


### PR DESCRIPTION
This PR backports #13338 to 0.74.

## Description

This PR updates the `cpp-app` and `cpp-lib` new architecture templates to build against the pre-built `Microsoft.ReactNative` NuGet packages by default.

### Type of Change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
Building the `Microsoft.ReactNative` native code is very resource-intensive. Pre-building that code makes for much faster builds and greatly improved developer experience. This experience has been experimental and poorly support for Paper for some time now - for the new architecture projects we want using NuGets to be the primary experience from day one.

Resolves #12639

### What
The `cpp-app` and `cpp-lib` new architecture templates now set up projects to consume the ("-Fabric" versions) of the pre-built `Microsoft.ReactNative` NuGet packages by default.

The CI and PR builds have also been updated to make sure nugets for x64, x86, arm64 are built first and then consumed by the new project tests.

To support working on RNW itself, the new projects made using "devMode" (i.e. by yarn linking with your local RNW repo) will still build against the source of that local RNW repo rather than the nugets.

This PR also fixes the `--singleproc` flag for `run-windows`. Previously it didn't do anything on machines with high RAM, but now if you specify the flag it forces single processor builds as expected.

## Screenshots

Building x64 Release Paper (build RNW from source): ![image](https://github.com/user-attachments/assets/d7a529b9-d313-4227-b236-f4781aa25855)

Building x64 Release Fabric (use RNW Nugets):
![image](https://github.com/user-attachments/assets/bdb81df2-e111-4d61-a20a-302b3b6b1ecf)

## Testing
Verified new projects build and run using the pre-built nugets.

## Changelog
Should this change be included in the release notes: _yes_

[0.74] Switch New Architecture templates to use prebuilt NuGets
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13621)