### PR TITLE
[Fabric] Fix ScrollViewComponentView object leak

### DIFF
--- a/change/react-native-windows-d8175a4a-46c8-40d0-b42b-097f50a633c1.json
+++ b/change/react-native-windows-d8175a4a-46c8-40d0-b42b-097f50a633c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix ScrollViewComponentView object leak",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -378,6 +378,7 @@ struct WindowData {
         auto async = Host().UnloadInstance();
         async.Completed([&, uidispatch = InstanceSettings().UIDispatcher()](
                             auto asyncInfo, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
+          asyncStatus;
           OutputDebugStringA("Instance Unload completed\n");
 
           uidispatch.Post([&]() {

--- a/packages/playground/windows/playground-composition/Playground-Composition.rc
+++ b/packages/playground/windows/playground-composition/Playground-Composition.rc
@@ -57,6 +57,7 @@ BEGIN
         MENUITEM "&Open Javascript File...\tCtrl+O", IDM_OPENJSFILE
         MENUITEM "&New Window\tCtrl+N",         IDM_NEWWINDOW
         MENUITEM "&Refresh\tF5",                IDM_REFRESH
+        MENUITEM "&Unload",                     IDM_UNLOAD
         MENUITEM SEPARATOR
         MENUITEM "&Settings...\tAlt+S",         IDM_SETTINGS
         MENUITEM SEPARATOR

--- a/packages/playground/windows/playground-composition/resource.h
+++ b/packages/playground/windows/playground-composition/resource.h
@@ -24,6 +24,7 @@
 #define IDC_THEMELABEL 110
 #define IDC_JSENGINELABEL 111
 #define IDC_SIZETOCONTENT 112
+#define IDM_UNLOAD 113
 #define IDI_ICON1 1008
 
 // Next default values for new objects

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -140,9 +140,11 @@ struct CompositionInputKeyboardSource : winrt::implements<
 CompositionEventHandler::CompositionEventHandler(
     const winrt::Microsoft::ReactNative::ReactContext &context,
     const winrt::Microsoft::ReactNative::ReactNativeIsland &reactNativeIsland)
-    : m_context(context), m_wkRootView(reactNativeIsland) {
+    : m_context(context), m_wkRootView(reactNativeIsland) {}
+
+void CompositionEventHandler::Initialize() noexcept {
 #ifdef USE_WINUI3
-  if (auto island = reactNativeIsland.Island()) {
+  if (auto island = m_wkRootView.get().Island()) {
     auto pointerSource = winrt::Microsoft::UI::Input::InputPointerSource::GetForIsland(island);
 
     m_pointerPressedToken =

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -246,7 +246,6 @@ CompositionEventHandler::CompositionEventHandler(
                                 ->RootTag()),
                   args,
                   keyboardSource);
-          auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
           strongThis->onKeyDown(keyArgs);
           winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
         }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -146,143 +146,159 @@ CompositionEventHandler::CompositionEventHandler(
     auto pointerSource = winrt::Microsoft::UI::Input::InputPointerSource::GetForIsland(island);
 
     m_pointerPressedToken =
-        pointerSource.PointerPressed([this](
+        pointerSource.PointerPressed([wkThis = weak_from_this()](
                                          winrt::Microsoft::UI::Input::InputPointerSource const &,
                                          winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (auto strongRootView = m_wkRootView.get()) {
-            if (SurfaceId() == -1)
-              return;
+          if (auto strongThis = wkThis.lock()) {
+            if (auto strongRootView = m_wkRootView.get()) {
+              if (SurfaceId() == -1)
+                return;
 
-            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-                args.CurrentPoint(), strongRootView.ScaleFactor());
-            onPointerPressed(pp, args.KeyModifiers());
+              auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                  args.CurrentPoint(), strongRootView.ScaleFactor());
+              onPointerPressed(pp, args.KeyModifiers());
+            }
           }
         });
 
     m_pointerReleasedToken =
-        pointerSource.PointerReleased([this](
+        pointerSource.PointerReleased([wkThis = weak_from_this()](
                                           winrt::Microsoft::UI::Input::InputPointerSource const &,
                                           winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (auto strongRootView = m_wkRootView.get()) {
-            if (SurfaceId() == -1)
-              return;
+          if (auto strongThis = wkThis.lock()) {
+            if (auto strongRootView = m_wkRootView.get()) {
+              if (SurfaceId() == -1)
+                return;
 
-            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-                args.CurrentPoint(), strongRootView.ScaleFactor());
-            onPointerReleased(pp, args.KeyModifiers());
+              auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                  args.CurrentPoint(), strongRootView.ScaleFactor());
+              onPointerReleased(pp, args.KeyModifiers());
+            }
           }
         });
 
-    m_pointerMovedToken = pointerSource.PointerMoved([this](
+    m_pointerMovedToken = pointerSource.PointerMoved([wkThis = weak_from_this()](
                                                          winrt::Microsoft::UI::Input::InputPointerSource const &,
                                                          winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-      if (auto strongRootView = m_wkRootView.get()) {
-        if (SurfaceId() == -1)
-          return;
+      if (auto strongThis = wkThis.lock()) {
+        if (auto strongRootView = strongThis->m_wkRootView.get()) {
+          if (strongThis->SurfaceId() == -1)
+            return;
 
-        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-            args.CurrentPoint(), strongRootView.ScaleFactor());
-        onPointerMoved(pp, args.KeyModifiers());
+          auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+              args.CurrentPoint(), strongRootView.ScaleFactor());
+          strongThis->onPointerMoved(pp, args.KeyModifiers());
+        }
       }
     });
 
     m_pointerCaptureLostToken =
-        pointerSource.PointerCaptureLost([this](
+        pointerSource.PointerCaptureLost([wkThis = weak_from_this()](
                                              winrt::Microsoft::UI::Input::InputPointerSource const &,
                                              winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (auto strongRootView = m_wkRootView.get()) {
-            if (SurfaceId() == -1)
-              return;
+          if (auto strongThis = wkThis.lock()) {
+            if (auto strongRootView = m_wkRootView.get()) {
+              if (SurfaceId() == -1)
+                return;
 
-            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-                args.CurrentPoint(), strongRootView.ScaleFactor());
-            onPointerCaptureLost(pp, args.KeyModifiers());
+              auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                  args.CurrentPoint(), strongRootView.ScaleFactor());
+              onPointerCaptureLost(pp, args.KeyModifiers());
+            }
           }
         });
 
     m_pointerWheelChangedToken =
-        pointerSource.PointerWheelChanged([this](
+        pointerSource.PointerWheelChanged([wkThis = weak_from_this()](
                                               winrt::Microsoft::UI::Input::InputPointerSource const &,
                                               winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (auto strongRootView = m_wkRootView.get()) {
-            if (SurfaceId() == -1)
-              return;
+          if (auto strongThis = wkThis.lock()) {
+            if (auto strongRootView = m_wkRootView.get()) {
+              if (SurfaceId() == -1)
+                return;
 
-            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-                args.CurrentPoint(), strongRootView.ScaleFactor());
-            onPointerWheelChanged(pp, args.KeyModifiers());
+              auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                  args.CurrentPoint(), strongRootView.ScaleFactor());
+              onPointerWheelChanged(pp, args.KeyModifiers());
+            }
           }
         });
 
     auto keyboardSource = winrt::Microsoft::UI::Input::InputKeyboardSource::GetForIsland(island);
 
-    m_keyDownToken = keyboardSource.KeyDown([this](
+    m_keyDownToken = keyboardSource.KeyDown([wkThis = weak_from_this()](
                                                 winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                                 winrt::Microsoft::UI::Input::KeyEventArgs const &args) {
-      if (auto strongRootView = m_wkRootView.get()) {
-        if (SurfaceId() == -1)
-          return;
+      if (auto strongThis = wkThis.lock()) {
+        if (auto strongRootView = m_wkRootView.get()) {
+          if (SurfaceId() == -1)
+            return;
 
-        auto focusedComponent = RootComponentView().GetFocusedComponent();
-        auto keyArgs =
-            winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
-                focusedComponent
-                    ? focusedComponent.Tag()
-                    : static_cast<facebook::react::Tag>(
-                          winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(
-                              strongRootView)
-                              ->RootTag()),
-                args);
-        auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-        onKeyDown(keyboardSource, keyArgs);
-        winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+          auto focusedComponent = RootComponentView().GetFocusedComponent();
+          auto keyArgs =
+              winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
+                  focusedComponent
+                      ? focusedComponent.Tag()
+                      : static_cast<facebook::react::Tag>(
+                            winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(
+                                strongRootView)
+                                ->RootTag()),
+                  args);
+          auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
+          onKeyDown(keyboardSource, keyArgs);
+          winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+        }
       }
     });
 
-    m_keyUpToken = keyboardSource.KeyUp([this](
+    m_keyUpToken = keyboardSource.KeyUp([wkThis = weak_from_this()](
                                             winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                             winrt::Microsoft::UI::Input::KeyEventArgs const &args) {
-      if (auto strongRootView = m_wkRootView.get()) {
-        if (SurfaceId() == -1)
-          return;
+      if (auto strongThis = wkThis.lock()) {
+        if (auto strongRootView = m_wkRootView.get()) {
+          if (SurfaceId() == -1)
+            return;
 
-        auto focusedComponent = RootComponentView().GetFocusedComponent();
-        auto keyArgs =
-            winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
-                focusedComponent
-                    ? focusedComponent.Tag()
-                    : static_cast<facebook::react::Tag>(
-                          winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(
-                              strongRootView)
-                              ->RootTag()),
-                args);
-        auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-        onKeyUp(keyboardSource, keyArgs);
-        winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+          auto focusedComponent = RootComponentView().GetFocusedComponent();
+          auto keyArgs =
+              winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
+                  focusedComponent
+                      ? focusedComponent.Tag()
+                      : static_cast<facebook::react::Tag>(
+                            winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(
+                                strongRootView)
+                                ->RootTag()),
+                  args);
+          auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
+          onKeyUp(keyboardSource, keyArgs);
+          winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+        }
       }
     });
 
     m_characterReceivedToken =
-        keyboardSource.CharacterReceived([this](
+        keyboardSource.CharacterReceived([wkThis = weak_from_this()](
                                              winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                              winrt::Microsoft::UI::Input::CharacterReceivedEventArgs const &args) {
-          if (auto strongRootView = m_wkRootView.get()) {
-            if (SurfaceId() == -1)
-              return;
+          if (auto strongThis = wkThis.lock()) {
+            if (auto strongRootView = m_wkRootView.get()) {
+              if (SurfaceId() == -1)
+                return;
 
-            auto focusedComponent = RootComponentView().GetFocusedComponent();
-            auto charArgs = winrt::make<
-                winrt::Microsoft::ReactNative::Composition::Input::implementation::CharacterReceivedRoutedEventArgs>(
-                focusedComponent
-                    ? focusedComponent.Tag()
-                    : static_cast<facebook::react::Tag>(
-                          winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(
-                              strongRootView)
-                              ->RootTag()),
-                args);
-            auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-            onCharacterReceived(keyboardSource, charArgs);
-            winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+              auto focusedComponent = RootComponentView().GetFocusedComponent();
+              auto charArgs = winrt::make<
+                  winrt::Microsoft::ReactNative::Composition::Input::implementation::CharacterReceivedRoutedEventArgs>(
+                  focusedComponent
+                      ? focusedComponent.Tag()
+                      : static_cast<facebook::react::Tag>(
+                            winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(
+                                strongRootView)
+                                ->RootTag()),
+                  args);
+              auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
+              onCharacterReceived(keyboardSource, charArgs);
+              winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+            }
           }
         });
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -150,13 +150,13 @@ CompositionEventHandler::CompositionEventHandler(
                                          winrt::Microsoft::UI::Input::InputPointerSource const &,
                                          winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
           if (auto strongThis = wkThis.lock()) {
-            if (auto strongRootView = m_wkRootView.get()) {
-              if (SurfaceId() == -1)
+            if (auto strongRootView = strongThis->m_wkRootView.get()) {
+              if (strongThis->SurfaceId() == -1)
                 return;
 
               auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
                   args.CurrentPoint(), strongRootView.ScaleFactor());
-              onPointerPressed(pp, args.KeyModifiers());
+              strongThis->onPointerPressed(pp, args.KeyModifiers());
             }
           }
         });
@@ -166,13 +166,13 @@ CompositionEventHandler::CompositionEventHandler(
                                           winrt::Microsoft::UI::Input::InputPointerSource const &,
                                           winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
           if (auto strongThis = wkThis.lock()) {
-            if (auto strongRootView = m_wkRootView.get()) {
-              if (SurfaceId() == -1)
+            if (auto strongRootView = strongThis->m_wkRootView.get()) {
+              if (strongThis->SurfaceId() == -1)
                 return;
 
               auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
                   args.CurrentPoint(), strongRootView.ScaleFactor());
-              onPointerReleased(pp, args.KeyModifiers());
+              strongThis->onPointerReleased(pp, args.KeyModifiers());
             }
           }
         });
@@ -197,13 +197,13 @@ CompositionEventHandler::CompositionEventHandler(
                                              winrt::Microsoft::UI::Input::InputPointerSource const &,
                                              winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
           if (auto strongThis = wkThis.lock()) {
-            if (auto strongRootView = m_wkRootView.get()) {
-              if (SurfaceId() == -1)
+            if (auto strongRootView = strongThis->m_wkRootView.get()) {
+              if (strongThis->SurfaceId() == -1)
                 return;
 
               auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
                   args.CurrentPoint(), strongRootView.ScaleFactor());
-              onPointerCaptureLost(pp, args.KeyModifiers());
+              strongThis->onPointerCaptureLost(pp, args.KeyModifiers());
             }
           }
         });
@@ -213,13 +213,13 @@ CompositionEventHandler::CompositionEventHandler(
                                               winrt::Microsoft::UI::Input::InputPointerSource const &,
                                               winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
           if (auto strongThis = wkThis.lock()) {
-            if (auto strongRootView = m_wkRootView.get()) {
-              if (SurfaceId() == -1)
+            if (auto strongRootView = strongThis->m_wkRootView.get()) {
+              if (strongThis->SurfaceId() == -1)
                 return;
 
               auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
                   args.CurrentPoint(), strongRootView.ScaleFactor());
-              onPointerWheelChanged(pp, args.KeyModifiers());
+              strongThis->onPointerWheelChanged(pp, args.KeyModifiers());
             }
           }
         });
@@ -230,11 +230,11 @@ CompositionEventHandler::CompositionEventHandler(
                                                 winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                                 winrt::Microsoft::UI::Input::KeyEventArgs const &args) {
       if (auto strongThis = wkThis.lock()) {
-        if (auto strongRootView = m_wkRootView.get()) {
-          if (SurfaceId() == -1)
+        if (auto strongRootView = strongThis->m_wkRootView.get()) {
+          if (strongThis->SurfaceId() == -1)
             return;
 
-          auto focusedComponent = RootComponentView().GetFocusedComponent();
+          auto focusedComponent = strongThis->RootComponentView().GetFocusedComponent();
           auto keyArgs =
               winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
                   focusedComponent
@@ -245,7 +245,7 @@ CompositionEventHandler::CompositionEventHandler(
                                 ->RootTag()),
                   args);
           auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-          onKeyDown(keyboardSource, keyArgs);
+          strongThis->onKeyDown(keyboardSource, keyArgs);
           winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
         }
       }
@@ -255,11 +255,11 @@ CompositionEventHandler::CompositionEventHandler(
                                             winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                             winrt::Microsoft::UI::Input::KeyEventArgs const &args) {
       if (auto strongThis = wkThis.lock()) {
-        if (auto strongRootView = m_wkRootView.get()) {
-          if (SurfaceId() == -1)
+        if (auto strongRootView = strongThis->m_wkRootView.get()) {
+          if (strongThis->SurfaceId() == -1)
             return;
 
-          auto focusedComponent = RootComponentView().GetFocusedComponent();
+          auto focusedComponent = strongThis->RootComponentView().GetFocusedComponent();
           auto keyArgs =
               winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
                   focusedComponent
@@ -270,7 +270,7 @@ CompositionEventHandler::CompositionEventHandler(
                                 ->RootTag()),
                   args);
           auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-          onKeyUp(keyboardSource, keyArgs);
+          strongThis->onKeyUp(keyboardSource, keyArgs);
           winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
         }
       }
@@ -281,11 +281,11 @@ CompositionEventHandler::CompositionEventHandler(
                                              winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                              winrt::Microsoft::UI::Input::CharacterReceivedEventArgs const &args) {
           if (auto strongThis = wkThis.lock()) {
-            if (auto strongRootView = m_wkRootView.get()) {
-              if (SurfaceId() == -1)
+            if (auto strongRootView = strongThis->m_wkRootView.get()) {
+              if (strongThis->SurfaceId() == -1)
                 return;
 
-              auto focusedComponent = RootComponentView().GetFocusedComponent();
+              auto focusedComponent = strongThis->RootComponentView().GetFocusedComponent();
               auto charArgs = winrt::make<
                   winrt::Microsoft::ReactNative::Composition::Input::implementation::CharacterReceivedRoutedEventArgs>(
                   focusedComponent
@@ -296,7 +296,7 @@ CompositionEventHandler::CompositionEventHandler(
                                 ->RootTag()),
                   args);
               auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-              onCharacterReceived(keyboardSource, charArgs);
+              strongThis->onCharacterReceived(keyboardSource, charArgs);
               winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
             }
           }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -27,13 +27,14 @@ struct FabricUIManager;
 struct winrt::Microsoft::ReactNative::implementation::ComponentView;
 typedef int PointerId;
 
-class CompositionEventHandler : std::enable_shared_from_this<CompositionEventHandler> {
+class CompositionEventHandler : public std::enable_shared_from_this<CompositionEventHandler> {
  public:
   CompositionEventHandler(
       const winrt::Microsoft::ReactNative::ReactContext &context,
       const winrt::Microsoft::ReactNative::ReactNativeIsland &ReactNativeIsland);
   virtual ~CompositionEventHandler();
 
+  void Initialize() noexcept;
   int64_t SendMessage(HWND hwnd, uint32_t msg, uint64_t wParam, int64_t lParam) noexcept;
   void RemoveTouchHandlers();
   winrt::Microsoft::UI::Input::VirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -27,7 +27,7 @@ struct FabricUIManager;
 struct winrt::Microsoft::ReactNative::implementation::ComponentView;
 typedef int PointerId;
 
-class CompositionEventHandler {
+class CompositionEventHandler : std::enable_shared_from_this<CompositionEventHandler> {
  public:
   CompositionEventHandler(
       const winrt::Microsoft::ReactNative::ReactContext &context,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -408,6 +408,7 @@ void ReactNativeIsland::InitRootView(
   m_context = winrt::Microsoft::ReactNative::ReactContext(std::move(context));
   m_reactViewOptions = std::move(viewOptions);
   m_CompositionEventHandler = std::make_shared<::Microsoft::ReactNative::CompositionEventHandler>(m_context, *this);
+  m_CompositionEventHandler->Initialize();
 
   UpdateRootViewInternal();
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -42,7 +42,7 @@ struct ScrollBarComponent {
       const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext,
       bool vertical)
-      : m_outer(outer), m_compContext(compContext), m_reactContext(reactContext), m_vertical(vertical) {
+      : m_wkOuter(outer), m_compContext(compContext), m_reactContext(reactContext), m_vertical(vertical) {
     m_rootVisual = m_compContext.CreateSpriteVisual();
     m_trackVisual = m_compContext.CreateRoundedRectangleVisual();
     m_thumbVisual = m_compContext.CreateRoundedRectangleVisual();
@@ -73,9 +73,11 @@ struct ScrollBarComponent {
     updateHighlight(ScrollbarHitRegion::ArrowLast);
     updateHighlight(ScrollbarHitRegion::Thumb);
 
-    m_trackVisual.Brush(
-        winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(m_outer.Theme())
-            ->InternalPlatformBrush(L"ScrollBarTrackFill"));
+    if (auto outer = m_wkOuter.get()) {
+      m_trackVisual.Brush(
+          winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(outer.Theme())
+              ->InternalPlatformBrush(L"ScrollBarTrackFill"));
+    }
   }
 
   void ContentSize(winrt::Windows::Foundation::Size contentSize) noexcept {
@@ -293,19 +295,21 @@ struct ScrollBarComponent {
   }
 
   void OnPointerReleased(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
-    if (!m_visible)
-      return;
-    auto pt = args.GetCurrentPoint(m_outer.Tag());
-    if (m_nTrackInputOffset != -1 &&
-        pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse &&
-        pt.Properties().PointerUpdateKind() ==
-            winrt::Microsoft::ReactNative::Composition::Input::PointerUpdateKind::LeftButtonReleased) {
-      handleMoveThumb(args);
-      stopTrackingThumb();
-      m_outer.ReleasePointerCapture(args.Pointer());
+    if (auto outer = m_wkOuter.get()) {
+      if (!m_visible)
+        return;
+      auto pt = args.GetCurrentPoint(outer.Tag());
+      if (m_nTrackInputOffset != -1 &&
+          pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse &&
+          pt.Properties().PointerUpdateKind() ==
+              winrt::Microsoft::ReactNative::Composition::Input::PointerUpdateKind::LeftButtonReleased) {
+        handleMoveThumb(args);
+        stopTrackingThumb();
+        outer.ReleasePointerCapture(args.Pointer());
 
-      auto reg = HitTest(pt.Position());
-      updateShy(reg == ScrollbarHitRegion::Unknown);
+        auto reg = HitTest(pt.Position());
+        updateShy(reg == ScrollbarHitRegion::Unknown);
+      }
     }
   }
 
@@ -318,78 +322,85 @@ struct ScrollBarComponent {
   }
 
   void handleMoveThumb(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
-    auto pt = args.GetCurrentPoint(m_outer.Tag());
-    auto pos = pt.Position();
+    if (auto outer = m_wkOuter.get()) {
+      auto pt = args.GetCurrentPoint(outer.Tag());
+      auto pos = pt.Position();
 
-    auto newTrackingPosition = static_cast<int>((m_vertical ? pos.Y : pos.X) * m_scaleFactor) - m_nTrackInputOffset;
-    winrt::get_self<ScrollViewComponentView>(m_outer)->scrollTo(
-        m_vertical ? winrt::Windows::Foundation::Numerics::
-                         float3{m_offset.x, scrollOffsetFromThumbPos(newTrackingPosition), m_offset.z}
-                   : winrt::Windows::Foundation::Numerics::
-                         float3{scrollOffsetFromThumbPos(newTrackingPosition), m_offset.y, m_offset.z},
-        false);
+      auto newTrackingPosition = static_cast<int>((m_vertical ? pos.Y : pos.X) * m_scaleFactor) - m_nTrackInputOffset;
+      winrt::get_self<ScrollViewComponentView>(outer)->scrollTo(
+          m_vertical ? winrt::Windows::Foundation::Numerics::
+                           float3{m_offset.x, scrollOffsetFromThumbPos(newTrackingPosition), m_offset.z}
+                     : winrt::Windows::Foundation::Numerics::
+                           float3{scrollOffsetFromThumbPos(newTrackingPosition), m_offset.y, m_offset.z},
+          false);
+    }
     args.Handled(true);
   }
 
   void OnPointerPressed(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
-    if (!m_visible)
-      return;
-    auto pt = args.GetCurrentPoint(m_outer.Tag());
-    if (pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
-      auto pos = pt.Position();
-      auto reg = HitTest(pos);
+    if (auto outer = m_wkOuter.get()) {
+      if (!m_visible)
+        return;
+      auto pt = args.GetCurrentPoint(outer.Tag());
+      if (pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
+        auto pos = pt.Position();
+        auto reg = HitTest(pos);
 
-      switch (reg) {
-        case ScrollbarHitRegion::ArrowFirst:
-          if (m_vertical) {
-            winrt::get_self<ScrollViewComponentView>(m_outer)->lineUp(false);
-          } else {
-            winrt::get_self<ScrollViewComponentView>(m_outer)->lineLeft(false);
+        switch (reg) {
+          case ScrollbarHitRegion::ArrowFirst:
+            if (m_vertical) {
+              winrt::get_self<ScrollViewComponentView>(outer)->lineUp(false);
+            } else {
+              winrt::get_self<ScrollViewComponentView>(outer)->lineLeft(false);
+            }
+            args.Handled(true);
+            break;
+          case ScrollbarHitRegion::ArrowLast:
+            if (m_vertical) {
+              winrt::get_self<ScrollViewComponentView>(outer)->lineDown(false);
+            } else {
+              winrt::get_self<ScrollViewComponentView>(outer)->lineRight(false);
+            }
+            args.Handled(true);
+            break;
+          case ScrollbarHitRegion::PageUp:
+            if (m_vertical) {
+              winrt::get_self<ScrollViewComponentView>(outer)->pageUp(false);
+            }
+            args.Handled(true);
+            break;
+          case ScrollbarHitRegion::PageDown:
+            if (m_vertical) {
+              winrt::get_self<ScrollViewComponentView>(outer)->pageDown(false);
+            }
+            args.Handled(true);
+            break;
+          case ScrollbarHitRegion::Thumb: {
+            outer.CapturePointer(args.Pointer());
+            m_nTrackInputOffset = static_cast<int>((m_vertical ? pos.Y : pos.X) * m_scaleFactor) - m_thumbPos;
+            m_thumbVisual.AnimationClass(
+                winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::None);
+            handleMoveThumb(args);
           }
-          args.Handled(true);
-          break;
-        case ScrollbarHitRegion::ArrowLast:
-          if (m_vertical) {
-            winrt::get_self<ScrollViewComponentView>(m_outer)->lineDown(false);
-          } else {
-            winrt::get_self<ScrollViewComponentView>(m_outer)->lineRight(false);
-          }
-          args.Handled(true);
-          break;
-        case ScrollbarHitRegion::PageUp:
-          if (m_vertical) {
-            winrt::get_self<ScrollViewComponentView>(m_outer)->pageUp(false);
-          }
-          args.Handled(true);
-          break;
-        case ScrollbarHitRegion::PageDown:
-          if (m_vertical) {
-            winrt::get_self<ScrollViewComponentView>(m_outer)->pageDown(false);
-          }
-          args.Handled(true);
-          break;
-        case ScrollbarHitRegion::Thumb: {
-          m_outer.CapturePointer(args.Pointer());
-          m_nTrackInputOffset = static_cast<int>((m_vertical ? pos.Y : pos.X) * m_scaleFactor) - m_thumbPos;
-          m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::None);
-          handleMoveThumb(args);
         }
       }
     }
   }
 
   void OnPointerMoved(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
-    if (!m_visible)
-      return;
-    auto pt = args.GetCurrentPoint(m_outer.Tag());
-    if (pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
-      if (m_nTrackInputOffset != -1) {
-        handleMoveThumb(args);
-      } else {
-        auto pos = pt.Position();
-        auto reg = HitTest(pos);
-        updateShy(reg == ScrollbarHitRegion::Unknown);
-        setHighlightedRegion(reg);
+    if (auto outer = m_wkOuter.get()) {
+      if (!m_visible)
+        return;
+      auto pt = args.GetCurrentPoint(outer.Tag());
+      if (pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
+        if (m_nTrackInputOffset != -1) {
+          handleMoveThumb(args);
+        } else {
+          auto pos = pt.Position();
+          auto reg = HitTest(pos);
+          updateShy(reg == ScrollbarHitRegion::Unknown);
+          setHighlightedRegion(reg);
+        }
       }
     }
   }
@@ -427,122 +438,126 @@ struct ScrollBarComponent {
 
   // Renders the text into our composition surface
   void drawArrow(ScrollbarHitRegion region, bool disabled, bool hovered) noexcept {
-    auto &drawingSurface =
-        (region == ScrollbarHitRegion::ArrowFirst) ? m_arrowFirstDrawingSurface : m_arrowLastDrawingSurface;
-    if (!drawingSurface) {
-      drawingSurface = m_compContext.CreateDrawingSurfaceBrush(
-          {m_arrowSize, m_arrowSize},
-          winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
-          winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
-    }
-
-    if (winrt::get_self<ScrollViewComponentView>(m_outer)->theme()->IsEmpty()) {
-      return;
-    }
-
-    winrt::com_ptr<IDWriteTextFormat> spTextFormat;
-    winrt::check_hresult(::Microsoft::ReactNative::DWriteFactory()->CreateTextFormat(
-        L"Segoe Fluent Icons",
-        nullptr, // Font collection (nullptr sets it to use the system font collection).
-        DWRITE_FONT_WEIGHT_REGULAR,
-        DWRITE_FONT_STYLE_NORMAL,
-        DWRITE_FONT_STRETCH_NORMAL,
-        8, //  Xaml resource: ScrollBarButtonArrowIconFontSize
-        L"",
-        spTextFormat.put()));
-
-    winrt::check_hresult(spTextFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
-
-    winrt::com_ptr<IDWriteTextLayout> spTextLayout;
-    winrt::check_hresult(::Microsoft::ReactNative::DWriteFactory()->CreateTextLayout(
-        m_vertical ? ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDDB" : L"\uEDDC")
-                   : ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDD9" : L"\uEDDA"),
-        1, // The length of the string.
-        spTextFormat.get(), // The text format to apply to the string (contains font information, etc).
-        (m_arrowSize / m_scaleFactor), // The width of the layout box.
-        (m_arrowSize / m_scaleFactor), // The height of the layout box.
-        spTextLayout.put() // The IDWriteTextLayout interface pointer.
-        ));
-
-    POINT offset;
-    {
-      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_scaleFactor, &offset);
-      if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
-        d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Black, 0.0f));
-        assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
-
-        // Create a solid color brush for the text. A more sophisticated application might want
-        // to cache and reuse a brush across all text elements instead, taking care to recreate
-        // it in the event of device removed.
-        winrt::com_ptr<ID2D1SolidColorBrush> brush;
-
-        D2D1::ColorF color{0};
-        if (disabled) {
-          color = winrt::get_self<ScrollViewComponentView>(m_outer)->theme()->D2DPlatformColor(
-              "ScrollBarButtonArrowForegroundDisabled");
-        } else if (hovered) {
-          color = winrt::get_self<ScrollViewComponentView>(m_outer)->theme()->D2DPlatformColor(
-              "ScrollBarButtonArrowForegroundPointerOver");
-        } else {
-          color = winrt::get_self<ScrollViewComponentView>(m_outer)->theme()->D2DPlatformColor(
-              "ScrollBarButtonArrowForeground");
-        }
-        winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(color, brush.put()));
-
-        {
-          DWRITE_TEXT_METRICS dtm{};
-          winrt::check_hresult(spTextLayout->GetMetrics(&dtm));
-          offset.y += static_cast<int>((m_arrowSize - dtm.height) / 2.0f);
-        }
-
-        // Draw the line of text at the specified offset, which corresponds to the top-left
-        // corner of our drawing surface. Notice we don't call BeginDraw on the D2D device
-        // context; this has already been done for us by the composition API.
-        d2dDeviceContext->DrawTextLayout(
-            D2D1::Point2F(
-                static_cast<FLOAT>((offset.x) / m_scaleFactor), static_cast<FLOAT>((offset.y) / m_scaleFactor)),
-            spTextLayout.get(),
-            brush.get(),
-            D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
+    if (auto outer = m_wkOuter.get()) {
+      auto &drawingSurface =
+          (region == ScrollbarHitRegion::ArrowFirst) ? m_arrowFirstDrawingSurface : m_arrowLastDrawingSurface;
+      if (!drawingSurface) {
+        drawingSurface = m_compContext.CreateDrawingSurfaceBrush(
+            {m_arrowSize, m_arrowSize},
+            winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
+            winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
       }
-    }
-    if (drawingSurface) {
-      drawingSurface.HorizontalAlignmentRatio(0.0f);
-      drawingSurface.VerticalAlignmentRatio(0.0f);
-      drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
-    }
 
-    auto &arrowVisual = (region == ScrollbarHitRegion::ArrowFirst) ? m_arrowVisualFirst : m_arrowVisualLast;
-    arrowVisual.Brush(drawingSurface);
+      if (winrt::get_self<ScrollViewComponentView>(outer)->theme()->IsEmpty()) {
+        return;
+      }
+
+      winrt::com_ptr<IDWriteTextFormat> spTextFormat;
+      winrt::check_hresult(::Microsoft::ReactNative::DWriteFactory()->CreateTextFormat(
+          L"Segoe Fluent Icons",
+          nullptr, // Font collection (nullptr sets it to use the system font collection).
+          DWRITE_FONT_WEIGHT_REGULAR,
+          DWRITE_FONT_STYLE_NORMAL,
+          DWRITE_FONT_STRETCH_NORMAL,
+          8, //  Xaml resource: ScrollBarButtonArrowIconFontSize
+          L"",
+          spTextFormat.put()));
+
+      winrt::check_hresult(spTextFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER));
+
+      winrt::com_ptr<IDWriteTextLayout> spTextLayout;
+      winrt::check_hresult(::Microsoft::ReactNative::DWriteFactory()->CreateTextLayout(
+          m_vertical ? ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDDB" : L"\uEDDC")
+                     : ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDD9" : L"\uEDDA"),
+          1, // The length of the string.
+          spTextFormat.get(), // The text format to apply to the string (contains font information, etc).
+          (m_arrowSize / m_scaleFactor), // The width of the layout box.
+          (m_arrowSize / m_scaleFactor), // The height of the layout box.
+          spTextLayout.put() // The IDWriteTextLayout interface pointer.
+          ));
+
+      POINT offset;
+      {
+        ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_scaleFactor, &offset);
+        if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
+          d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Black, 0.0f));
+          assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
+
+          // Create a solid color brush for the text. A more sophisticated application might want
+          // to cache and reuse a brush across all text elements instead, taking care to recreate
+          // it in the event of device removed.
+          winrt::com_ptr<ID2D1SolidColorBrush> brush;
+
+          D2D1::ColorF color{0};
+          if (disabled) {
+            color = winrt::get_self<ScrollViewComponentView>(outer)->theme()->D2DPlatformColor(
+                "ScrollBarButtonArrowForegroundDisabled");
+          } else if (hovered) {
+            color = winrt::get_self<ScrollViewComponentView>(outer)->theme()->D2DPlatformColor(
+                "ScrollBarButtonArrowForegroundPointerOver");
+          } else {
+            color = winrt::get_self<ScrollViewComponentView>(outer)->theme()->D2DPlatformColor(
+                "ScrollBarButtonArrowForeground");
+          }
+          winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(color, brush.put()));
+
+          {
+            DWRITE_TEXT_METRICS dtm{};
+            winrt::check_hresult(spTextLayout->GetMetrics(&dtm));
+            offset.y += static_cast<int>((m_arrowSize - dtm.height) / 2.0f);
+          }
+
+          // Draw the line of text at the specified offset, which corresponds to the top-left
+          // corner of our drawing surface. Notice we don't call BeginDraw on the D2D device
+          // context; this has already been done for us by the composition API.
+          d2dDeviceContext->DrawTextLayout(
+              D2D1::Point2F(
+                  static_cast<FLOAT>((offset.x) / m_scaleFactor), static_cast<FLOAT>((offset.y) / m_scaleFactor)),
+              spTextLayout.get(),
+              brush.get(),
+              D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
+        }
+      }
+      if (drawingSurface) {
+        drawingSurface.HorizontalAlignmentRatio(0.0f);
+        drawingSurface.VerticalAlignmentRatio(0.0f);
+        drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
+      }
+
+      auto &arrowVisual = (region == ScrollbarHitRegion::ArrowFirst) ? m_arrowVisualFirst : m_arrowVisualLast;
+      arrowVisual.Brush(drawingSurface);
+    }
   }
 
   void updateHighlight(ScrollbarHitRegion region) noexcept {
-    switch (region) {
-      case ScrollbarHitRegion::ArrowFirst:
-      case ScrollbarHitRegion::ArrowLast: {
-        auto disabled = !std::static_pointer_cast<const facebook::react::ScrollViewProps>(
-                             winrt::get_self<ScrollViewComponentView>(m_outer)->viewProps())
-                             ->scrollEnabled;
-        drawArrow(region, disabled, m_highlightedRegion == region);
-      }
-      case ScrollbarHitRegion::Thumb: {
-        if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(
-                 winrt::get_self<ScrollViewComponentView>(m_outer)->viewProps())
-                 ->scrollEnabled) {
-          m_thumbVisual.Brush(
-              winrt::get_self<Theme>(m_outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFillDisabled"));
-        } else if (m_highlightedRegion == region) {
-          m_thumbVisual.Brush(
-              winrt::get_self<Theme>(m_outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFillPointerOver"));
-        } else {
-          m_thumbVisual.Brush(winrt::get_self<Theme>(m_outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFill"));
+    if (auto outer = m_wkOuter.get()) {
+      switch (region) {
+        case ScrollbarHitRegion::ArrowFirst:
+        case ScrollbarHitRegion::ArrowLast: {
+          auto disabled = !std::static_pointer_cast<const facebook::react::ScrollViewProps>(
+                               winrt::get_self<ScrollViewComponentView>(outer)->viewProps())
+                               ->scrollEnabled;
+          drawArrow(region, disabled, m_highlightedRegion == region);
+        }
+        case ScrollbarHitRegion::Thumb: {
+          if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(
+                   winrt::get_self<ScrollViewComponentView>(outer)->viewProps())
+                   ->scrollEnabled) {
+            m_thumbVisual.Brush(
+                winrt::get_self<Theme>(outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFillDisabled"));
+          } else if (m_highlightedRegion == region) {
+            m_thumbVisual.Brush(
+                winrt::get_self<Theme>(outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFillPointerOver"));
+          } else {
+            m_thumbVisual.Brush(winrt::get_self<Theme>(outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFill"));
+          }
         }
       }
     }
   }
 
  private:
-  winrt::Microsoft::ReactNative::Composition::ScrollViewComponentView m_outer;
+  winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::ScrollViewComponentView> m_wkOuter;
   winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext m_compContext;
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;
   const bool m_vertical;


### PR DESCRIPTION
## Description
ScrollViewComponentView's are currently leaking when used.  This fixes the ref cycle between the ScrollView and the ScrollBars.  I also added a new command to playground-composition to unload the instance which helps debug leak issues.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13633)