### PR TITLE
[Fabric] Enable implementation of custom events on custom components

### DIFF
--- a/change/react-native-windows-dd026530-5f0b-4ca5-b43e-a7a6960d7696.json
+++ b/change/react-native-windows-dd026530-5f0b-4ca5-b43e-a7a6960d7696.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Enable implementation of custom events on custom components",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/CustomXamlComponentWithNativeLayoutNativeComponent.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/CustomXamlComponentWithNativeLayoutNativeComponent.js
@@ -12,13 +12,22 @@
 
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {DirectEventHandler} from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+type MyEventEvent = $ReadOnly<{|
+  value: boolean,
+  target: Int32,
+|}>;
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
 
   // Props
   label: string,
+
+  // Events
+  onMyEvent?: ?DirectEventHandler<MyEventEvent>,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/CustomXamlComponentWithYogaLayoutNativeComponent.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/CustomXamlComponentWithYogaLayoutNativeComponent.js
@@ -12,13 +12,22 @@
 
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {DirectEventHandler} from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+type MyEventEvent = $ReadOnly<{|
+  value: boolean,
+  target: Int32,
+|}>;
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
 
   // Props
   label: string,
+
+  // Events
+  onMyEvent?: ?DirectEventHandler<MyEventEvent>,
 |}>;
 
 type ComponentType = HostComponent<NativeProps>;

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponent.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponent.windows.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import React from 'react';
+import React, { useState } from 'react';
 import {Text, View} from 'react-native';
 import CustomXamlComponentWithNativeLayout from './CustomXamlComponentWithNativeLayoutNativeComponent';
 
@@ -26,6 +26,7 @@ exports.examples = [
   {
     title: 'Native Component',
     render: function (): React.Node {
+      let [log, setLog] = useState('');
       return (
         <View
           style={{
@@ -42,9 +43,11 @@ exports.examples = [
           <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
           <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
           <Text style={{color: 'gray'}}>This is RN Text</Text>
+          <Text style={{color: 'red'}}>{log}</Text>
           <CustomXamlComponentWithNativeLayout
             label="This is a Xaml Button set to ellipisify on truncation"
             style={{flexShrink: 1}}
+            onMyEvent={(arg) => {setLog(log + '\nRecieved MyEvent: ' + JSON.stringify(arg.nativeEvent) + '\n')}}
           />
           <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
           <View style={{width: 100, height: 100, backgroundColor: 'red'}} />

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponent.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponent.windows.js
@@ -14,6 +14,39 @@ import React, { useState } from 'react';
 import {Text, View} from 'react-native';
 import CustomXamlComponentWithNativeLayout from './CustomXamlComponentWithNativeLayoutNativeComponent';
 
+const NativeComponentWithNativeLayout = () => {
+  let [log, setLog] = useState('');
+  return (
+    <View
+      style={{
+        borderRadius: 0,
+        margin: 10,
+        borderWidth: 2,
+        flexWrap: 'wrap',
+        flexDirection: 'row',
+        gap: 5,
+      }}>
+      <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
+      <Text style={{color: 'gray'}}>This is RN Text</Text>
+      <Text style={{color: 'red'}}>{log}</Text>
+      <CustomXamlComponentWithNativeLayout
+        label="This is a Xaml Button set to ellipisify on truncation"
+        style={{flexShrink: 1}}
+        onMyEvent={(arg) => {setLog(log + '\nRecieved MyEvent: ' + JSON.stringify(arg.nativeEvent) + '\n')}}
+      />
+      <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
+    </View>
+  );
+}
+
 exports.displayName = 'NativeFabricComponent';
 exports.framework = 'React';
 exports.category = 'UI';
@@ -26,36 +59,9 @@ exports.examples = [
   {
     title: 'Native Component',
     render: function (): React.Node {
-      let [log, setLog] = useState('');
       return (
-        <View
-          style={{
-            borderRadius: 0,
-            margin: 10,
-            borderWidth: 2,
-            flexWrap: 'wrap',
-            flexDirection: 'row',
-            gap: 5,
-          }}>
-          <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
-          <Text style={{color: 'gray'}}>This is RN Text</Text>
-          <Text style={{color: 'red'}}>{log}</Text>
-          <CustomXamlComponentWithNativeLayout
-            label="This is a Xaml Button set to ellipisify on truncation"
-            style={{flexShrink: 1}}
-            onMyEvent={(arg) => {setLog(log + '\nRecieved MyEvent: ' + JSON.stringify(arg.nativeEvent) + '\n')}}
-          />
-          <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
-        </View>
+        <NativeComponentWithNativeLayout />
       );
     },
-  },
+  }
 ];

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponentYoga.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponentYoga.windows.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import React from 'react';
+import React, { useState } from 'react';
 import {Text, View} from 'react-native';
 import CustomXamlComponentWithYogaLayout from './CustomXamlComponentWithYogaLayoutNativeComponent';
 
@@ -26,6 +26,7 @@ exports.examples = [
   {
     title: 'Native Component',
     render: function (): React.Node {
+      let [log, setLog] = useState('');
       return (
         <View
           style={{
@@ -42,9 +43,11 @@ exports.examples = [
           <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
           <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
           <Text style={{color: 'gray'}}>This is RN Text</Text>
+          <Text style={{color: 'red'}}>{log}</Text>
           <CustomXamlComponentWithYogaLayout
             label="This is a Xaml Button set to ellipisify on truncation"
             style={{flex: 1, minWidth: 100}}
+            onMyEvent={(arg) => {setLog(log + '\nRecieved MyEvent: ' + JSON.stringify(arg.nativeEvent) + '\n')}}
           />
           <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
           <View style={{width: 100, height: 100, backgroundColor: 'red'}} />

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponentYoga.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativeComponents/NativeComponentYoga.windows.js
@@ -14,6 +14,39 @@ import React, { useState } from 'react';
 import {Text, View} from 'react-native';
 import CustomXamlComponentWithYogaLayout from './CustomXamlComponentWithYogaLayoutNativeComponent';
 
+const NativeComponentWithYogaExample = () => {
+  let [log, setLog] = useState('');
+  return (
+    <View
+      style={{
+        borderRadius: 0,
+        margin: 10,
+        borderWidth: 2,
+        flexWrap: 'wrap',
+        flexDirection: 'row',
+        gap: 5,
+      }}>
+      <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
+      <Text style={{color: 'gray'}}>This is RN Text</Text>
+      <Text style={{color: 'red'}}>{log}</Text>
+      <CustomXamlComponentWithYogaLayout
+        label="This is a Xaml Button set to ellipisify on truncation"
+        style={{flex: 1, minWidth: 100}}
+        onMyEvent={(arg) => {setLog(log + '\nRecieved MyEvent: ' + JSON.stringify(arg.nativeEvent) + '\n')}}
+      />
+      <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
+      <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
+    </View>
+  );
+};
+
 exports.displayName = 'NativeFabricComponentYoga';
 exports.framework = 'React';
 exports.category = 'UI';
@@ -26,35 +59,8 @@ exports.examples = [
   {
     title: 'Native Component',
     render: function (): React.Node {
-      let [log, setLog] = useState('');
       return (
-        <View
-          style={{
-            borderRadius: 0,
-            margin: 10,
-            borderWidth: 2,
-            flexWrap: 'wrap',
-            flexDirection: 'row',
-            gap: 5,
-          }}>
-          <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
-          <Text style={{color: 'gray'}}>This is RN Text</Text>
-          <Text style={{color: 'red'}}>{log}</Text>
-          <CustomXamlComponentWithYogaLayout
-            label="This is a Xaml Button set to ellipisify on truncation"
-            style={{flex: 1, minWidth: 100}}
-            onMyEvent={(arg) => {setLog(log + '\nRecieved MyEvent: ' + JSON.stringify(arg.nativeEvent) + '\n')}}
-          />
-          <View style={{width: 100, height: 100, backgroundColor: 'green'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'red'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'blue'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'pink'}} />
-          <View style={{width: 100, height: 100, backgroundColor: 'gray'}} />
-        </View>
+        <NativeComponentWithYogaExample />
       );
     },
   },

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -10550,8 +10550,16 @@ exports[`snapshotAllPages Fabric Native Component 1`] = `
   >
     This is RN Text
   </Text>
+  <Text
+    style={
+      {
+        "color": "red",
+      }
+    }
+  />
   <CustomXamlComponentWithNativeLayout
     label="This is a Xaml Button set to ellipisify on truncation"
+    onMyEvent={[Function]}
     style={
       {
         "flexShrink": 1,
@@ -10673,8 +10681,16 @@ exports[`snapshotAllPages Fabric Native Component Yoga 1`] = `
   >
     This is RN Text
   </Text>
+  <Text
+    style={
+      {
+        "color": "red",
+      }
+    }
+  />
   <CustomXamlComponentWithYogaLayout
     label="This is a Xaml Button set to ellipisify on truncation"
+    onMyEvent={[Function]}
     style={
       {
         "flex": 1,

--- a/packages/playground/windows/playground-composition/CustomComponent.cpp
+++ b/packages/playground/windows/playground-composition/CustomComponent.cpp
@@ -44,6 +44,31 @@ struct CustomXamlComponentStateData : winrt::implements<CustomXamlComponentState
   winrt::Windows::Foundation::Size desiredSize;
 };
 
+// Should be codegen'd
+REACT_STRUCT(OnMyEvent)
+struct OnMyEvent {
+  REACT_FIELD(value)
+  bool value;
+
+  REACT_FIELD(target)
+  int32_t target;
+};
+
+// Should be codegen'd
+struct CustomXamlComponentEventEmitter {
+  CustomXamlComponentEventEmitter(const winrt::Microsoft::ReactNative::EventEmitter &eventEmitter)
+      : m_eventEmitter(eventEmitter) {}
+
+  void onMyEvent(OnMyEvent &value) const {
+    m_eventEmitter.DispatchEvent(L"MyEvent", [value](const winrt::Microsoft::ReactNative::IJSValueWriter writer) {
+      winrt::Microsoft::ReactNative::WriteValue(writer, value);
+    });
+  }
+
+ private:
+  winrt::Microsoft::ReactNative::EventEmitter m_eventEmitter{nullptr};
+};
+
 struct CustomComponentUserData : winrt::implements<CustomComponentUserData, winrt::IInspectable> {
   void Initialize(
       const winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView &islandView,
@@ -65,6 +90,14 @@ struct CustomComponentUserData : winrt::implements<CustomComponentUserData, winr
 #ifdef USE_EXPERIMENTAL_WINUI3
     m_buttonLabelTextBlock.Text(myProps->label);
 #endif
+  }
+
+  void FinalizeUpdates() noexcept {
+    if (m_eventEmitter) {
+      OnMyEvent args;
+      args.value = false;
+      m_eventEmitter->onMyEvent(args);
+    }
   }
 
   winrt::Microsoft::UI::Xaml::UIElement CreateXamlButtonContent(bool nativeLayout) {
@@ -103,94 +136,108 @@ struct CustomComponentUserData : winrt::implements<CustomComponentUserData, winr
     return yogaXamlPanel;
   }
 
+  static void ConfigureBuilderForCustomComponent(
+      winrt::Microsoft::ReactNative::IReactViewComponentBuilder const &builder,
+      bool nativeLayout) {
+    builder.SetCreateProps([](winrt::Microsoft::ReactNative::ViewProps props) noexcept {
+      return winrt::make<CustomXamlComponentProps>(props);
+    });
+
+    builder.SetFinalizeUpdateHandler([](const winrt::Microsoft::ReactNative::ComponentView &source,
+                                        winrt::Microsoft::ReactNative::ComponentViewUpdateMask /*mask*/) {
+      auto userData = source.UserData().as<CustomComponentUserData>();
+      userData->FinalizeUpdates();
+    });
+
+    auto compBuilder = builder.as<winrt::Microsoft::ReactNative::Composition::IReactCompositionViewComponentBuilder>();
+
+    compBuilder.SetContentIslandComponentViewInitializer(
+        [nativeLayout](
+            const winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView &islandView) noexcept {
+          auto userData = winrt::make_self<CustomComponentUserData>();
+          userData->Initialize(islandView, nativeLayout);
+          islandView.UserData(*userData);
+
+#ifdef USE_EXPERIMENTAL_WINUI3
+          islandView.Destroying([](const winrt::IInspectable &sender, const winrt::IInspectable &args) {
+            auto senderIslandView = sender.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
+            auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
+            userData->m_xamlIsland.Close();
+          });
+#endif
+        });
+
+    builder.SetUpdateEventEmitterHandler([](const winrt::Microsoft::ReactNative::ComponentView &source,
+                                            const winrt::Microsoft::ReactNative::EventEmitter &eventEmitter) {
+      auto senderIslandView = source.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
+      auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
+      userData->m_eventEmitter = std::make_unique<CustomXamlComponentEventEmitter>(eventEmitter);
+    });
+
+    if (nativeLayout) {
+      builder.SetMeasureContentHandler([](winrt::Microsoft::ReactNative::ShadowNode shadowNode,
+                                          winrt::Microsoft::ReactNative::LayoutContext layoutContext,
+                                          winrt::Microsoft::ReactNative::LayoutConstraints layoutContraints) noexcept {
+        shadowNode.Tag(winrt::box_value(layoutContraints));
+
+        auto currentState = winrt::get_self<CustomXamlComponentStateData>(shadowNode.StateData());
+
+        if (currentState) {
+          // Snap up to the nearest whole pixel to avoid pixel snapping truncations
+          auto size = winrt::Windows::Foundation::Size{
+              std::ceil(currentState->desiredSize.Width * layoutContext.PointScaleFactor()) /
+                      layoutContext.PointScaleFactor() +
+                  1.0f,
+              std::ceil(currentState->desiredSize.Height * layoutContext.PointScaleFactor()) /
+                      layoutContext.PointScaleFactor() +
+                  1.0f,
+          };
+          return size;
+        }
+
+        return winrt::Windows::Foundation::Size{0, 0};
+      });
+      builder.SetInitialStateDataFactory([](const winrt::Microsoft::ReactNative::IComponentProps & /*props*/) noexcept {
+        return winrt::make<CustomXamlComponentStateData>(winrt::Windows::Foundation::Size{0, 0});
+      });
+    }
+
+    builder.SetUpdatePropsHandler([](const winrt::Microsoft::ReactNative::ComponentView &source,
+                                     const winrt::Microsoft::ReactNative::IComponentProps &newProps,
+                                     const winrt::Microsoft::ReactNative::IComponentProps &oldProps) {
+      auto senderIslandView = source.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
+      auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
+      userData->PropsChanged(senderIslandView, newProps, oldProps);
+    });
+
+    builder.SetUpdateStateHandler([](const winrt::Microsoft::ReactNative::ComponentView &source,
+                                     const winrt::Microsoft::ReactNative::IComponentState &newState) {
+      auto senderIslandView = source.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
+      auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
+      userData->m_state = newState;
+    });
+  }
+
  private:
   winrt::Microsoft::UI::Xaml::Controls::TextBlock m_buttonLabelTextBlock{nullptr};
   winrt::Microsoft::ReactNative::IComponentState m_state;
+  std::unique_ptr<CustomXamlComponentEventEmitter> m_eventEmitter{nullptr};
 #ifdef USE_EXPERIMENTAL_WINUI3
   winrt::Microsoft::UI::Xaml::XamlIsland m_xamlIsland{nullptr};
 #endif
 };
 
-void ConfigureBuilderForCustomComponent(
-    winrt::Microsoft::ReactNative::IReactViewComponentBuilder const &builder,
-    bool nativeLayout) {
-  builder.SetCreateProps([](winrt::Microsoft::ReactNative::ViewProps props) noexcept {
-    return winrt::make<CustomXamlComponentProps>(props);
-  });
-  auto compBuilder = builder.as<winrt::Microsoft::ReactNative::Composition::IReactCompositionViewComponentBuilder>();
-
-  compBuilder.SetContentIslandComponentViewInitializer(
-      [nativeLayout](
-          const winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView &islandView) noexcept {
-        auto userData = winrt::make_self<CustomComponentUserData>();
-        userData->Initialize(islandView, nativeLayout);
-
-#ifdef USE_EXPERIMENTAL_WINUI3
-        islandView.Destroying([](const winrt::IInspectable &sender, const winrt::IInspectable &args) {
-          auto senderIslandView = sender.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
-          auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
-          userData->m_xamlIsland.Close();
-        });
-#endif
-      });
-
-  if (nativeLayout) {
-    builder.SetMeasureContentHandler([](winrt::Microsoft::ReactNative::ShadowNode shadowNode,
-                                        winrt::Microsoft::ReactNative::LayoutContext layoutContext,
-                                        winrt::Microsoft::ReactNative::LayoutConstraints layoutContraints) noexcept {
-      shadowNode.Tag(winrt::box_value(layoutContraints));
-
-      auto currentState = winrt::get_self<CustomXamlComponentStateData>(shadowNode.StateData());
-
-      if (currentState) {
-        // Snap up to the nearest whole pixel to avoid pixel snapping truncations
-        auto size = winrt::Windows::Foundation::Size{
-            std::ceil(currentState->desiredSize.Width * layoutContext.PointScaleFactor()) /
-                    layoutContext.PointScaleFactor() +
-                1.0f,
-            std::ceil(currentState->desiredSize.Height * layoutContext.PointScaleFactor()) /
-                    layoutContext.PointScaleFactor() +
-                1.0f,
-        };
-        return size;
-      }
-
-      return winrt::Windows::Foundation::Size{0, 0};
-    });
-    builder.SetInitialStateDataFactory([](const winrt::Microsoft::ReactNative::IComponentProps & /*props*/) noexcept {
-      return winrt::make<CustomXamlComponentStateData>(winrt::Windows::Foundation::Size{0, 0});
-    });
-  }
-
-#ifdef USE_EXPERIMENTAL_WINUI3
-  compBuilder.SetUpdatePropsHandler([](const winrt::Microsoft::ReactNative::ComponentView &source,
-                                       const winrt::Microsoft::ReactNative::IComponentProps &newProps,
-                                       const winrt::Microsoft::ReactNative::IComponentProps &oldProps) {
-    auto senderIslandView = source.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
-    auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
-    userData->PropsChanged(senderIslandView, newProps, oldProps);
-  });
-
-  compBuilder.SetUpdateStateHandler([](const winrt::Microsoft::ReactNative::ComponentView &source,
-                                       const winrt::Microsoft::ReactNative::IComponentState &newState) {
-    auto senderIslandView = source.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
-    auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
-    userData->m_state = newState;
-  });
-#endif
-}
-
 static void RegisterViewComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) {
   packageBuilder.as<winrt::Microsoft::ReactNative::IReactPackageBuilderFabric>().AddViewComponent(
       L"CustomXamlComponentWithNativeLayout",
       [](winrt::Microsoft::ReactNative::IReactViewComponentBuilder const &builder) noexcept {
-        ConfigureBuilderForCustomComponent(builder, true /*nativeLayout*/);
+        CustomComponentUserData::ConfigureBuilderForCustomComponent(builder, true /*nativeLayout*/);
       });
 
   packageBuilder.as<winrt::Microsoft::ReactNative::IReactPackageBuilderFabric>().AddViewComponent(
       L"CustomXamlComponentWithYogaLayout",
       [](winrt::Microsoft::ReactNative::IReactViewComponentBuilder const &builder) noexcept {
-        ConfigureBuilderForCustomComponent(builder, false /*nativeLayout*/);
+        CustomComponentUserData::ConfigureBuilderForCustomComponent(builder, false /*nativeLayout*/);
       });
 }
 } // namespace winrt::PlaygroundApp::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.cpp
@@ -8,8 +8,10 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 EventEmitter::EventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) : m_eventEmitter(eventEmitter) {}
 
-void EventEmitter::DispatchEvent(winrt::hstring eventName, const winrt::Microsoft::ReactNative::JSValueArgWriter& args) {
-  m_eventEmitter->dispatchEvent(winrt::to_string(eventName), [args](facebook::jsi::Runtime& runtime) {
+void EventEmitter::DispatchEvent(
+    winrt::hstring eventName,
+    const winrt::Microsoft::ReactNative::JSValueArgWriter &args) {
+  m_eventEmitter->dispatchEvent(winrt::to_string(eventName), [args](facebook::jsi::Runtime &runtime) {
     auto writer = winrt::make<JsiWriter>(runtime);
     args(writer);
     return winrt::get_self<JsiWriter>(writer)->MoveResult();

--- a/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "AbiEventEmitter.h"
+#include "JsiWriter.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+EventEmitter::EventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) : m_eventEmitter(eventEmitter) {}
+
+void EventEmitter::DispatchEvent(winrt::hstring eventName, const winrt::Microsoft::ReactNative::JSValueArgWriter& args) {
+  m_eventEmitter->dispatchEvent(winrt::to_string(eventName), [args](facebook::jsi::Runtime& runtime) {
+    auto writer = winrt::make<JsiWriter>(runtime);
+    args(writer);
+    return winrt::get_self<JsiWriter>(writer)->MoveResult();
+  });
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.h
@@ -5,8 +5,8 @@
 
 #include "ViewProps.g.h"
 
-#include <react/renderer/core/EventEmitter.h>
 #include "EventEmitter.g.h"
+#include <react/renderer/core/EventEmitter.h>
 #include <winrt/Microsoft.ReactNative.h>
 
 namespace winrt::Microsoft::ReactNative::implementation {
@@ -14,9 +14,9 @@ namespace winrt::Microsoft::ReactNative::implementation {
 struct EventEmitter : EventEmitterT<EventEmitter> {
   EventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter);
 
-  void DispatchEvent(winrt::hstring eventName, const winrt::Microsoft::ReactNative::JSValueArgWriter& args);
+  void DispatchEvent(winrt::hstring eventName, const winrt::Microsoft::ReactNative::JSValueArgWriter &args);
 
-private:
+ private:
   facebook::react::EventEmitter::Shared const m_eventEmitter;
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiEventEmitter.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "ViewProps.g.h"
+
+#include <react/renderer/core/EventEmitter.h>
+#include "EventEmitter.g.h"
+#include <winrt/Microsoft.ReactNative.h>
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct EventEmitter : EventEmitterT<EventEmitter> {
+  EventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter);
+
+  void DispatchEvent(winrt::hstring eventName, const winrt::Microsoft::ReactNative::JSValueArgWriter& args);
+
+private:
+  facebook::react::EventEmitter::Shared const m_eventEmitter;
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.cpp
@@ -65,6 +65,13 @@ void ShadowNode::StateData(winrt::IInspectable tag) noexcept {
   }
 }
 
+winrt::Microsoft::ReactNative::EventEmitter ShadowNode::EventEmitter() const noexcept {
+  if (auto shadowNode = m_shadowNode.lock()) {
+    return winrt::make<winrt::Microsoft::ReactNative::implementation::EventEmitter>(shadowNode->getEventEmitter());
+  }
+  return nullptr;
+}
+
 } // namespace winrt::Microsoft::ReactNative::implementation
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.h
@@ -8,6 +8,7 @@
 #include "YogaLayoutableShadowNode.g.h"
 #include <react/components/rnwcore/EventEmitters.h>
 #include <unordered_map>
+#include "AbiEventEmitter.h"
 #include "AbiState.h"
 #include "AbiViewProps.h"
 
@@ -41,6 +42,8 @@ struct ShadowNode : ShadowNodeT<ShadowNode> {
 
   winrt::IInspectable StateData() const noexcept;
   void StateData(winrt::IInspectable tag) noexcept;
+
+  winrt::Microsoft::ReactNative::EventEmitter EventEmitter() const noexcept;
 
  protected:
   facebook::react::ShadowNode::Weak m_shadowNode;

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
@@ -12,6 +12,7 @@
 #include "MountChildComponentViewArgs.g.cpp"
 #include "UnmountChildComponentViewArgs.g.cpp"
 #include <Fabric/Composition/RootComponentView.h>
+#include "AbiEventEmitter.h"
 #include "AbiShadowNode.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
@@ -58,12 +59,8 @@ void ComponentView::MountChildComponentView(
   }
 }
 
-void ComponentView::MountChildComponentViewHandler(const MountChildComponentViewDelegate &handler) {
+void ComponentView::MountChildComponentViewHandler(const MountChildComponentViewDelegate &handler) noexcept {
   m_mountChildComponentViewHandler = handler;
-}
-
-MountChildComponentViewDelegate ComponentView::MountChildComponentViewHandler() const noexcept {
-  return m_mountChildComponentViewHandler;
 }
 
 void ComponentView::onMounted() noexcept {
@@ -94,12 +91,8 @@ void ComponentView::UnmountChildComponentView(
   winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->parent(nullptr);
   winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->onUnmounted();
 }
-void ComponentView::UnmountChildComponentViewHandler(const UnmountChildComponentViewDelegate &handler) {
+void ComponentView::UnmountChildComponentViewHandler(const UnmountChildComponentViewDelegate &handler) noexcept {
   m_unmountChildComponentViewHandler = handler;
-}
-
-UnmountChildComponentViewDelegate ComponentView::UnmountChildComponentViewHandler() const noexcept {
-  return m_unmountChildComponentViewHandler;
 }
 
 void ComponentView::onUnmounted() noexcept {
@@ -154,12 +147,8 @@ void ComponentView::updateProps(
   }
 }
 
-void ComponentView::UpdatePropsHandler(const UpdatePropsDelegate &handler) {
+void ComponentView::UpdatePropsHandler(const UpdatePropsDelegate &handler) noexcept {
   m_updatePropsDelegate = handler;
-}
-
-UpdatePropsDelegate ComponentView::UpdatePropsHandler() const noexcept {
-  return m_updatePropsDelegate;
 }
 
 const winrt::Microsoft::ReactNative::IComponentProps ComponentView::userProps(
@@ -169,7 +158,15 @@ const winrt::Microsoft::ReactNative::IComponentProps ComponentView::userProps(
   return abiProps.UserProps();
 }
 
-void ComponentView::updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept {}
+void ComponentView::updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept {
+  if (m_updateEventEmitterHandler) {
+    m_updateEventEmitterHandler(*this, winrt::make<EventEmitter>(eventEmitter));
+  }
+}
+
+void ComponentView::UpdateEventEmitterHandler(const UpdateEventEmitterDelegate &handler) noexcept {
+  m_updateEventEmitterHandler = handler;
+}
 
 void ComponentView::updateState(
     facebook::react::State::Shared const &state,
@@ -180,12 +177,8 @@ void ComponentView::updateState(
   }
 }
 
-void ComponentView::UpdateStateHandler(const UpdateStateDelegate &handler) {
+void ComponentView::UpdateStateHandler(const UpdateStateDelegate &handler) noexcept {
   m_updateStateDelegate = handler;
-}
-
-UpdateStateDelegate ComponentView::UpdateStateHandler() const noexcept {
-  return m_updateStateDelegate;
 }
 
 LayoutMetricsChangedArgs::LayoutMetricsChangedArgs(
@@ -241,12 +234,8 @@ void ComponentView::LayoutMetricsChanged(winrt::event_token const &token) noexce
   m_layoutMetricsChangedEvent.remove(token);
 }
 
-void ComponentView::FinalizeUpdateHandler(const UpdateFinalizerDelegate &handler) {
+void ComponentView::FinalizeUpdateHandler(const UpdateFinalizerDelegate &handler) noexcept {
   m_finalizeUpdateHandler = handler;
-}
-
-UpdateFinalizerDelegate ComponentView::FinalizeUpdateHandler() const noexcept {
-  return m_finalizeUpdateHandler;
 }
 
 void ComponentView::FinalizeUpdates(winrt::Microsoft::ReactNative::ComponentViewUpdateMask updateMask) noexcept {
@@ -262,12 +251,8 @@ facebook::react::Props::Shared ComponentView::props() noexcept {
   return {};
 }
 
-void ComponentView::CustomCommandHandler(const HandleCommandDelegate &handler) {
+void ComponentView::CustomCommandHandler(const HandleCommandDelegate &handler) noexcept {
   m_customCommandHandler = handler;
-}
-
-HandleCommandDelegate ComponentView::CustomCommandHandler() const noexcept {
-  return m_customCommandHandler;
 }
 
 void ComponentView::HandleCommand(

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -211,23 +211,13 @@ struct ComponentView : public ComponentViewT<ComponentView> {
   void UserData(const winrt::IInspectable &userData) noexcept;
   winrt::IInspectable UserData() const noexcept;
 
-  void CustomCommandHandler(const HandleCommandDelegate &handler);
-  HandleCommandDelegate CustomCommandHandler() const noexcept;
-
-  void UpdatePropsHandler(const UpdatePropsDelegate &handler);
-  UpdatePropsDelegate UpdatePropsHandler() const noexcept;
-
-  void UpdateStateHandler(const UpdateStateDelegate &handler);
-  UpdateStateDelegate UpdateStateHandler() const noexcept;
-
-  void MountChildComponentViewHandler(const MountChildComponentViewDelegate &handler);
-  MountChildComponentViewDelegate MountChildComponentViewHandler() const noexcept;
-
-  void UnmountChildComponentViewHandler(const UnmountChildComponentViewDelegate &handler);
-  UnmountChildComponentViewDelegate UnmountChildComponentViewHandler() const noexcept;
-
-  void FinalizeUpdateHandler(const UpdateFinalizerDelegate &handler);
-  UpdateFinalizerDelegate FinalizeUpdateHandler() const noexcept;
+  void CustomCommandHandler(const HandleCommandDelegate &handler) noexcept;
+  void UpdatePropsHandler(const UpdatePropsDelegate &handler) noexcept;
+  void UpdateStateHandler(const UpdateStateDelegate &handler) noexcept;
+  void UpdateEventEmitterHandler(const UpdateEventEmitterDelegate &handler) noexcept;
+  void MountChildComponentViewHandler(const MountChildComponentViewDelegate &handler) noexcept;
+  void UnmountChildComponentViewHandler(const UnmountChildComponentViewDelegate &handler) noexcept;
+  void FinalizeUpdateHandler(const UpdateFinalizerDelegate &handler) noexcept;
 
   virtual void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
@@ -276,6 +266,7 @@ struct ComponentView : public ComponentViewT<ComponentView> {
   UpdateFinalizerDelegate m_finalizeUpdateHandler{nullptr};
   MountChildComponentViewDelegate m_mountChildComponentViewHandler{nullptr};
   UnmountChildComponentViewDelegate m_unmountChildComponentViewHandler{nullptr};
+  UpdateEventEmitterDelegate m_updateEventEmitterHandler{nullptr};
 
   winrt::event<
       winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs>>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -245,6 +245,7 @@ void ComponentView::StartBringIntoView(
 
 void ComponentView::updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept {
   m_eventEmitter = std::static_pointer_cast<facebook::react::ViewEventEmitter const>(eventEmitter);
+  base_type::updateEventEmitter(eventEmitter);
 }
 
 void ComponentView::HandleCommand(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -67,10 +67,6 @@ void ParagraphComponentView::updateProps(
   Super::updateProps(props, oldProps);
 }
 
-void ParagraphComponentView::updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept {
-  Super::updateEventEmitter(eventEmitter);
-}
-
 void ParagraphComponentView::updateState(
     facebook::react::State::Shared const &state,
     facebook::react::State::Shared const &oldState) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -33,7 +33,6 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
       uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept
       override;
-  void updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept override;
   void updateLayoutMetrics(
       facebook::react::LayoutMetrics const &layoutMetrics,
       facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
@@ -59,6 +59,8 @@ void ReactCompositionViewComponentBuilder::InitializeComponentView(
     self->UpdatePropsHandler(m_updatePropsHandler);
   if (m_updateStateHandler)
     self->UpdateStateHandler(m_updateStateHandler);
+  if (m_updateEventEmitterHandler)
+    self->UpdateEventEmitterHandler(m_updateEventEmitterHandler);
   if (m_mountChildComponentViewHandler)
     self->MountChildComponentViewHandler(m_mountChildComponentViewHandler);
   if (m_unmountChildComponentViewHandler)
@@ -164,6 +166,10 @@ void ReactCompositionViewComponentBuilder::SetUpdatePropsHandler(UpdatePropsDele
 
 void ReactCompositionViewComponentBuilder::SetUpdateStateHandler(UpdateStateDelegate impl) noexcept {
   m_updateStateHandler = impl;
+}
+
+void ReactCompositionViewComponentBuilder::SetUpdateEventEmitterHandler(UpdateEventEmitterDelegate impl) noexcept {
+  m_updateEventEmitterHandler = impl;
 }
 
 void ReactCompositionViewComponentBuilder::SetMountChildComponentViewHandler(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
@@ -35,6 +35,7 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   void SetFinalizeUpdateHandler(UpdateFinalizerDelegate impl) noexcept;
   void SetUpdatePropsHandler(UpdatePropsDelegate impl) noexcept;
   void SetUpdateStateHandler(UpdateStateDelegate impl) noexcept;
+  void SetUpdateEventEmitterHandler(UpdateEventEmitterDelegate impl) noexcept;
   void SetMountChildComponentViewHandler(MountChildComponentViewDelegate impl) noexcept;
   void SetUnmountChildComponentViewHandler(UnmountChildComponentViewDelegate impl) noexcept;
 
@@ -78,6 +79,7 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   winrt::Microsoft::ReactNative::UpdateFinalizerDelegate m_finalizeUpdateHandler;
   winrt::Microsoft::ReactNative::UpdatePropsDelegate m_updatePropsHandler;
   winrt::Microsoft::ReactNative::UpdateStateDelegate m_updateStateHandler;
+  winrt::Microsoft::ReactNative::UpdateEventEmitterDelegate m_updateEventEmitterHandler;
   winrt::Microsoft::ReactNative::MountChildComponentViewDelegate m_mountChildComponentViewHandler;
   winrt::Microsoft::ReactNative::UnmountChildComponentViewDelegate m_unmountChildComponentViewHandler;
 

--- a/vnext/Microsoft.ReactNative/IReactViewComponentBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactViewComponentBuilder.idl
@@ -3,6 +3,7 @@
 
 import "ViewProps.idl";
 import "ComponentView.idl";
+import "IJSValueWriter.idl";
 
 #include "DocString.h"
 
@@ -87,6 +88,14 @@ namespace Microsoft.ReactNative
   [experimental]
   delegate void UnmountChildComponentViewDelegate(ComponentView source, UnmountChildComponentViewArgs args);
 
+  [experimental]
+  runtimeclass EventEmitter {
+    void DispatchEvent(String eventName, JSValueArgWriter args);
+  };
+
+  [experimental]
+  delegate void UpdateEventEmitterDelegate(ComponentView source, EventEmitter eventEmitter);
+
   [webhosthidden]
   [experimental]
   interface IReactViewComponentBuilder
@@ -105,6 +114,7 @@ namespace Microsoft.ReactNative
     void SetFinalizeUpdateHandler(UpdateFinalizerDelegate impl);
     void SetUpdatePropsHandler(UpdatePropsDelegate impl);
     void SetUpdateStateHandler(UpdateStateDelegate impl);
+    void SetUpdateEventEmitterHandler(UpdateEventEmitterDelegate impl);
     void SetMountChildComponentViewHandler(MountChildComponentViewDelegate impl);
     void SetUnmountChildComponentViewHandler(UnmountChildComponentViewDelegate impl);
   };
@@ -123,6 +133,7 @@ namespace Microsoft.ReactNative
     void EnsureUnsealed();
     Object Tag { get; set; };
     Object StateData{ get; set; };
+    EventEmitter EventEmitter { get; };
   };
 
   [webhosthidden]

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -159,6 +159,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiViewComponentDescriptor.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiEventEmitter.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiViewProps.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>


### PR DESCRIPTION
## Description
Enable custom components to raise events.

### What
Implement a public EventEmitter class, which can be used to raise events on a component.
Add a builder method to set a updateEventEmitter handler to allow access to the event emitter to custom components.
Removed some unused methods on ComponentView.
Made some trivial methods on ComponentView noexcept.
Added example usage of custom events in playground app.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13635)