### PR TITLE
Fix compilation with clang19

### DIFF
--- a/change/react-native-windows-e3429291-6256-4f18-a0fa-9572295d76bd.json
+++ b/change/react-native-windows-e3429291-6256-4f18-a0fa-9572295d76bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix compilation with clang19",
+  "packageName": "react-native-windows",
+  "email": "tiagomacarios@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -431,12 +431,12 @@ struct MethodSignature {
   }
 
   template <class TOtherInputArgs, size_t... I>
-  static constexpr bool MatchInputArgs(std::index_sequence<I...>) noexcept {
+  constexpr bool MatchInputArgs(std::index_sequence<I...>) noexcept {
     return (MatchInputArg<std::tuple_element_t<I, InputArgs>, std::tuple_element_t<I, TOtherInputArgs>>() && ...);
   }
 
   template <class TOtherOutputCallbacks, size_t... I>
-  static constexpr bool MatchOutputCallbacks(std::index_sequence<I...>) noexcept {
+  constexpr bool MatchOutputCallbacks(std::index_sequence<I...>) noexcept {
     return (
         std::is_same_v<std::tuple_element_t<I, OutputCallbacks>, std::tuple_element_t<I, TOtherOutputCallbacks>> &&
         ...);


### PR DESCRIPTION
This code does not compile with clang 19

```
D:\dbs\Cx\omr\officereact.win32.0.73.20\Microsoft.ReactNative.Cxx\NativeModules.h:384:3: error: explicit specialization cannot have a storage class [clang-diagnostic-explicit-specialization-storage-class]
  384 |   static constexpr bool MatchInputArg<std::wstring, std::string>() noexcept {
      |   ^~~~~~
D:\dbs\Cx\omr\officereact.win32.0.73.20\Microsoft.ReactNative.Cxx\NativeModules.h:389:3: error: explicit specialization cannot have a storage class [clang-diagnostic-explicit-specialization-storage-class]
  389 |   static constexpr bool MatchInputArg<std::string, std::wstring>() noexcept {
      |   ^~~~~~
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13661)