### PR TITLE
Bump @types/react from 18.3.4 to 18.3.5

### DIFF
--- a/change/react-native-windows-5f99e270-3856-4418-8433-99c1333d8579.json
+++ b/change/react-native-windows-5f99e270-3856-4418-8433-99c1333d8579.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix to enable update of @types/react",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src-win/Libraries/Components/Keyboard/KeyboardExt.tsx
+++ b/vnext/src-win/Libraries/Components/Keyboard/KeyboardExt.tsx
@@ -21,17 +21,17 @@ export const supportKeyboard = <P extends Record<string, any>>(
   // children is used to avoid error: Property 'children' does not exist on type 'IntrinsicAttributes & ViewProps &
   // IKeyboardProps & RefAttributes<any>
   type PropsWithoutForwardedRef = P & React.PropsWithChildren<IKeyboardProps>;
-  type PropsWithForwardedRef = PropsWithoutForwardedRef & IForwardRefProps;
+  type PropsWithForwardedRef = React.PropsWithoutRef<PropsWithoutForwardedRef> & IForwardRefProps;
 
   class SupportKeyboard extends React.Component<PropsWithForwardedRef> {
     public render(): JSX.Element {
       const {forwardedRef, ...rest} = this.props;
-      return <WrappedComponent ref={forwardedRef} {...(rest as P)} />;
+      return <WrappedComponent ref={forwardedRef} {...(rest as unknown as P)} />;
     }
   }
 
   return React.forwardRef(
-    (props: PropsWithoutForwardedRef, ref: React.Ref<any>) => {
+    (props: React.PropsWithoutRef<PropsWithoutForwardedRef>, ref: React.Ref<any>) => {
       return <SupportKeyboard {...props} forwardedRef={ref} />;
     },
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,9 +3358,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^18.2.6":
-  version "18.3.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.4.tgz#dfdd534a1d081307144c00e325c06e00312c93a3"
-  integrity sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==
+  version "18.3.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
+  integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"


### PR DESCRIPTION
## Description
Fix supportKeyboard to handle types in latest @types/react package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13663)