### PR TITLE
Fix msbuild-sln.yml detection of changed packages.lock.json files after build

### DIFF
--- a/.ado/templates/msbuild-sln.yml
+++ b/.ado/templates/msbuild-sln.yml
@@ -56,15 +56,16 @@ steps:
         ${{parameters.msbuildArguments}}
 
   - powershell: |
+      & git add */packages.lock.json
       $changed = git status --porcelain=v1 */packages.lock.json
       if ($changed -ne $null) {
         Write-Host "##[warning] Detected packages.lock.json changes. See full log for details."
         Write-Host Files changed:`n([string]::Join("`n", $changed))
-        $diff = git diff */packages.lock.json
+        $diff = git diff --cached -- */packages.lock.json
         Write-Host Diff:`n([string]::Join("`n", $diff))
         Write-Host "Run vnext/Scripts/NuGetRestoreForceEvaluateAllSolutions.ps1 to update lock files locally."
       }
-    displayName: Process NuGet Restore Issues
+    displayName: Detect packages.lock.json changes during build
     condition: succeededOrFailed()
 
   - template: upload-build-logs.yml


### PR DESCRIPTION
## Description

Fixes the task which checked for changed `packages.lock.json` files so that it actually detects changes in the files.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To get more warnings when a forced NuGet restore has changed the lock file.

Extracted from PR #13634

### What
See above.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13669)