### PR TITLE
[Fabric] Add Support for accessibilityActions and onAccessibilityAction

### DIFF
--- a/change/react-native-windows-b2ad5990-4475-4b62-9ec8-6ddd45ba06be.json
+++ b/change/react-native-windows-b2ad5990-4475-4b62-9ec8-6ddd45ba06be.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Implementation for accessibilityActions",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -382,6 +382,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::Invoke() {
     UiaRaiseAutomationEvent(spProviderSimple.get(), UIA_Invoke_InvokedEventId);
   }
   DispatchAccessibilityAction(m_view, "invoke");
+  DispatchAccessibilityAction(m_view, "activate");
 
   return S_OK;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -381,6 +381,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::Invoke() {
   if (spProviderSimple != nullptr) {
     UiaRaiseAutomationEvent(spProviderSimple.get(), UIA_Invoke_InvokedEventId);
   }
+  DispatchAccessibilityAction(m_view, "invoke");
 
   return S_OK;
 }
@@ -394,6 +395,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::ScrollIntoView() {
   winrt::Microsoft::ReactNative::implementation::BringIntoViewOptions scrollOptions;
   winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(strongView)
       ->StartBringIntoView(std::move(scrollOptions));
+  DispatchAccessibilityAction(m_view, "scrollIntoView");
 
   return S_OK;
 }
@@ -422,6 +424,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::SetValue(LPCWSTR val) {
 
   winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(strongView)
       ->setAcccessiblityValue(winrt::to_string(val));
+  DispatchAccessibilityAction(m_view, "setValue");
   return S_OK;
 }
 
@@ -488,6 +491,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::Toggle() {
     return UIA_E_ELEMENTNOTAVAILABLE;
 
   winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(strongView)->Toggle();
+  DispatchAccessibilityAction(m_view, "toggle");
   return S_OK;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -182,4 +182,26 @@ std::string extractAccessibilityValue(const facebook::react::AccessibilityValue 
   }
 }
 
+void DispatchAccessibilityAction(::Microsoft::ReactNative::ReactTaggedView &view, const std::string &action) noexcept{
+  auto strongView = view.view();
+
+  if (!strongView)
+    return;
+
+  auto baseView = strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
+  if (baseView == nullptr)
+    return;
+
+  auto props = std::static_pointer_cast<const facebook::react::ViewProps>(baseView->props());
+  if (props == nullptr)
+    return;
+
+  auto accessibilityActions = props->accessibilityActions;
+  for (size_t i = 0; i < accessibilityActions.size(); i++) {
+    if (accessibilityActions[i].name == action) {
+      baseView->GetEventEmitter()->onAccessibilityAction(action);
+    }
+  }
+}
+
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -182,7 +182,7 @@ std::string extractAccessibilityValue(const facebook::react::AccessibilityValue 
   }
 }
 
-void DispatchAccessibilityAction(::Microsoft::ReactNative::ReactTaggedView &view, const std::string &action) noexcept{
+void DispatchAccessibilityAction(::Microsoft::ReactNative::ReactTaggedView &view, const std::string &action) noexcept {
   auto strongView = view.view();
 
   if (!strongView)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
@@ -33,4 +33,6 @@ long GetLiveSetting(const std::string &liveRegion) noexcept;
 
 std::string extractAccessibilityValue(const facebook::react::AccessibilityValue &value) noexcept;
 
+void DispatchAccessibilityAction(::Microsoft::ReactNative::ReactTaggedView &view, const std::string &action) noexcept;
+
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
## Description

### Type of Change
- Feature

### Why
Bring Fabric to API parity with Paper.

Resolves [Add Relevant Issue Here]

### What
This PR adds initial native support for the accessibilityActions and onAccessibilityAction props. In this PR we add support for the "invoke", "scrollIntoView", "setValue", and "toggle" actions. These are actions specific to the Windows platform. This PR also adds support for the "activate" action which is a cross-platform action. 

As we add support for other UIA providers to Fabric, we will be able to expand the list of accessibilityActions we can support. 

Note the onAccessibilityAction event emitter only supports specifying an action name at this time, so for the Windows setValue action, there is currently no way to pass the new value back to the JS. This infrastructure could be added. The code sample below captures how we would do this: 
![image](https://github.com/user-attachments/assets/ace31586-a2ba-4324-b531-65f1ea922a52)
![image](https://github.com/user-attachments/assets/d50e9414-5be9-44b2-ab24-5851fdaf35a1)
![image](https://github.com/user-attachments/assets/83063153-3bc5-4330-975a-269d22bc79ed)

If we wanted to add this infrastructure, we should coordinate with React Native to make sure this would be a change they'd want to upstream, so that all platforms have a consistent API for onAccessibilityAction. 

## Testing
Tested locally. No infrastructure in E2E tests yet to have automated tests for assistive tech interaction. 

## Changelog
Should this change be included in the release notes: Yes

Add support for "activate", "invoke", "scrollIntoView", "setValue", and "toggle" accessibilityActions. 