### PR TITLE
[Fabric] LogBox should destroy its window on instance shutdown

### DIFF
--- a/change/react-native-windows-35fe2283-4a8f-4316-8159-4f399c3fbe8f.json
+++ b/change/react-native-windows-35fe2283-4a8f-4316-8159-4f399c3fbe8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] LogBox should destroy its window on instance shutdown",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -19,6 +19,20 @@
 
 namespace Microsoft::ReactNative {
 
+LogBox::~LogBox() {
+#ifdef USE_FABRIC
+  if (m_hwnd)
+  {
+    m_context.UIDispatcher().Post([hwnd = m_hwnd]()
+    {
+      DestroyWindow(hwnd);
+    });
+    m_hwnd = nullptr;
+  }
+#endif
+}
+
+
 #ifdef USE_FABRIC
 constexpr PCWSTR c_logBoxWindowClassName = L"MS_REACTNATIVE_LOGBOX";
 constexpr auto CompHostProperty = L"CompHost";

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -21,17 +21,12 @@ namespace Microsoft::ReactNative {
 
 LogBox::~LogBox() {
 #ifdef USE_FABRIC
-  if (m_hwnd)
-  {
-    m_context.UIDispatcher().Post([hwnd = m_hwnd]()
-    {
-      DestroyWindow(hwnd);
-    });
+  if (m_hwnd) {
+    m_context.UIDispatcher().Post([hwnd = m_hwnd]() { DestroyWindow(hwnd); });
     m_hwnd = nullptr;
   }
 #endif
 }
-
 
 #ifdef USE_FABRIC
 constexpr PCWSTR c_logBoxWindowClassName = L"MS_REACTNATIVE_LOGBOX";

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
@@ -14,6 +14,8 @@ REACT_MODULE(LogBox)
 struct LogBox : public std::enable_shared_from_this<LogBox> {
   using ModuleSpec = ReactNativeSpecs::LogBoxSpec;
 
+  ~LogBox();
+
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 

--- a/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
@@ -170,13 +170,6 @@ ReactContext::ReactContext(
       m_properties{winrt::make<WeakRefPropertyBag>(properties)},
       m_notifications{notifications} {}
 
-void ReactContext::Destroy() noexcept {
-  if (auto notificationService =
-          winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNotificationService>(m_notifications)) {
-    notificationService->UnsubscribeAll();
-  }
-}
-
 winrt::Microsoft::ReactNative::IReactPropertyBag ReactContext::Properties() const noexcept {
   return m_properties;
 }

--- a/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.h
@@ -45,11 +45,6 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
       winrt::Microsoft::ReactNative::IReactPropertyBag const &properties,
       winrt::Microsoft::ReactNative::IReactNotificationService const &notifications) noexcept;
 
-  // ReactContext may have longer lifespan than ReactInstance.
-  // The ReactInstance uses the Destroy method to enforce the ReactContext cleanup
-  // when the ReactInstance is destroyed.
-  void Destroy() noexcept;
-
  public: // IReactContext
   winrt::Microsoft::ReactNative::IReactPropertyBag Properties() const noexcept override;
   winrt::Microsoft::ReactNative::IReactNotificationService Notifications() const noexcept override;


### PR DESCRIPTION
## Description
Currently LogBox will create a new window, and never destroy it.

I also deleted some dead code.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13675)