### PR TITLE
[0.73] C++ 20: Fix `Explicit template specialization cannot have a storage class` (#12328)

### DIFF
--- a/change/react-native-windows-39577653-1e51-4a5f-899b-b34e2da6d70f.json
+++ b/change/react-native-windows-39577653-1e51-4a5f-899b-b34e2da6d70f.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "C++ 20: Fix \"Explicit template specialization cannot have a storage class\"",
   "packageName": "react-native-windows",
   "email": "ngerlem@fb.com",

--- a/change/react-native-windows-39577653-1e51-4a5f-899b-b34e2da6d70f.json
+++ b/change/react-native-windows-39577653-1e51-4a5f-899b-b34e2da6d70f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "C++ 20: Fix \"Explicit template specialization cannot have a storage class\"",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -356,6 +356,21 @@ struct MethodSignatureMatchResult {
   bool IsSucceeded;
 };
 
+template <class TInputArg, class TOtherInputArg>
+constexpr bool MatchInputArg() noexcept {
+  return std::is_same_v<TInputArg, TOtherInputArg>;
+}
+
+template <>
+constexpr bool MatchInputArg<std::wstring, std::string>() noexcept {
+  return true;
+}
+
+template <>
+constexpr bool MatchInputArg<std::string, std::wstring>() noexcept {
+  return true;
+}
+
 template <class TResult, class TInputArgs, class TOutputCallbacks, class TOutputPromises>
 struct MethodSignature {
   using Result = TResult;
@@ -373,21 +388,6 @@ struct MethodSignature {
     } else {
       return 0;
     }
-  }
-
-  template <class TInputArg, class TOtherInputArg>
-  static constexpr bool MatchInputArg() noexcept {
-    return std::is_same_v<TInputArg, TOtherInputArg>;
-  }
-
-  template <>
-  static constexpr bool MatchInputArg<std::wstring, std::string>() noexcept {
-    return true;
-  }
-
-  template <>
-  static constexpr bool MatchInputArg<std::string, std::wstring>() noexcept {
-    return true;
   }
 
   template <class TOtherInputArgs, size_t... I>


### PR DESCRIPTION
Cherry pick PR #12328

The RNW MS.RN.Cxx code fails to compile with Clang 19 in Office. The issue is already fixed in the main branch last year.

The original PR description:

Fixes "[Explicit template specialization cannot have a storage class](https://stackoverflow.com/questions/29041775/explicit-template-specialization-cannot-have-a-storage-class-member-method-spe)" in C++ 20 by moving a function outside of a struct.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13681)