### PR TITLE
Fix CLI init args to prevent non-blocking errors

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -57,7 +57,7 @@ steps:
 
   - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
-        npx --yes @react-native-community/cli@next init testcli --version $(reactNativeDevDependency)
+        npx --yes @react-native-community/cli@latest init testcli --version $(reactNativeDevDependency) --verbose --install-pods false --skip-git-init true
       displayName: Init new app project with @react-native-community/cli init
       workingDirectory: $(Agent.BuildDirectory)
 

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -57,7 +57,7 @@ steps:
 
   - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
-        npx --yes @react-native-community/cli@latest init testcli --version $(reactNativeDevDependency) --verbose --install-pods false --skip-git-init true
+        npx --yes @react-native-community/cli@latest init testcli --version $(reactNativeDevDependency) --verbose --skip-install --install-pods false --skip-git-init true
       displayName: Init new app project with @react-native-community/cli init
       workingDirectory: $(Agent.BuildDirectory)
 


### PR DESCRIPTION
## Description

Changed our creation of new RN projects via the CLI to:
* Be verbose for better debugging
* Not automatically install ios pods (we don't need them)
* Not call yarn install (it fails sometimes due to yarn version mismatches, we call `yarn install` later anyway)
* No create a git repo (unnecessary for our tests)

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To unblock PRs.
 
### What
See above.

## Screenshots
N/A

## Testing
Verified commands worked

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13684)