### PR TITLE
[0.75] Fix parsing of empty build props in run-windows

### DIFF
--- a/change/@react-native-windows-cli-81405bf2-50e6-426f-8c7a-81c622d5fa43.json
+++ b/change/@react-native-windows-cli-81405bf2-50e6-426f-8c7a-81c622d5fa43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.75] Fix parsing of empty build props in run-windows",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
@@ -50,7 +50,7 @@ function optionSanitizer(key: keyof RunWindowsOptions, value: any): any {
     case 'buildLogDirectory':
       return value === undefined ? false : true; // Strip PII
     case 'msbuildprops':
-      return value === undefined ? 0 : value.split(',').length; // Convert to count
+      return typeof value === 'string' ? value.split(',').length : 0; // Convert to count
     case 'release':
     case 'arch':
     case 'singleproc':

--- a/packages/@react-native-windows/cli/src/utils/build.ts
+++ b/packages/@react-native-windows/cli/src/utils/build.ts
@@ -8,7 +8,7 @@ import path from 'path';
 
 import MSBuildTools from './msbuildtools';
 import Version from './version';
-import {newError} from './commandWithProgress';
+import {newError, newWarn} from './commandWithProgress';
 import {
   RunWindowsOptions,
   BuildConfig,
@@ -122,11 +122,15 @@ export function parseMsBuildProps(
   options: RunWindowsOptions,
 ): Record<string, string> {
   const result: Record<string, string> = {};
-  if (options.msbuildprops) {
+  if (typeof options.msbuildprops === 'string') {
     const props = options.msbuildprops.split(',');
     for (const prop of props) {
       const propAssignment = prop.split('=');
-      result[propAssignment[0]] = propAssignment[1];
+      if (propAssignment.length === 2 && propAssignment[0].trim().length > 0) {
+        result[propAssignment[0].trim()] = propAssignment[1].trim();
+      } else if (options.logging === true) {
+        newWarn(`Unable to parse msbuildprop: '${prop}'`);
+      }
     }
   }
   return result;


### PR DESCRIPTION
This PR backports #13665 to 0.75.

## Description

This PR fixes the two issues with `run-windows --msbuildprops`

1. When passing nothing, the command should not error and exit
2. When the string is parsed into key/value pairs, do not add empty keys to the msbuild command (which will cause msbuild to fail)

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Ran into these issues while working on PR #13634, extracted them as general bug fixes here.

### What
See above.

## Screenshots
N/A

## Testing
Verified running `run-windows` with malformed `--msbuildprops` no longer errors.

## Changelog
Should this change be included in the release notes: _yes_

[0.75] Fix parsing of empty build props in run-windows
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13704)