### PR TITLE
Moving childrenWithImportantForAccessibility creation out of every View

### DIFF
--- a/change/react-native-windows-34f9da3d-13df-48ee-8489-f8f3de5cb985.json
+++ b/change/react-native-windows-34f9da3d-13df-48ee-8489-f8f3de5cb985.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Moving childrenWithImportantForAccessibility creation out of every View render",
+  "packageName": "react-native-windows",
+  "email": "sawalker@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/src-win/Libraries/Components/View/View.windows.js
+++ b/vnext/src-win/Libraries/Components/View/View.windows.js
@@ -20,6 +20,38 @@ import type {KeyEvent} from '../../Types/CoreEventTypes';
 
 export type Props = ViewProps;
 
+// [Windows
+// $FlowFixMe - children typing
+const childrenWithImportantForAccessibility = children => {
+  if (children == null) {
+    return children;
+  }
+  const updatedChildren = React.Children.map(children, child => {
+    if (React.isValidElement(child)) {
+      // $FlowFixMe[incompatible-use]
+      if (child.props.children) {
+        // $FlowFixMe[incompatible-call]
+        return React.cloneElement(child, {
+          accessible: false,
+          children: childrenWithImportantForAccessibility(
+            child.props.children,
+          ),
+        });
+      } else {
+        // $FlowFixMe[incompatible-call]
+        return React.cloneElement(child, {accessible: false});
+      }
+    }
+    return child;
+  });
+  if (updatedChildren.length === 1) {
+    return updatedChildren[0];
+  } else {
+    return updatedChildren;
+  }
+};
+// Windows]
+
 /**
  * The most fundamental component for building a UI, View is a container that
  * supports layout with flexbox, style, some touch handling, and accessibility
@@ -165,36 +197,6 @@ const View: React.AbstractComponent<
     };
 
     // [Windows
-    // $FlowFixMe - children typing
-    const childrenWithImportantForAccessibility = children => {
-      if (children == null) {
-        return children;
-      }
-      const updatedChildren = React.Children.map(children, child => {
-        if (React.isValidElement(child)) {
-          // $FlowFixMe[incompatible-use]
-          if (child.props.children) {
-            // $FlowFixMe[incompatible-call]
-            return React.cloneElement(child, {
-              accessible: false,
-              children: childrenWithImportantForAccessibility(
-                child.props.children,
-              ),
-            });
-          } else {
-            // $FlowFixMe[incompatible-call]
-            return React.cloneElement(child, {accessible: false});
-          }
-        }
-        return child;
-      });
-      if (updatedChildren.length === 1) {
-        return updatedChildren[0];
-      } else {
-        return updatedChildren;
-      }
-    };
-
     const _focusable = tabIndex !== undefined ? !tabIndex : focusable;
     const _accessible =
       importantForAccessibility === 'no-hide-descendants'


### PR DESCRIPTION
## Description
childrenWithImportantForAccessibility  is created in every render and probably used infrequently.
This PR seeks to move it to a standalone function within the file to avoid the cost to create the function over and over.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
This should be an extremely minor performance increase.

### What
Moved a function creation out of the rendered View to the file module.

## Testing
Tested locally in the Xbox app

- Rendered views with no children
- Rendered views with children
- Rendered views with children and the `importantForAccessibility` set to "no-hide-descendants"

## Changelog
Probably not. Not important.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13877)