### PR TITLE
fix(cli): additional search paths for New Arch

### DIFF
--- a/change/@react-native-windows-cli-d7725610-1df7-4b35-847b-4f0bbbe377fb.json
+++ b/change/@react-native-windows-cli-d7725610-1df7-4b35-847b-4f0bbbe377fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add additional search paths for New Arch builds",
+  "packageName": "@react-native-windows/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/utils/deploy.ts
@@ -126,7 +126,8 @@ function getAppPackage(
       ? `{*_x86_${configuration}_*,*_Win32_${configuration}_*}`
       : `*_${options.arch}_${configuration}_*`;
 
-  const appPackageGlob = `${options.root}/windows/{*/AppPackages,AppPackages/*}/${packageFolder}`;
+  const rootGlob = `${options.root}/windows/{*/AppPackages,AppPackages/*,${options.arch}/${configuration}/*/AppPackages}`;
+  const appPackageGlob = `${rootGlob}/${packageFolder}`;
   const appPackageCandidates = glob.sync(appPackageGlob);
   let appPackage;
   if (appPackageCandidates.length === 1 || !projectName) {
@@ -146,7 +147,6 @@ function getAppPackage(
       'No package found in *_Release_* folder, removing the _Release_ prefix and checking again',
     );
 
-    const rootGlob = `${options.root}/windows/{*/AppPackages,AppPackages/*}`;
     const newGlob = `${rootGlob}/*_${
       options.arch === 'x86' ? '{Win32,x86}' : options.arch
     }_Test`;


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

`@react-native-windows/cli` currently looks for the app package path in paths that may not be written to when New Arch is enabled.

### What

This change adds another path that the app package may be output to when New Arch is enabled.

## Screenshots

n/a

## Testing

n/a

## Changelog

Should this change be included in the release notes: yes

Added additional search paths for New Arch builds

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13880)