### PR TITLE
Add invoke support for 'link' accessibilityRole

### DIFF
--- a/change/react-native-windows-9126fadc-f129-4191-92d1-bbfd77422aea.json
+++ b/change/react-native-windows-9126fadc-f129-4191-92d1-bbfd77422aea.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add invoke support for link",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -257,7 +257,8 @@ winrt::IInspectable DynamicAutomationPeer::GetPatternCore(winrt::PatternInterfac
   if (patternInterface == winrt::PatternInterface::Invoke &&
       (accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Button ||
        accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::ImageButton ||
-       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Radio)) {
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Radio ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Link)) {
     return *this;
   } else if (
       (patternInterface == winrt::PatternInterface::Selection ||


### PR DESCRIPTION
## Description
Add 'link' accessibilityRole to the list of controls that support the invoke provider.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Resolves #13861

### What
Added the 'link' accessibilityRole to list of controls that are supported by the Invoke provider in `DynamicAutomationPeer`.

## Screenshots
Tested on a `Pressable` with `accessibilityRole='link'`

Before:
![Link without invoke](https://github.com/user-attachments/assets/f7cd75cd-7960-46ba-9b55-a31d86e149ec)

After:
![image](https://github.com/user-attachments/assets/e6916c63-d90d-4fe9-9440-c089b65f9361)

## Changelog
Should this change be included in the release notes: Yes

Add 'link' accessibilityRole to the list of controls that support the invoke provider.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13891)