### PR TITLE
SampleTurboModule only works as a turbomodule, so do not install it when using web debugger

### DIFF
--- a/change/react-native-windows-8fc62f61-155f-45b2-824c-26d42a3281cb.json
+++ b/change/react-native-windows-8fc62f61-155f-45b2-824c-26d42a3281cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "SampleTurboModule only works as a turbomodule, so do not install it when using web debugger",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -401,7 +401,10 @@ void ReactInstanceWin::LoadModules(
 #endif
 
   if (!m_options.UseWebDebugger()) {
-    turboModulesProvider->AddModuleProvider(L"SampleTurboModule", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::SampleTurboModule>()), false);
+    turboModulesProvider->AddModuleProvider(
+        L"SampleTurboModule",
+        winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::SampleTurboModule>(),
+        false);
   }
 
   if (devSettings->useTurboModulesOnly) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -400,9 +400,9 @@ void ReactInstanceWin::LoadModules(
   }
 #endif
 
-  registerTurboModule(
-      L"SampleTurboModule",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::SampleTurboModule>());
+  if (!m_options.UseWebDebugger()) {
+    turboModulesProvider->AddModuleProvider(L"SampleTurboModule", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::SampleTurboModule>()), false);
+  }
 
   if (devSettings->useTurboModulesOnly) {
     ::Microsoft::ReactNative::ExceptionsManager::SetRedBoxHander(


### PR DESCRIPTION
## Description
WebDebugging currently crashes due to usage of a TurboModule only module trying to initialize.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13911)