### PR TITLE
Fix escaping arguments for PowerShell tasks

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -195,7 +195,7 @@ jobs:
                 inputs:
                   targetType: filePath # filePath | inline
                   filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-                  arguments: "-ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose"
+                  arguments: -ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose
 
               # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
               # of debug feature tests. In the future, these tests should be performed against a host app

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -190,12 +190,9 @@ jobs:
                     New-Item -Path '$(Build.StagingDirectory)\DebugTestCrashDumps' -ItemType Directory
                 displayName: Set CrashDumpRootPath
 
-              - task: PowerShell@2
+              - powershell: |
+                  & $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1 -ProcDumpArgs @("-mm", "-i", "$(CrashDumpRootPath)") -ProcDumpInstallPath "$(ProcDumpPath)" -Verbose
                 displayName: Setup ProcDump as AeDebug
-                inputs:
-                  targetType: filePath # filePath | inline
-                  filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-                  arguments: -ProcDumpArgs @("-mm", "-i", "$(CrashDumpRootPath)") -ProcDumpInstallPath "$(ProcDumpPath)" -Verbose
 
               # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
               # of debug feature tests. In the future, these tests should be performed against a host app

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -195,7 +195,7 @@ jobs:
                 inputs:
                   targetType: filePath # filePath | inline
                   filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-                  arguments: -ProcDumpArgs `@(`'-mm`', `'-i`', `'$(CrashDumpRootPath)`') -ProcDumpInstallPath `'$(ProcDumpPath)`' -Verbose
+                  arguments: -ProcDumpArgs @("-mm", "-i", "$(CrashDumpRootPath)") -ProcDumpInstallPath "$(ProcDumpPath)" -Verbose
 
               # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
               # of debug feature tests. In the future, these tests should be performed against a host app

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -195,7 +195,7 @@ jobs:
                 inputs:
                   targetType: filePath # filePath | inline
                   filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-                  arguments: -ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose
+                  arguments: -ProcDumpArgs `@('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose
 
               # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
               # of debug feature tests. In the future, these tests should be performed against a host app

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -195,7 +195,7 @@ jobs:
                 inputs:
                   targetType: filePath # filePath | inline
                   filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-                  arguments: -ProcDumpArgs `@('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose
+                  arguments: -ProcDumpArgs `@(`'-mm`', `'-i`', `'$(CrashDumpRootPath)`') -ProcDumpInstallPath `'$(ProcDumpPath)`' -Verbose
 
               # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
               # of debug feature tests. In the future, these tests should be performed against a host app

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -61,4 +61,4 @@ steps:
     inputs:
       targetType: filePath # filePath | inline
       filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-      arguments: "-ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose"
+      arguments: -ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -56,12 +56,7 @@ steps:
         Write-Host "##vso[task.setvariable variable=ProcDumpPath]$(Build.StagingDirectory)\Procdump"
     displayName: Set ProcDumpPath
 
-  - task: PowerShell@2
+  - powershell: |
+      & $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1 -ProcDumpArgs @("-mm", "-i", "$(CrashDumpRootPath)") -ProcDumpInstallPath "$(ProcDumpPath)" -Verbose
     displayName: Setup ProcDump as AeDebug
-    inputs:
-      targetType: filePath # filePath | inline
-      filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-      arguments: >
-        -ProcDumpArgs @()
-        -ProcDumpInstallPath "$(ProcDumpPath)"
-        -Verbose
+  

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -61,4 +61,4 @@ steps:
     inputs:
       targetType: filePath # filePath | inline
       filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-      arguments: -ProcDumpArgs `@(`'-mm`', `'-i`', `'$(CrashDumpRootPath)`') -ProcDumpInstallPath `'$(ProcDumpPath)`' -Verbose
+      arguments: -ProcDumpArgs @("-mm", "-i", "$(CrashDumpRootPath)") -ProcDumpInstallPath "$(ProcDumpPath)" -Verbose

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -62,5 +62,6 @@ steps:
       targetType: filePath # filePath | inline
       filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
       arguments: >
+        -ProcDumpArgs @()
         -ProcDumpInstallPath "$(ProcDumpPath)"
         -Verbose

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -62,6 +62,5 @@ steps:
       targetType: filePath # filePath | inline
       filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
       arguments: >
-        -ProcDumpArgs @("-mm", "-i", "`$(CrashDumpRootPath)")
-        -ProcDumpInstallPath "`$(ProcDumpPath)"
+        -ProcDumpInstallPath "$(ProcDumpPath)"
         -Verbose

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -61,4 +61,4 @@ steps:
     inputs:
       targetType: filePath # filePath | inline
       filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-      arguments: -ProcDumpArgs `@('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose
+      arguments: -ProcDumpArgs `@(`'-mm`', `'-i`', `'$(CrashDumpRootPath)`') -ProcDumpInstallPath `'$(ProcDumpPath)`' -Verbose

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -61,4 +61,7 @@ steps:
     inputs:
       targetType: filePath # filePath | inline
       filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-      arguments: -ProcDumpArgs @("-mm", "-i", "$(CrashDumpRootPath)") -ProcDumpInstallPath "$(ProcDumpPath)" -Verbose
+      arguments: >
+        -ProcDumpArgs @("-mm", "-i", "`$(CrashDumpRootPath)")
+        -ProcDumpInstallPath "`$(ProcDumpPath)"
+        -Verbose

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -61,4 +61,4 @@ steps:
     inputs:
       targetType: filePath # filePath | inline
       filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
-      arguments: -ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose
+      arguments: -ProcDumpArgs `@('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose


### PR DESCRIPTION
## Description

Fixing error blocking PRs due to surprise ADO policy change:

```
Detected characters in arguments that may not be executed correctly by the shell. Please escape special characters using backtick (`). More information is available here: https://aka.ms/ado/75787
```

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Unblock pipelines.

### What
Fixed argument escaping.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13918)