### PR TITLE
[0.76] Exclude NuGet package lock files from NPM packages (#13916)

### DIFF
--- a/change/@react-native-windows-automation-channel-618f52b6-bbe6-4449-9165-d6a447f0da53.json
+++ b/change/@react-native-windows-automation-channel-618f52b6-bbe6-4449-9165-d6a447f0da53.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "[0.76] Exclude NuGet package lock files from NPM packages",
-  "packageName": "@react-native-windows/automation-channel",
-  "email": "jthysell@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@react-native-windows-automation-channel-618f52b6-bbe6-4449-9165-d6a447f0da53.json
+++ b/change/@react-native-windows-automation-channel-618f52b6-bbe6-4449-9165-d6a447f0da53.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.76] Exclude NuGet package lock files from NPM packages",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-73248300-7bfa-4031-8b40-14125d248e4f.json
+++ b/change/react-native-windows-73248300-7bfa-4031-8b40-14125d248e4f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.76] Exclude NuGet package lock files from NPM packages",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation-channel/package.json
+++ b/packages/@react-native-windows/automation-channel/package.json
@@ -37,7 +37,9 @@
   },
   "files": [
     "lib-commonjs",
-    "windows"
+    "windows",
+    "!packages.lock.json",
+    "!packages.fabric.lock.json"
   ],
   "engines": {
     "node": ">= 18"

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -144,7 +144,9 @@
     "/metro-react-native-platform.js",
     "/metro.config.js",
     "/react-native.config.js",
-    "/rn-get-polyfills.js"
+    "/rn-get-polyfills.js",
+    "!packages.lock.json",
+    "!packages.fabric.lock.json"
   ],
   "promoteRelease": true,
   "engines": {


### PR DESCRIPTION
## Description

Removes the `packages.lock.json` and `packages.fabric.lock.json` files from our published NPM packages, as customers who choose to build M.RN themselves don't necessarily choose the same dependencies as us (such as SourceLink).

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
See above.

Resolves #13914

### What
Added filters to the NPM `package.json` files to exclude these lock files.

## Screenshots
N/A

## Testing
Verified with `npm pack` that new packages do not contain these files.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13923)