### PR TITLE
Fix RootComponentView leak

### DIFF
--- a/change/react-native-windows-408fe985-f784-4dff-aed3-9045a0c7a420.json
+++ b/change/react-native-windows-408fe985-f784-4dff-aed3-9045a0c7a420.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix RootComponentView leak",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -157,6 +157,7 @@ void ReactNativeIsland::ReactViewHost(winrt::Microsoft::ReactNative::IReactViewH
   }
 
   if (m_reactViewHost) {
+    UninitRootView();
     m_reactViewHost.DetachViewInstance();
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -155,6 +155,9 @@ void FabricUIManager::startSurface(
 
 void FabricUIManager::stopSurface(facebook::react::SurfaceId surfaceId) noexcept {
   m_surfaceManager->stopSurface(surfaceId);
+  auto& rootDescriptor = m_registry.componentViewDescriptorWithTag(surfaceId);
+  m_registry.enqueueComponentViewWithComponentHandle(
+    facebook::react::RootShadowNode::Handle(), surfaceId, rootDescriptor);
 }
 
 winrt::Microsoft::ReactNative::ReactNativeIsland FabricUIManager::GetReactNativeIsland(

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -155,9 +155,9 @@ void FabricUIManager::startSurface(
 
 void FabricUIManager::stopSurface(facebook::react::SurfaceId surfaceId) noexcept {
   m_surfaceManager->stopSurface(surfaceId);
-  auto& rootDescriptor = m_registry.componentViewDescriptorWithTag(surfaceId);
+  auto &rootDescriptor = m_registry.componentViewDescriptorWithTag(surfaceId);
   m_registry.enqueueComponentViewWithComponentHandle(
-    facebook::react::RootShadowNode::Handle(), surfaceId, rootDescriptor);
+      facebook::react::RootShadowNode::Handle(), surfaceId, rootDescriptor);
 }
 
 winrt::Microsoft::ReactNative::ReactNativeIsland FabricUIManager::GetReactNativeIsland(


### PR DESCRIPTION
## Description
When removing a ReactNativeIsland the RootComponentView is kept around in the FabricUIManager until the instance is shutdown.  This means if you have a long running instance, and you create/destroy lots of ReactNativeIslands these objects will build up over time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13959)