### PR TITLE
[0.74] Build arm64ec platform for desktop fabric dll

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -70,6 +70,14 @@ parameters:
       BuildConfiguration: Release
       BuildPlatform: x86
       UseFabric: true
+    - Name: ARM64ECDebugFabric
+      BuildConfiguration: Debug
+      BuildPlatform: ARM64EC
+      UseFabric: true
+    - Name: ARM64ECReleaseFabric
+      BuildConfiguration: Release
+      BuildPlatform: ARM64EC
+      UseFabric: true
 
 - name: universalBuildMatrix
   type: object
@@ -529,14 +537,14 @@ extends:
                   configuration: Release
                 - platform: x86
                   configuration: Release
-                # - platform: ARM64EC
-                #   configuration: Release
+                - platform: ARM64EC
+                  configuration: Release
                 - platform: x64
                   configuration: Debug
                 - platform: x86
                   configuration: Debug
-                # - platform: ARM64EC
-                #   configuration: Debug
+                - platform: ARM64EC
+                  configuration: Debug
 
           templateContext:
             sdl:

--- a/change/react-native-windows-517cb4e7-9eb3-490c-ba03-b7e303394065.json
+++ b/change/react-native-windows-517cb4e7-9eb3-490c-ba03-b7e303394065.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Build arm64ec platform for desktop fabric dll",
+  "packageName": "react-native-windows",
+  "email": "53619745+rnbot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -111,7 +111,12 @@
         %(AdditionalDependencies);
         Bcrypt.lib;
         Chakrart.lib;
-        Pathcch.lib
+        D2D1.lib;
+        D3D11.lib;
+        DWrite.lib;
+        Pathcch.lib;
+        ShCore.lib;
+        Uiautomationcore.lib
       </AdditionalDependencies>
       <DelayLoadDLLs>Chakra.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>


### PR DESCRIPTION
Office requires a Arm64EC version of the desktop fabric dll.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13978)