### PR TITLE
Introducing `--list` option to `init-windows`

### DIFF
--- a/change/@react-native-windows-cli-20847412-8db7-478f-97c3-d42fd0a860a7.json
+++ b/change/@react-native-windows-cli-20847412-8db7-478f-97c3-d42fd0a860a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added --list option to init-windows",
+  "packageName": "@react-native-windows/cli",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
@@ -125,107 +125,123 @@ export class InitWindows {
     return name;
   }
 
+  protected printTemplateList() {
+    if (this.templates.size === 0) {
+      console.log('\nNo templates found.\n');
+      return;
+    }
+
+    for (const [key, value] of this.templates.entries()) {
+      console.log(`\n${key} - ${value.name}\n    ${value.description}`);
+    }
+    console.log(`\n`)
+  }
+
   public async run(spinner: Ora) {
     await this.loadTemplates();
 
     spinner.info();
 
-    this.options.template ??= this.getDefaultTemplateName();
-
-    spinner.info(`Using template '${this.options.template}'...`);
-    if (!this.templates.has(this.options.template.replace(/[\\]/g, '/'))) {
-      throw new CodedError(
-        'InvalidTemplateName',
-        `Unable to find template '${this.options.template}'.`,
-      );
+    if (this.options.list) {
+      this.printTemplateList();
     }
-    const templateConfig = this.templates.get(this.options.template)!;
+    else {
+      this.options.template ??= this.getDefaultTemplateName();
 
-    // Check if there's a passed-in project name and if it's valid
-    if (this.options.name && !nameHelpers.isValidProjectName(this.options.name)) {
-      throw new CodedError(
-        'InvalidProjectName',
-        `The specified name '${this.options.name}' is not a valid identifier`,
-      );
-    }
-
-    // If no project name is provided, calculate the name and clean if necessary
-    if (!this.options.name) {
-      const projectName = this.getReactNativeProjectName(this.config.root);
-      this.options.name = nameHelpers.isValidProjectName(projectName)
-        ? projectName
-        : nameHelpers.cleanName(projectName);
-    }
-
-    // Final check that the project name is valid
-    if (!nameHelpers.isValidProjectName(this.options.name)) {
-      throw new CodedError(
-        'InvalidProjectName',
-        `The name '${this.options.name}' is not a valid identifier`,
-      );
-    }
-
-    // Check if there's a passed-in project namespace and if it's valid
-    if (this.options.namespace && !nameHelpers.isValidProjectNamespace(this.options.namespace)) {
-      throw new CodedError(
-        'InvalidProjectNamespace',
-        `The specified namespace '${this.options.namespace}' is not a valid identifier`,
-      );
-    }
-
-    // If no project namespace is provided, use the project name and clean if necessary
-    if (!this.options.namespace) {
-      const namespace = this.options.name;
-      this.options.namespace = nameHelpers.isValidProjectNamespace(namespace)
-        ? namespace
-        : nameHelpers.cleanNamespace(namespace);
-    }
-
-    // Final check that the project namespace is valid
-    if (!nameHelpers.isValidProjectNamespace(this.options.namespace)) {
-      throw new CodedError(
-        'InvalidProjectNamespace',
-        `The namespace '${this.options.namespace}' is not a valid identifier`,
-      );
-    }
-
-    if (templateConfig.preInstall) {
-      spinner.info(`Running ${this.options.template} preInstall()...`);
-      await templateConfig.preInstall(this.config, this.options);
-    }
-
-    // Get template files to copy and copy if available
-    if (templateConfig.getFileMappings) {
-      const fileMappings = await templateConfig.getFileMappings(
-        this.config,
-        this.options,
-      );
-
-      for (const fileMapping of fileMappings) {
-        const targetDir = path.join(
-          this.config.root,
-          path.dirname(fileMapping.to),
-        );
-
-        if (!(await fs.exists(targetDir))) {
-          await fs.mkdir(targetDir, {recursive: true});
-        }
-
-        await copyAndReplaceWithChangedCallback(
-          fileMapping.from,
-          this.config.root,
-          fileMapping.to,
-          fileMapping.replacements,
-          this.options.overwrite,
+      spinner.info(`Using template '${this.options.template}'...`);
+      if (!this.templates.has(this.options.template.replace(/[\\]/g, '/'))) {
+        throw new CodedError(
+          'InvalidTemplateName',
+          `Unable to find template '${this.options.template}'.`,
         );
       }
-    }
+      const templateConfig = this.templates.get(this.options.template)!;
 
-    if (templateConfig.postInstall) {
-      spinner.info(`Running ${this.options.template} postInstall()...`);
-      await templateConfig.postInstall(this.config, this.options);
-    }
+      // Check if there's a passed-in project name and if it's valid
+      if (this.options.name && !nameHelpers.isValidProjectName(this.options.name)) {
+        throw new CodedError(
+          'InvalidProjectName',
+          `The specified name '${this.options.name}' is not a valid identifier`,
+        );
+      }
 
+      // If no project name is provided, calculate the name and clean if necessary
+      if (!this.options.name) {
+        const projectName = this.getReactNativeProjectName(this.config.root);
+        this.options.name = nameHelpers.isValidProjectName(projectName)
+          ? projectName
+          : nameHelpers.cleanName(projectName);
+      }
+
+      // Final check that the project name is valid
+      if (!nameHelpers.isValidProjectName(this.options.name)) {
+        throw new CodedError(
+          'InvalidProjectName',
+          `The name '${this.options.name}' is not a valid identifier`,
+        );
+      }
+
+      // Check if there's a passed-in project namespace and if it's valid
+      if (this.options.namespace && !nameHelpers.isValidProjectNamespace(this.options.namespace)) {
+        throw new CodedError(
+          'InvalidProjectNamespace',
+          `The specified namespace '${this.options.namespace}' is not a valid identifier`,
+        );
+      }
+
+      // If no project namespace is provided, use the project name and clean if necessary
+      if (!this.options.namespace) {
+        const namespace = this.options.name;
+        this.options.namespace = nameHelpers.isValidProjectNamespace(namespace)
+          ? namespace
+          : nameHelpers.cleanNamespace(namespace);
+      }
+
+      // Final check that the project namespace is valid
+      if (!nameHelpers.isValidProjectNamespace(this.options.namespace)) {
+        throw new CodedError(
+          'InvalidProjectNamespace',
+          `The namespace '${this.options.namespace}' is not a valid identifier`,
+        );
+      }
+
+      if (templateConfig.preInstall) {
+        spinner.info(`Running ${this.options.template} preInstall()...`);
+        await templateConfig.preInstall(this.config, this.options);
+      }
+
+      // Get template files to copy and copy if available
+      if (templateConfig.getFileMappings) {
+        const fileMappings = await templateConfig.getFileMappings(
+          this.config,
+          this.options,
+        );
+
+        for (const fileMapping of fileMappings) {
+          const targetDir = path.join(
+            this.config.root,
+            path.dirname(fileMapping.to),
+          );
+
+          if (!(await fs.exists(targetDir))) {
+            await fs.mkdir(targetDir, {recursive: true});
+          }
+
+          await copyAndReplaceWithChangedCallback(
+            fileMapping.from,
+            this.config.root,
+            fileMapping.to,
+            fileMapping.replacements,
+            this.options.overwrite,
+          );
+        }
+      }
+
+      if (templateConfig.postInstall) {
+        spinner.info(`Running ${this.options.template} postInstall()...`);
+        await templateConfig.postInstall(this.config, this.options);
+      }
+    }
     spinner.succeed();
   }
 }
@@ -259,6 +275,7 @@ function optionSanitizer(key: keyof InitOptions, value: any): any {
     case 'template':
     case 'overwrite':
     case 'telemetry':
+    case 'list':
       return value === undefined ? false : value; // Return value
   }
 }

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
@@ -132,7 +132,8 @@ export class InitWindows {
     }
 
     for (const [key, value] of this.templates.entries()) {
-      console.log(`\n${key} - ${value.name}\n    ${value.description}`);
+      const defaultLabel = value.isDefault ? chalk.yellow('[Default] ') : '';
+      console.log(`\n${key} - ${value.name}\n    ${defaultLabel}${value.description}`);      
     }
     console.log(`\n`)
   }

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -13,6 +13,7 @@ export interface InitOptions {
   namespace?: string;
   overwrite?: boolean;
   telemetry?: boolean;
+  list?: boolean;
 }
 
 export const initOptions: CommandOption[] = [
@@ -45,5 +46,10 @@ export const initOptions: CommandOption[] = [
     name: '--no-telemetry',
     description:
       'Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI',
+  },
+  {
+    name: '--list',
+    description:
+      'Shows a list with all available templates with their descriptions.',
   },
 ];

--- a/packages/@react-native-windows/cli/src/e2etest/initWindows.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/initWindows.test.ts
@@ -25,6 +25,7 @@ function validateOptionName(
     case 'namespace':
     case 'overwrite':
     case 'telemetry':
+    case 'list':
       return true;
   }
   throw new Error(


### PR DESCRIPTION
## Description
Introducing `--list` option to `init-windows` command.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Displays a list of templates available for usage with `init-windows`.

Resolves #13459

### What
- Added `--list` description, in case developers look for command help.
- Created a function to display template key, name and description in a friendly-readable format.

## Screenshots
https://github.com/user-attachments/assets/ae57779b-c257-4fe7-be5d-0066b65eed6d

## Testing
Ran the cli tests locally, with all tests passing after the change.

## Changelog
Should this change be included in the release notes: yes.

Introduced `--list` option to `init-windows` command.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13986)