### PR TITLE
[0.76] Introducing `--list` option to `init-windows`

### DIFF
--- a/change/@react-native-windows-cli-20847412-8db7-478f-97c3-d42fd0a860a7.json
+++ b/change/@react-native-windows-cli-20847412-8db7-478f-97c3-d42fd0a860a7.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Added --list option to init-windows",
-  "packageName": "@react-native-windows/cli",
-  "email": "14967941+danielayala94@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@react-native-windows-cli-20847412-8db7-478f-97c3-d42fd0a860a7.json
+++ b/change/@react-native-windows-cli-20847412-8db7-478f-97c3-d42fd0a860a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added --list option to init-windows",
+  "packageName": "@react-native-windows/cli",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@react-native-windows-cli-c88dbeae-73cb-4394-b26a-9eed7864646c.json
+++ b/change/@react-native-windows-cli-c88dbeae-73cb-4394-b26a-9eed7864646c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Introducing `--list` option to `init-windows` (#13986)",
+  "packageName": "@react-native-windows/cli",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
@@ -125,10 +125,28 @@ export class InitWindows {
     return name;
   }
 
+  protected printTemplateList() {
+    if (this.templates.size === 0) {
+      console.log('\nNo templates found.\n');
+      return;
+    }
+
+    for (const [key, value] of this.templates.entries()) {
+      const defaultLabel = value.isDefault ? chalk.yellow('[Default] ') : '';
+      console.log(`\n${key} - ${value.name}\n    ${defaultLabel}${value.description}`);      
+    }
+    console.log(`\n`)
+  }
+
   public async run(spinner: Ora) {
     await this.loadTemplates();
 
     spinner.info();
+
+    if (this.options.list) {
+      this.printTemplateList();
+      return;
+    }
 
     this.options.template ??= this.getDefaultTemplateName();
 
@@ -259,6 +277,7 @@ function optionSanitizer(key: keyof InitOptions, value: any): any {
     case 'template':
     case 'overwrite':
     case 'telemetry':
+    case 'list':
       return value === undefined ? false : value; // Return value
   }
 }

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -13,6 +13,7 @@ export interface InitOptions {
   namespace?: string;
   overwrite?: boolean;
   telemetry?: boolean;
+  list?: boolean;
 }
 
 export const initOptions: CommandOption[] = [
@@ -45,5 +46,10 @@ export const initOptions: CommandOption[] = [
     name: '--no-telemetry',
     description:
       'Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI',
+  },
+  {
+    name: '--list',
+    description:
+      'Shows a list with all available templates with their descriptions.',
   },
 ];

--- a/packages/@react-native-windows/cli/src/e2etest/initWindows.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/initWindows.test.ts
@@ -25,6 +25,7 @@ function validateOptionName(
     case 'namespace':
     case 'overwrite':
     case 'telemetry':
+    case 'list':
       return true;
   }
   throw new Error(


### PR DESCRIPTION
## Description
**Backporting #13986 into 0.76**

Introducing `--list` option to `init-windows` command.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Displays a list of templates available for usage with `init-windows`.

Resolves #13459

### What
- Added `--list` description, in case developers look for command help.
- Created a function to display template key, name and description in a friendly-readable format.

## Screenshots
https://github.com/user-attachments/assets/ae57779b-c257-4fe7-be5d-0066b65eed6d

## Testing
Ran the cli tests locally, with all tests passing after the change.

## Changelog
Should this change be included in the release notes: yes.

Introduced `--list` option to `init-windows` command.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13986)