### PR TITLE
Default scroll to bring a component into view should have padding around the viewport

### DIFF
--- a/change/react-native-windows-6b83103d-e55d-427a-a482-d2706e24f6a0.json
+++ b/change/react-native-windows-6b83103d-e55d-427a-a482-d2706e24f6a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Default scroll to bring a component into view should have padding around the viewport",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -37,11 +37,11 @@ struct BringIntoViewOptions {
   bool AnimationDesired{false};
   // NaN will bring the element fully into view aligned to the nearest edge of the viewport
   float HorizontalAlignmentRatio{std::numeric_limits<float>::quiet_NaN()};
-  float HorizontalOffset{0};
+  float HorizontalOffset{20};
   std::optional<facebook::react::Rect> TargetRect;
   // NaN will bring the element fully into view aligned to the nearest edge of the viewport
   float VerticalAlignmentRatio{std::numeric_limits<float>::quiet_NaN()};
-  float VerticalOffset{0};
+  float VerticalOffset{20};
 };
 
 struct LayoutMetricsChangedArgs : public LayoutMetricsChangedArgsT<LayoutMetricsChangedArgs> {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -1112,9 +1112,9 @@ void ScrollViewComponentView::StartBringIntoView(
         options.TargetRect->origin.y > m_scrollVisual.ScrollPosition().y) {
       needsScroll = true;
       if (options.TargetRect->size.height > viewerHeight) {
-        scrollToVertical = options.TargetRect->origin.y + options.VerticalOffset;
+        scrollToVertical = options.TargetRect->origin.y + options.VerticalOffset * m_layoutMetrics.pointScaleFactor;
       } else {
-        scrollToVertical = (targetBottom - viewerHeight) + options.VerticalOffset;
+        scrollToVertical = (targetBottom - viewerHeight) + options.VerticalOffset * m_layoutMetrics.pointScaleFactor;
       }
       // Scroll Up
     } else if (
@@ -1122,9 +1122,9 @@ void ScrollViewComponentView::StartBringIntoView(
         targetBottom < (m_scrollVisual.ScrollPosition().y + viewerHeight)) {
       needsScroll = true;
       if (options.TargetRect->size.height > viewerHeight) {
-        scrollToVertical = targetBottom - viewerHeight - options.VerticalOffset;
+        scrollToVertical = targetBottom - viewerHeight - options.VerticalOffset * m_layoutMetrics.pointScaleFactor;
       } else {
-        scrollToVertical = options.TargetRect->origin.y - options.VerticalOffset;
+        scrollToVertical = options.TargetRect->origin.y - options.VerticalOffset * m_layoutMetrics.pointScaleFactor;
       }
     }
   } else {
@@ -1138,9 +1138,9 @@ void ScrollViewComponentView::StartBringIntoView(
         options.TargetRect->origin.x > m_scrollVisual.ScrollPosition().x) {
       needsScroll = true;
       if (options.TargetRect->size.width > viewerWidth) {
-        scrollToHorizontal = options.TargetRect->origin.x + options.HorizontalOffset;
+        scrollToHorizontal = options.TargetRect->origin.x + options.HorizontalOffset * m_layoutMetrics.pointScaleFactor;
       } else {
-        scrollToHorizontal = (targetRight - viewerWidth) + options.HorizontalOffset;
+        scrollToHorizontal = (targetRight - viewerWidth) + options.HorizontalOffset * m_layoutMetrics.pointScaleFactor;
       }
       // Scroll Left
     } else if (
@@ -1148,9 +1148,9 @@ void ScrollViewComponentView::StartBringIntoView(
         targetRight < (m_scrollVisual.ScrollPosition().x + viewerWidth)) {
       needsScroll = true;
       if (options.TargetRect->size.width > viewerWidth) {
-        scrollToHorizontal = targetRight - viewerWidth - options.HorizontalOffset;
+        scrollToHorizontal = targetRight - viewerWidth - options.HorizontalOffset * m_layoutMetrics.pointScaleFactor;
       } else {
-        scrollToHorizontal = options.TargetRect->origin.x - options.HorizontalOffset;
+        scrollToHorizontal = options.TargetRect->origin.x - options.HorizontalOffset * m_layoutMetrics.pointScaleFactor;
       }
     }
   } else {


### PR DESCRIPTION
Currently when tabbing to a component outside the visible viewport we scroll the scrollviewer just enough to being the component into view.  This changes the default to add some additional padding to being the component not completely to the edge of the viewport.

Fixes #14005 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14018)