### PR TITLE
[0.76] Update the `cpp-lib` template project to support importing either paper Uwp or fabric Composition prop/targets

### DIFF
--- a/change/@react-native-windows-cli-e586f288-c915-4e23-905d-df2ae20d6777.json
+++ b/change/@react-native-windows-cli-e586f288-c915-4e23-905d-df2ae20d6777.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.76] Create hybrid CppLib props/targets",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-10791c91-ee8b-489d-a0d2-a8047ec1cd70.json
+++ b/change/react-native-windows-10791c91-ee8b-489d-a0d2-a8047ec1cd70.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.76] Create hybrid CppLib props/targets",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
@@ -118,6 +118,10 @@ export function isRnwDependencyProject(filePath: string): boolean {
       importProjectExists(
         projectContents,
         'Microsoft.ReactNative.Composition.CppLib.targets',
+      ) ||
+      importProjectExists(
+        projectContents,
+        'Microsoft.ReactNative.CppLib.targets',
       )
     );
   }

--- a/packages/sample-custom-component/windows/SampleCustomComponent/SampleCustomComponent.vcxproj
+++ b/packages/sample-custom-component/windows/SampleCustomComponent/SampleCustomComponent.vcxproj
@@ -65,7 +65,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="ReactNativeWindowsPropertySheets">
-    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.props" />
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props')" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -137,13 +137,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ReactNativeWindowsTargets">
-    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets')" />
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets')" />
   </ImportGroup>
   <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references targets in your node_modules\react-native-windows folder. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.props'))" />
-    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets'))" />
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props'))" />
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets'))" />
   </Target>
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.CppLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.CppLib.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation.
+  Licensed under the MIT License.
+
+  This file will be consumed by ALL C++ module projects (both inside
+  and outside of this repo) that build on top of Microsoft.ReactNative.
+  Do not make any changes here unless it applies to ALL such projects.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Condition="'$(UseFabric)' == 'true'">
+    <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Composition.CppLib.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(UseFabric)' != 'true'">
+    <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.CppLib.props" />
+  </ImportGroup>
+</Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.CppLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.CppLib.targets
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation.
+  Licensed under the MIT License.
+
+  This file will be consumed by ALL C++ module projects (both inside
+  and outside of this repo) that build on top of Microsoft.ReactNative.
+  Do not make any changes here unless it applies to ALL such projects.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Condition="'$(UseFabric)' == 'true'">
+    <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Composition.CppLib.targets" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(UseFabric)' != 'true'">
+    <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.CppLib.targets" />
+  </ImportGroup>
+</Project>

--- a/vnext/templates/cpp-lib/windows/MyLib/MyLib.vcxproj
+++ b/vnext/templates/cpp-lib/windows/MyLib/MyLib.vcxproj
@@ -66,7 +66,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="ReactNativeWindowsPropertySheets">
-    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.props" />
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props')" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -131,7 +131,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ReactNativeWindowsTargets">
-    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets')" />
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets')" />
   </ImportGroup>
   <ItemGroup>
     {{#cppNugetPackages}}
@@ -142,7 +142,7 @@
     <PropertyGroup>
       <ErrorText>This project references targets in your node_modules\react-native-windows folder. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.props'))" />
-    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Composition.CppLib.targets'))" />
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.props'))" />
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.CppLib.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
This PR backports #13945 to 0.76.

## Description

This PR creates new "entry" prop/target imports for C++ libraries that depend on the `UseFabric` property to conditionally import either the old Uwp props/targets or the new Composition props/targets.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
This helps enable module projects to support both paper and fabric with the same build files.

Resolves #13928.

### What
Added new imports, updated the `cpp-lib` template and existing sample to load them.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: yes

Update the `cpp-lib` template project to support importing either paper Uwp or fabric Composition prop/targets
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14024)