### PR TITLE
Focus should notify island host when tab loop wraps to give host oportunity to take focus

### DIFF
--- a/change/react-native-windows-433ea974-44c7-465f-a6e9-1f34927c7217.json
+++ b/change/react-native-windows-433ea974-44c7-465f-a6e9-1f34927c7217.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Focus should notify island host when tab loop wraps to give host oportunity to take focus",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
@@ -342,10 +342,13 @@ bool ComponentView::runOnChildren(
         return true;
     }
   } else {
-    // TODO is this conversion from rend correct?
-    for (auto it = m_children.end(); it != m_children.begin(); --it) {
-      if (fn(*winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(*it)))
-        return true;
+    if (m_children.Size()) {
+      auto it = m_children.end();
+      do {
+        it--;
+        if (fn(*winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(*it)))
+          return true;
+      } while (it != m_children.begin());
     }
   }
   return false;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1913,6 +1913,9 @@ winrt::Microsoft::ReactNative::ComponentView lastDeepChild(
   return current;
 }
 
+// Walks the tree calling the function fn on each node.
+// If fn returns true, then walkTree stops itterating over the tree, and returns true.
+// If the tree walk completes without fn returning true, then walkTree returns false.
 bool walkTree(
     const winrt::Microsoft::ReactNative::ComponentView &view,
     bool forward,


### PR DESCRIPTION
## Description
There is a ContentIsland API DepartFocus, which we should be calling to allow the host to move focus outside of the island when focus reaches the end of the ReactNativeIsland.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14026)