### PR TITLE
Add very basic box-shadow support

### DIFF
--- a/change/react-native-windows-7edd982f-196f-4feb-a824-cbf08e0a2c96.json
+++ b/change/react-native-windows-7edd982f-196f-4feb-a824-cbf08e0a2c96.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add very basic box-shadow support",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1245,18 +1245,26 @@ void ComponentView::updateShadowProps(
   // Shadow Properties
   if (oldViewProps.shadowOffset != newViewProps.shadowOffset || oldViewProps.shadowColor != newViewProps.shadowColor ||
       oldViewProps.shadowOpacity != newViewProps.shadowOpacity ||
-      oldViewProps.shadowRadius != newViewProps.shadowRadius) {
+      oldViewProps.shadowRadius != newViewProps.shadowRadius || oldViewProps.boxShadow != newViewProps.boxShadow) {
     applyShadowProps(newViewProps);
   }
 }
 
 void ComponentView::applyShadowProps(const facebook::react::ViewProps &viewProps) noexcept {
   auto shadow = m_compContext.CreateDropShadow();
-  shadow.Offset({viewProps.shadowOffset.width, viewProps.shadowOffset.height, 0});
-  shadow.Opacity(viewProps.shadowOpacity);
-  shadow.BlurRadius(viewProps.shadowRadius);
-  if (viewProps.shadowColor)
-    shadow.Color(theme()->Color(*viewProps.shadowColor));
+  if (!viewProps.boxShadow.empty()) {
+    shadow.Offset({viewProps.boxShadow[0].offsetX, viewProps.boxShadow[0].offsetY, 0});
+    shadow.Opacity(1);
+    shadow.BlurRadius(viewProps.boxShadow[0].blurRadius);
+    shadow.Color(theme()->Color(*viewProps.boxShadow[0].color));
+  } else {
+    shadow.Offset({viewProps.shadowOffset.width, viewProps.shadowOffset.height, 0});
+    shadow.Opacity(viewProps.shadowOpacity);
+    shadow.BlurRadius(viewProps.shadowRadius);
+    if (viewProps.shadowColor)
+      shadow.Color(theme()->Color(*viewProps.shadowColor));
+  }
+
   Visual().as<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual>().Shadow(shadow);
 }
 


### PR DESCRIPTION
## Description
This hooks up support for a single box-shadow.  If multiple shadows are specified, we ignore all but the first shadow.  If box-shadow is provided, then its value is used instead of the legacy shadow properties.

This is a partial fix for https://github.com/microsoft/react-native-windows/issues/13944

There is another issue where shadows are not correctly showing currently on Views with a border radius. (#14027). That also affects the existing shadow properties.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14028)