### PR TITLE
Temporarily disable code-signing of NuGet packages

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -451,7 +451,7 @@ extends:
               packMicrosoftReactNativeManaged: true
               packMicrosoftReactNativeManagedCodeGen: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-                signMicrosoft: true
+                signMicrosoft: false # Temporarily disabled for all builds, see issue #14030
               slices:
                 - platform: x64
                   configuration: Release
@@ -477,7 +477,7 @@ extends:
               # packMicrosoftReactNativeManaged: true
               # packMicrosoftReactNativeManagedCodeGen: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-                signMicrosoft: true
+                signMicrosoft: false # Temporarily disabled for all builds, see issue #14030
               slices:
                 - platform: x64
                   configuration: Release
@@ -500,7 +500,7 @@ extends:
               nugetroot: $(System.DefaultWorkingDirectory)\Desktop
               packDesktop: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-                signMicrosoft: true
+                signMicrosoft: false # Temporarily disabled for all builds, see issue #14030
               slices:
                 - platform: x64
                   configuration: Release
@@ -523,7 +523,7 @@ extends:
               nugetroot: $(System.DefaultWorkingDirectory)\Desktop
               packDesktop: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-                signMicrosoft: true
+                signMicrosoft: false # Temporarily disabled for all builds, see issue #14030
               slices:
                 - platform: x64
                   configuration: Release

--- a/change/@react-native-windows-cli-a0eba9ea-32a2-43ac-925d-8f7cb0eae5d7.json
+++ b/change/@react-native-windows-cli-a0eba9ea-32a2-43ac-925d-8f7cb0eae5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Temporarily disable code-signing of NuGet packages",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-75287088-403a-4dd5-9392-ea74c6da3d3d.json
+++ b/change/react-native-windows-75287088-403a-4dd5-9392-ea74c6da3d3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Temporarily disable code-signing of NuGet packages",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -209,7 +209,8 @@ export async function copyProjectTemplateAndReplace(
 
     useExperimentalNuget: options.experimentalNuGetDependency,
     nuGetTestFeed: options.nuGetTestFeed,
-    nuGetADOFeed: nugetVersion.startsWith('0.0.0-'),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    nuGetADOFeed: true || nugetVersion.startsWith('0.0.0-'), // Temporary true for all new projects until code-signing is restored, see issue #14030
 
     // cpp template variables
     useWinUI3: options.useWinUI3,

--- a/vnext/templates/cpp-app/template.config.js
+++ b/vnext/templates/cpp-app/template.config.js
@@ -72,7 +72,7 @@ async function getFileMappings(config = {}, options = {}) {
     devMode,
 
     useNuGets: !devMode, // default is to use published NuGets except in devMode, change to true here if you want to test devMode and nugets simultaneously
-    addReactNativePublicAdoFeed: isCanary,
+    addReactNativePublicAdoFeed: true || isCanary, // Temporary true for all new projects until code-signing is restored, see issue #14030
 
     cppNugetPackages,
   };

--- a/vnext/templates/cpp-lib/template.config.js
+++ b/vnext/templates/cpp-lib/template.config.js
@@ -120,7 +120,7 @@ async function getFileMappings(config = {}, options = {}) {
     devMode,
 
     useNuGets: !devMode, // default is to use published NuGets except in devMode, change to true here if you want to test devMode and nugets simultaneously
-    addReactNativePublicAdoFeed: isCanary,
+    addReactNativePublicAdoFeed: true || isCanary, // Temporary true for all new projects until code-signing is restored, see issue #14030
 
     cppNugetPackages,
   };


### PR DESCRIPTION
## Description

This PR temporarily disables NuGet code-signing during publish and also forces all new projects to include our public ADO feed which will contain unsigned packages.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
See #14030 for why this is necessary.

### What
See above.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: _yes_

Temporarily disable code-signing of NuGet packages
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14034)