### PR TITLE
[Telemetry] Enable data uploading

### DIFF
--- a/change/@react-native-windows-telemetry-4abe7bcd-e858-4ab9-bc9c-3e2fd948acf2.json
+++ b/change/@react-native-windows-telemetry-4abe7bcd-e858-4ab9-bc9c-3e2fd948acf2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Set instrumentation key",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -37,7 +37,8 @@ interface CommandInfo {
 }
 
 // 1DS instrumentation key
-const RNW_1DS_INSTRUMENTATION_KEY = "49ff6d3ef12f4578a7b75a2573d9dba8-026332b2-2d50-452f-ad0d-50f921c97a9d-7145";
+const RNW_1DS_INSTRUMENTATION_KEY =
+  '49ff6d3ef12f4578a7b75a2573d9dba8-026332b2-2d50-452f-ad0d-50f921c97a9d-7145';
 
 // Environment variable to override the default setup string
 const ENV_SETUP_OVERRIDE = 'RNW_TELEMETRY_SETUP';

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -37,7 +37,7 @@ interface CommandInfo {
 }
 
 // 1DS instrumentation key
-const RNW_1DS_INSTRUMENTATION_KEY = '';
+const RNW_1DS_INSTRUMENTATION_KEY = "49ff6d3ef12f4578a7b75a2573d9dba8-026332b2-2d50-452f-ad0d-50f921c97a9d-7145";
 
 // Environment variable to override the default setup string
 const ENV_SETUP_OVERRIDE = 'RNW_TELEMETRY_SETUP';


### PR DESCRIPTION
## Description
Set the telemetry instrumentation key to upload telemetry.

**Resolves #14089**

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Currently, the telemetry data goes nowhere.

As the backend is taking shape, we can start to let the data to flow upstream.

### What
Instead of an empty instrumentation key, set the one associated to the RNW telemetry project.

## Screenshots
N/A

## Testing
Ran the telemetry unit tests. Number of telemetry instances is correctly updated to the backend, with little to no delay. Measures are getting updated too with the new data.

## Changelog
Yes

_Enables telemetry collection to monitor RNW reliability, performance, and usage._

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14039)