### PR TITLE
Change CLI CI timeouts to 40min

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -310,7 +310,7 @@ jobs:
               pool: ${{ parameters.AgentPool.Small }}
             ${{ else }}:
               pool: ${{ parameters.AgentPool.Medium }}
-            timeoutInMinutes: 120
+            timeoutInMinutes: 40
             cancelTimeoutInMinutes: 5
 
             steps:


### PR DESCRIPTION
## Description
When the CLI CI succeeds, it usually only takes < 20 min. Sometimes it goes up to low 30s, so reducing the timeout from 120 to 40 to increase speed of re-runs.

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14045)