### PR TITLE
[0.75] Backport certificate fixes to unblock CI

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -83,7 +83,6 @@ jobs:
             - template: ../templates/run-windows-with-certificates.yml
               parameters:
                 buildEnvironment: ${{ parameters.BuildEnvironment }}
-                certificateName: reactUWPTestAppEncodedKey
                 buildConfiguration: Release
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 buildLogDirectory: $(BuildLogDirectory)
@@ -191,7 +190,6 @@ jobs:
               - template: ../templates/run-windows-with-certificates.yml
                 parameters:
                   buildEnvironment: ${{ parameters.BuildEnvironment }}
-                  certificateName: reactUWPTestAppEncodedKey
                   buildConfiguration: Release
                   buildPlatform: ${{ matrix.BuildPlatform }}
                   buildLogDirectory: $(BuildLogDirectory)

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -134,8 +134,6 @@ jobs:
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/write-certificate.yml
-                parameters:
-                  certificateName: playgroundEncodedKey
 
             - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
               - template:  ../templates/set-experimental-feature.yml

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -8,6 +8,9 @@ parameters:
       - Continuous
   - name: AgentPool
     type: object
+  - name: certificatePassword
+    type: string
+    default: 'pwd'
   - name: buildMatrix
     type: object
     default:
@@ -134,7 +137,9 @@ jobs:
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/write-certificate.yml
-
+                parameters:
+                  certificatePassword: ${{ parameters.certificatePassword }}
+        
             - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
               - template:  ../templates/set-experimental-feature.yml
                 parameters:
@@ -173,6 +178,7 @@ jobs:
                 ${{if eq(config.BuildEnvironment, 'Continuous')}}:
                   msbuildArgs:
                     /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
+                    /p:PackageCertificatePassword=${{ parameters.certificatePassword }}
 
             - ${{if and(endsWith(matrix.Name, 'Universal'), eq(matrix.BuildConfiguration, 'Debug')) }}:
               # Execute debug feature tests (skip this step for the Win32 Playground app and for release builds)

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -94,7 +94,6 @@ jobs:
             - template: ../templates/run-windows-with-certificates.yml
               parameters:
                 buildEnvironment: ${{ parameters.BuildEnvironment }}
-                certificateName: sampleAppCPPEncodedKey
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 deployOption:  ${{ matrix.DeployOption }}
@@ -137,7 +136,6 @@ jobs:
             - template: ../templates/run-windows-with-certificates.yml
               parameters:
                 buildEnvironment: ${{ parameters.BuildEnvironment }}
-                certificateName: sampleAppCPPEncodedKey
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 deployOption:  ${{ matrix.DeployOption }}

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -177,7 +177,6 @@ steps:
   - template: ../templates/run-windows-with-certificates.yml
     parameters:
       buildEnvironment: ${{ parameters.BuildEnvironment }}
-      certificateName: RNWEncodedKey
       buildConfiguration: ${{ parameters.configuration }}
       buildPlatform: ${{ parameters.platform }}
       deployOption: ${{ parameters.additionalRunArguments }}

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -62,8 +62,8 @@ steps:
       workingDirectory: $(Agent.BuildDirectory)
 
   - ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
-    - script: |
-        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type module-new --react-native-version $(reactNativeDevDependency) --example vanilla testcli
+    - script: | # Force version 0.42.1, version 0.42.2 is broken, see https://github.com/callstack/react-native-builder-bob/issues/674
+        npx --yes create-react-native-library@0.42.1 --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type module-new --react-native-version $(reactNativeDevDependency) --example vanilla testcli
       displayName: Init new lib project with create-react-native-library
       workingDirectory: $(Agent.BuildDirectory)
 

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -161,7 +161,6 @@ steps:
   - template: ../templates/run-windows-with-certificates.yml
     parameters:
       buildEnvironment: ${{ parameters.BuildEnvironment }}
-      certificateName: RNWEncodedKey
       buildConfiguration: ${{ parameters.configuration }}
       buildPlatform: ${{ parameters.platform }}
       deployOption: ${{ parameters.additionalRunArguments }}

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -29,7 +29,10 @@ parameters:
   - name: moreMSBuildProps
     type: string
     default: ''
-
+  - name: certificatePassword
+    type: string
+    default: 'pwd'
+  
 steps:
   - ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
     - script: >
@@ -58,6 +61,8 @@ steps:
 
   - ${{ if and(eq(parameters.buildConfiguration, 'Release'), eq(parameters.buildEnvironment, 'Continuous')) }}:
     - template: ../templates/write-certificate.yml
+      parameters:
+        certificatePassword: ${{ parameters.certificatePassword }}
 
     - script: >
         yarn react-native run-windows
@@ -66,7 +71,7 @@ steps:
         --no-launch
         --logging
         --buildLogDirectory ${{ parameters.buildLogDirectory }}
-        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }},PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx${{ parameters.moreMSBuildProps }}
+        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }},PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx,PackageCertificatePassword=${{ parameters.certificatePassword }}${{ parameters.moreMSBuildProps }}
         ${{ parameters.deployOption }}
       displayName: run-windows (Release) - CI
       workingDirectory: ${{ parameters.workingDirectory }}

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -6,8 +6,6 @@ parameters:
       - PullRequest
       - SecurePullRequest
       - Continuous
-  - name: certificateName
-    type: string
   - name: buildConfiguration
     type: string
     values:
@@ -60,8 +58,6 @@ steps:
 
   - ${{ if and(eq(parameters.buildConfiguration, 'Release'), eq(parameters.buildEnvironment, 'Continuous')) }}:
     - template: ../templates/write-certificate.yml
-      parameters:
-        certificateName: ${{ parameters.certificateName }}
 
     - script: >
         yarn react-native run-windows

--- a/.ado/templates/write-certificate.yml
+++ b/.ado/templates/write-certificate.yml
@@ -1,13 +1,20 @@
+parameters:
+  - name: certificatePassword
+    type: string
+    default: 'pwd'
+
 steps:
   - powershell: |
-      $certStoreRoot = "cert:\CurrentUser\My"
-      $rootFolder = $(Build.SourcesDirectory)
-      [System.Security.SecureString] $password = ConvertTo-SecureString -String "pwd" -Force -AsPlainText
+      $certStoreRoot="cert:\CurrentUser\My"
+      $rootFolder="$(Build.SourcesDirectory)"
+
+      # the following two lines must match
+      [System.Security.SecureString] $password = ConvertTo-SecureString -String "${{ parameters.certificatePassword }}" -Force -AsPlainText
 
       $cert = New-SelfSignedCertificate -KeyExportPolicy Exportable -CertStoreLocation $certStoreRoot -DnsName "Development Root CA" -NotAfter (Get-Date).AddYears(5) -Type CodeSigningCert -KeyUsage DigitalSignature
       [String] $pfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $rootFolder -ChildPath EncodedKey.pfx) )
       [String] $certPath = "$certStoreRoot\$($cert.Thumbprint)"
-      write-host "$certPath"
+
       Export-PfxCertificate -Cert $certPath -FilePath $pfxPath -Password $password
 
     displayName: Create self-signed certificate

--- a/.ado/templates/write-certificate.yml
+++ b/.ado/templates/write-certificate.yml
@@ -4,12 +4,14 @@ parameters:
 
 steps:
   - powershell: |
-      Write-Host "Using certificate named ${{ parameters.certificateName }}"
-      Write-Host "##vso[task.setvariable variable=EncodedKey]$(${{ parameters.certificateName }})"
-    displayName: Determining certificate
+      $certStoreRoot = "cert:\CurrentUser\My"
+      $rootFolder = $(Build.SourcesDirectory)
+      [System.Security.SecureString] $password = ConvertTo-SecureString -String "pwd" -Force -AsPlainText
 
-  - powershell: |
-      $PfxBytes = [System.Convert]::FromBase64String("$(EncodedKey)")
-      $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $(Build.SourcesDirectory) -ChildPath EncodedKey.pfx) )
-      [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
-    displayName: Write certificate
+      $cert = New-SelfSignedCertificate -KeyExportPolicy Exportable -CertStoreLocation $certStoreRoot -DnsName "Development Root CA" -NotAfter (Get-Date).AddYears(5) -Type CodeSigningCert -KeyUsage DigitalSignature
+      [String] $pfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $rootFolder -ChildPath EncodedKey.pfx) )
+      [String] $certPath = "$certStoreRoot\$($cert.Thumbprint)"
+      write-host "$certPath"
+      Export-PfxCertificate -Cert $certPath -FilePath $pfxPath -Password $password
+
+    displayName: Create self-signed certificate

--- a/.ado/templates/write-certificate.yml
+++ b/.ado/templates/write-certificate.yml
@@ -1,7 +1,3 @@
-parameters:
-  - name: certificateName
-    type: string
-
 steps:
   - powershell: |
       $certStoreRoot = "cert:\CurrentUser\My"


### PR DESCRIPTION
## Description

This PR cherry-picks the following certificate-related commits to unblock CI in 0.75:

https://github.com/microsoft/react-native-windows/commit/3a5ca66aab21739e168bd7d236de2f420bf3090c
https://github.com/microsoft/react-native-windows/commit/3534af4fdfb0e5b73b1ecf6b3da6c48f129d008b
https://github.com/microsoft/react-native-windows/commit/5fad854368beb3bee4a1526bb7fc97ad0f7bf8ad
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14057)