### PR TITLE
Add timeout to JS bundle creation in release builds

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -186,6 +186,7 @@ steps:
       ${{ else }}:
         workingDirectory: $(Agent.BuildDirectory)\testcli
       restoreLockedMode: false # Allow new lockfile to be created
+      moreMSBuildProps: ',BundleCommandTimeoutMs=30000' # Reduce bundle timeout
 
   - template: upload-build-logs.yml
     parameters:

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -186,7 +186,7 @@ steps:
       ${{ else }}:
         workingDirectory: $(Agent.BuildDirectory)\testcli
       restoreLockedMode: false # Allow new lockfile to be created
-      moreMSBuildProps: ',BundleCommandTimeoutMs=30000' # Reduce bundle timeout
+      moreMSBuildProps: ',BundleCommandTimeoutMs=60000' # Reduce bundle timeout to 1m
 
   - template: upload-build-logs.yml
     parameters:

--- a/change/react-native-windows-51a54d64-0977-4db3-9842-2c3face412ef.json
+++ b/change/react-native-windows-51a54d64-0977-4db3-9842-2c3face412ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add timeout to JS bundle creation in release builds",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/Bundle.Common.targets
+++ b/vnext/PropertySheets/Bundle.Common.targets
@@ -13,7 +13,7 @@
       <MakeDir Directories="$(BundleContentRoot)" />
       <MakeDir Directories="$(BundleSourceMapDir)" />
       <Message Importance="High" Text="Running [$(BundleCliCommand) --platform windows --entry-file $(BundleEntryFile) --bundle-output $(BundleOutputFile) --assets-dest $(BundleContentRoot) --dev $(UseDevBundle) --reset-cache --sourcemap-output $(PackagerSourceMap) $(BundlerExtraArgs)] to build bundle file." />
-      <Exec Command='$(BundleCliCommand) --platform windows --entry-file "$(BundleEntryFile)" --bundle-output "$(BundleOutputFile)" --assets-dest "$(BundleContentRoot)" --dev $(UseDevBundle) --reset-cache --sourcemap-output "$(PackagerSourceMap)" $(BundlerExtraArgs)' ConsoleToMSBuild="true" WorkingDirectory="$(BundleCommandWorkingDir)" Timeout="$(BundleCommandTimeoutMs)" />
+      <Exec Command='$(BundleCliCommand) --platform windows --entry-file "$(BundleEntryFile)" --bundle-output "$(BundleOutputFile)" --assets-dest "$(BundleContentRoot)" --dev $(UseDevBundle) --reset-cache --sourcemap-output "$(PackagerSourceMap)" $(BundlerExtraArgs)' ConsoleToMSBuild="true" WorkingDirectory="$(BundleCommandWorkingDir)" Timeout="$(BundleCommandTimeoutMs)" ContinueOnError="true" />
   </Target>
 
   <!-- See https://github.com/facebook/react-native/blob/07d090dbc6c46b8f3760dbd25dbe0540c18cb3f3/react.gradle#L190 for reference -->

--- a/vnext/PropertySheets/Bundle.Common.targets
+++ b/vnext/PropertySheets/Bundle.Common.targets
@@ -13,7 +13,7 @@
       <MakeDir Directories="$(BundleContentRoot)" />
       <MakeDir Directories="$(BundleSourceMapDir)" />
       <Message Importance="High" Text="Running [$(BundleCliCommand) --platform windows --entry-file $(BundleEntryFile) --bundle-output $(BundleOutputFile) --assets-dest $(BundleContentRoot) --dev $(UseDevBundle) --reset-cache --sourcemap-output $(PackagerSourceMap) $(BundlerExtraArgs)] to build bundle file." />
-      <Exec Command='$(BundleCliCommand) --platform windows --entry-file "$(BundleEntryFile)" --bundle-output "$(BundleOutputFile)" --assets-dest "$(BundleContentRoot)" --dev $(UseDevBundle) --reset-cache --sourcemap-output "$(PackagerSourceMap)" $(BundlerExtraArgs)' ConsoleToMSBuild="true" WorkingDirectory="$(BundleCommandWorkingDir)" />
+      <Exec Command='$(BundleCliCommand) --platform windows --entry-file "$(BundleEntryFile)" --bundle-output "$(BundleOutputFile)" --assets-dest "$(BundleContentRoot)" --dev $(UseDevBundle) --reset-cache --sourcemap-output "$(PackagerSourceMap)" $(BundlerExtraArgs)' ConsoleToMSBuild="true" WorkingDirectory="$(BundleCommandWorkingDir)" Timeout="$(BundleCommandTimeoutMs)" />
   </Target>
 
   <!-- See https://github.com/facebook/react-native/blob/07d090dbc6c46b8f3760dbd25dbe0540c18cb3f3/react.gradle#L190 for reference -->

--- a/vnext/PropertySheets/Bundle.props
+++ b/vnext/PropertySheets/Bundle.props
@@ -44,6 +44,9 @@
     <!-- This should be the app package root, this is where the bundle command will be run from -->
     <BundleCommandWorkingDir Condition="'$(BundleCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(ProjectDir), 'package.json'))</BundleCommandWorkingDir>
 
+    <!-- This timeout is to catch when the bundler hangs and can be increased for larger apps -->
+    <BundleCommandTimeoutMs Condition="'$(BundleCommandTimeoutMs)' == ''">300000</BundleCommandTimeoutMs>
+
     <!-- Entry file of the JS bundle. Defaults to use index.windows.js if it exists, otherwise index.js -->
     <BundleEntryFile Condition="'$(BundleEntryFile)' == '' and Exists('$(BundleCommandWorkingDir)\index.windows.js')">index.windows.js</BundleEntryFile>
     <BundleEntryFile Condition="'$(BundleEntryFile)' == ''">index.js</BundleEntryFile>


### PR DESCRIPTION
## Description

This PR sets a timeout for the bundle command (`npx react-native bundle`) that happens during release builds with `run-windows`. This is because sometimes Metro can hang indefinitely even after it's done, causing the command to not exit, and otherwise hold up a good build from finishing.

The new timeout defaults to 5m (a new app takes ~40s to bundle) but this variable can easily be modified by defining `BundleCommandTimeoutMs` MSBuild property.

For our new project tests, setting the timeout to 1m, so that, in theory, if the bundle actually finished at 40s, then timing out won't block the remainder of the build.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Why
See above.

May help fix some of the times we've seen hanging with #14055.

### What
See above.

## Screenshots
N/A

## Testing
Verified build continues after the timeout has hit.

## Changelog
Should this change be included in the release notes: _yes_

Add timeout to JS bundle creation in release builds
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14063)