### PR TITLE
[0.76] Update macos-tests to macos-latest images to unblock CI

### DIFF
--- a/.ado/jobs/macos-tests.yml
+++ b/.ado/jobs/macos-tests.yml
@@ -7,7 +7,7 @@ jobs:
       - template: ../variables/shared.yml
       - name: BUILDSECMON_OPT_IN
         value: true
-    pool: {vmImage: macOS-12}
+    pool: {vmImage: macos-latest}
     steps:
       - template: ../templates/checkout-shallow.yml
 


### PR DESCRIPTION
## Description

Updates our macOS testing in CI to the macos-latest VM image.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To unblock CI.

### What
See above.

## Screenshots
N/A

## Testing
Verified tests pass.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14075)