### PR TITLE
[0.76] Enable telemetry collection

### DIFF
--- a/change/@react-native-windows-telemetry-4abe7bcd-e858-4ab9-bc9c-3e2fd948acf2.json
+++ b/change/@react-native-windows-telemetry-4abe7bcd-e858-4ab9-bc9c-3e2fd948acf2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Set instrumentation key",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@react-native-windows-telemetry-a0c4007f-0fe6-4b25-8083-7476b6d51cae.json
+++ b/change/@react-native-windows-telemetry-a0c4007f-0fe6-4b25-8083-7476b6d51cae.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enables telemetry by migrating from AppInsights to 1DS",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -20,8 +20,9 @@
   "dependencies": {
     "@azure/core-auth": "1.5.0",
     "@react-native-windows/fs": "0.76.0-preview.2",
+    "@microsoft/1ds-core-js": "^4.3.0",
+    "@microsoft/1ds-post-js": "^4.3.0",
     "@xmldom/xmldom": "^0.7.7",
-    "applicationinsights": "2.9.1",
     "ci-info": "^3.2.0",
     "envinfo": "^7.8.1",
     "lodash": "^4.17.21",

--- a/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import * as appInsights from 'applicationinsights';
+import * as coreOneDS from '@microsoft/1ds-core-js';
 import * as path from 'path';
 
 import {
@@ -16,6 +16,7 @@ import {
   CommandEventName,
   CodedErrorEventName,
 } from '../telemetry';
+
 import * as basePropUtils from '../utils/basePropUtils';
 import * as errorUtils from '../utils/errorUtils';
 import * as projectUtils from '../utils/projectUtils';
@@ -35,22 +36,21 @@ export class TelemetryTest extends Telemetry {
     }
 
     // Ensure that we don't actually fire events when testing
-    Telemetry.isTest = true;
+    Telemetry.isTestEnvironment = true;
 
     await Telemetry.setup(options);
   }
 
   /** Run at the end of each test where telemetry was fired. */
   static endTest(finalCallback?: () => void): void {
-    Telemetry.client?.flush({
-      callback: _ => {
-        if (TelemetryTest.hasTestTelemetryProviders) {
-          expect(TelemetryTest.testTelemetryProvidersRan).toBe(true);
-        }
-        if (finalCallback) {
-          finalCallback();
-        }
-      },
+    Telemetry.appInsightsCore?.flush(undefined /* isAsync */, () => {
+      // Your callback logic here
+      if (TelemetryTest.hasTestTelemetryProviders) {
+        expect(TelemetryTest.testTelemetryProvidersRan).toBe(true);
+      }
+      if (finalCallback) {
+        finalCallback();
+      }
     });
   }
 
@@ -61,7 +61,7 @@ export class TelemetryTest extends Telemetry {
 
   /** Retrieves the value of a common property.*/
   static getCommonProperty(key: string): string | undefined {
-    return TelemetryTest.client?.commonProperties[key];
+    return TelemetryTest.commonProperties[key];
   }
 
   /** Retrieves the version of the specified tool/package. */
@@ -77,15 +77,12 @@ export class TelemetryTest extends Telemetry {
   }
 
   /** Adds a telemetry processor, usually for verifying the envelope. */
-  static addTelemetryProcessor(
-    telemetryProcessor: (
-      envelope: appInsights.Contracts.EnvelopeTelemetry,
-      contextObjects?: {
-        [name: string]: any;
-      },
+  static addTelemetryInitializer(
+    telemetryInitializer: (
+      envelope: coreOneDS.ITelemetryItem
     ) => boolean,
   ): void {
-    TelemetryTest.client?.addTelemetryProcessor(telemetryProcessor);
+    TelemetryTest.appInsightsCore?.addTelemetryInitializer(telemetryInitializer);
     TelemetryTest.hasTestTelemetryProviders = true;
   }
 }
@@ -126,13 +123,12 @@ test('setup() verify static common property values with sync sources', async () 
 
   const props: Record<string, () => string | undefined> = {
     deviceArchitecture: () => basePropUtils.deviceArchitecture(),
-    devicePlatform: () => basePropUtils.devicePlatform(),
+    nodePlatform: () => basePropUtils.nodePlatform(),
     deviceNumCPUs: () => basePropUtils.deviceNumCPUs().toString(),
     deviceTotalMemory: () => basePropUtils.deviceTotalMemory().toString(),
     ciCaptured: () => basePropUtils.captureCI().toString(),
     ciType: () => basePropUtils.ciType(),
     isMsftInternal: () => basePropUtils.isMsftInternal().toString(),
-    sampleRate: () => basePropUtils.sampleRate().toString(),
     isTest: () => 'true',
   };
 
@@ -346,57 +342,49 @@ function verifyTestCommandTelemetryProcessor(
   expectedResultCode?: errorUtils.CodedErrorType,
   expectedError?: Error,
 ): (
-  envelope: appInsights.Contracts.EnvelopeTelemetry,
-  contextObjects?: {
-    [name: string]: any;
-  },
+  envelope: coreOneDS.ITelemetryItem
 ) => boolean {
-  return (envelope, _) => {
+  return (envelope) => {
+    TelemetryTest.setTestTelemetryProvidersRan();
+
     try {
       // Processor has run, so the test can (potentially) pass
-      TelemetryTest.setTestTelemetryProvidersRan();
-
-      // Verify roleInstance has been removed
-      expect(envelope.tags['ai.cloud.roleInstance']).toBeUndefined();
-
-      const properties = envelope.data.baseData?.properties;
+      const properties = envelope.baseData;
       expect(properties).toBeDefined();
 
       // Verify basics
-      expect(properties.commandName).toBe('test-command');
+      const commonProperties = properties!.common;
+      expect(commonProperties.commandName).toBe('test-command');
 
       // Verify versions info
-      const versions = JSON.parse(properties.versions);
+      const versions = properties!.versions;
       expect(versions).toBeDefined();
-
-      // Verify project info
-      const project = JSON.parse(properties.project);
-      expect(project).toStrictEqual(getTestCommandProjectInfo());
 
       expect(Object.keys(versions).length).toBeGreaterThan(0);
       for (const key of Object.keys(versions)) {
         expect(versions[key]).toBe(TelemetryTest.getVersion(key));
       }
 
-      if (envelope.data.baseType === 'ExceptionData') {
-        // Verify event name
-        expect(properties.eventName).toBe(CodedErrorEventName);
+      // Verify project info
+      const project = properties!.project;
+      expect(project).toStrictEqual(getTestCommandProjectInfo());
 
+      // Verify properties exclusive to error scenarios
+      if (envelope.name === CodedErrorEventName) {
         // Verify exception info
-        const exceptions = envelope.data.baseData?.exceptions;
-        expect(exceptions).toBeDefined();
-        expect(exceptions.length).toBe(1);
-        expect(exceptions[0].message).toBeDefined();
-        expect(exceptions[0].message).not.toBe('');
+        const exceptionData = envelope.data!.exceptionData;
+        expect(exceptionData).toBeDefined();
+        expect(exceptionData.message).toBeDefined();
+        expect(exceptionData.message).not.toBe('');
 
-        expect(exceptions[0].message).toBe(
+        expect(exceptionData.message).toBe(
           TelemetryTest.getPreserveErrorMessages()
             ? errorUtils.sanitizeErrorMessage(expectedError?.message || 'None')
             : '[Removed]',
         );
 
         // Verify coded error info
-        const codedError = JSON.parse(properties.codedError);
+        const codedError = envelope.data!.codedError;
         expect(codedError).toBeDefined();
 
         expect(codedError.type).toBe(
@@ -409,14 +397,13 @@ function verifyTestCommandTelemetryProcessor(
           (expectedError as errorUtils.CodedError).data ?? {},
         );
       } else {
-        // Verify event name
-        expect(envelope.data.baseData?.name).toBe(CommandEventName);
-        expect(properties.eventName).toBe(CommandEventName);
+        // If this is not error scenario, it must be a command successful event.
+        expect(envelope.name).toBe(CommandEventName);
 
         // Verify command info
         const expectedInfo = getTestCommandStartInfo();
 
-        const command = JSON.parse(properties.command);
+        const command = envelope.data!.command;
         expect(command).toBeDefined();
         expect(command.args).toStrictEqual(expectedInfo.args);
         expect(command.options).toStrictEqual(expectedInfo.options);
@@ -428,7 +415,7 @@ function verifyTestCommandTelemetryProcessor(
 
         // Verify extra props
         const extraProps = getExtraProps();
-        expect(JSON.parse(properties.extraProps)).toStrictEqual(extraProps);
+        expect(envelope.data?.additionalData).toStrictEqual(extraProps);
       }
     } catch (ex) {
       caughtErrors.push(
@@ -445,7 +432,7 @@ test('Telemetry run test command end to end, verify event fires', async () => {
 
   // AI eats errors thrown in telemetry processors
   const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
+  TelemetryTest.addTelemetryInitializer(
     verifyTestCommandTelemetryProcessor(caughtErrors),
   );
 
@@ -474,7 +461,7 @@ test.each(testTelemetryOptions)(
 
     // AI eats errors thrown in telemetry processors
     const caughtErrors: Error[] = [];
-    TelemetryTest.addTelemetryProcessor(
+    TelemetryTest.addTelemetryInitializer(
       verifyTestCommandTelemetryProcessor(
         caughtErrors,
         expectedError.type,
@@ -503,7 +490,7 @@ test.each(testTelemetryOptions)(
 
     // AI eats errors thrown in telemetry processors
     const caughtErrors: Error[] = [];
-    TelemetryTest.addTelemetryProcessor(
+    TelemetryTest.addTelemetryInitializer(
       verifyTestCommandTelemetryProcessor(
         caughtErrors,
         expectedError.type,
@@ -533,7 +520,7 @@ test.each(testTelemetryOptions)(
 
     // AI eats errors thrown in telemetry processors
     const caughtErrors: Error[] = [];
-    TelemetryTest.addTelemetryProcessor(
+    TelemetryTest.addTelemetryInitializer(
       verifyTestCommandTelemetryProcessor(
         caughtErrors,
         expectedError.type,
@@ -559,7 +546,7 @@ test.each(testTelemetryOptions)(
 
     // AI eats errors thrown in telemetry processors
     const caughtErrors: Error[] = [];
-    TelemetryTest.addTelemetryProcessor(
+    TelemetryTest.addTelemetryInitializer(
       verifyTestCommandTelemetryProcessor(
         caughtErrors,
         'Unknown',
@@ -585,7 +572,7 @@ test.each(testTelemetryOptions)(
 
     // AI eats errors thrown in telemetry processors
     const caughtErrors: Error[] = [];
-    TelemetryTest.addTelemetryProcessor(
+    TelemetryTest.addTelemetryInitializer(
       verifyTestCommandTelemetryProcessor(
         caughtErrors,
         'Unknown',
@@ -615,44 +602,40 @@ function getVerifyStackTelemetryProcessor(
   caughtErrors: Error[],
   expectedError: Error,
 ): (
-  envelope: appInsights.Contracts.EnvelopeTelemetry,
-  contextObjects?: {
-    [name: string]: any;
-  },
+  envelope: coreOneDS.ITelemetryItem,
 ) => boolean {
-  return (envelope, _) => {
+  return (envelope) => {
     try {
       // Processor has run, so the test can (potentially) pass
       TelemetryTest.setTestTelemetryProvidersRan();
 
-      if (envelope.data.baseType === 'ExceptionData') {
-        const data = (envelope.data as any).baseData;
-        expect(data.exceptions).toBeDefined();
-        expect(data.exceptions.length).toBe(1);
-        expect(data.exceptions[0].message).toBeDefined();
-        expect(data.exceptions[0].message).not.toBe('');
+      if (envelope.name === CodedErrorEventName) {
+        const data = (envelope.data as any);
+        expect(data.exceptionData).toBeDefined();
+        expect(data.exceptionData.message).toBeDefined();
+        expect(data.exceptionData.message).not.toBe('');
 
-        expect(data.exceptions[0].message).toBe(
+        expect(data.exceptionData.message).toBe(
           TelemetryTest.getPreserveErrorMessages()
             ? errorUtils.sanitizeErrorMessage(expectedError.message || 'None')
             : '[Removed]',
         );
 
-        const stack = data.exceptions[0].parsedStack;
+        const stack = data.exceptionData.parsedStack;
         expect(stack).toBeDefined();
         expect(stack.length).toBeGreaterThan(2);
 
         const filename = path.relative(process.cwd(), __filename);
-        expect(stack[0].method).toEqual('b');
-        expect(stack[1].method).toEqual('b');
-        expect(stack[2].method).toEqual('a');
-        expect(stack[0].fileName).toEqual(
+        expect(stack[0].functionName).toEqual('b');
+        expect(stack[1].functionName).toEqual('b');
+        expect(stack[2].functionName).toEqual('a');
+        expect(stack[0].filePath).toEqual(
           `[project_dir]\\???.ts(${filename.length})`,
         );
-        expect(stack[1].fileName).toEqual(
+        expect(stack[1].filePath).toEqual(
           `[project_dir]\\???.ts(${filename.length})`,
         );
-        expect(stack[2].fileName).toEqual(
+        expect(stack[2].filePath).toEqual(
           `[project_dir]\\???.ts(${filename.length})`,
         );
       }
@@ -675,7 +658,7 @@ test.each(testTelemetryOptions)(
 
     // AI eats errors thrown in telemetry processors
     const caughtErrors: Error[] = [];
-    TelemetryTest.addTelemetryProcessor(
+    TelemetryTest.addTelemetryInitializer(
       getVerifyStackTelemetryProcessor(caughtErrors, expectedError),
     );
 
@@ -700,7 +683,7 @@ test.each(testTelemetryOptions)(
 
     // AI eats errors thrown in telemetry processors
     const caughtErrors: Error[] = [];
-    TelemetryTest.addTelemetryProcessor(
+    TelemetryTest.addTelemetryInitializer(
       getVerifyStackTelemetryProcessor(caughtErrors, expectedError),
     );
 

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -37,7 +37,8 @@ interface CommandInfo {
 }
 
 // 1DS instrumentation key
-const RNW_1DS_INSTRUMENTATION_KEY = ""
+const RNW_1DS_INSTRUMENTATION_KEY =
+  '49ff6d3ef12f4578a7b75a2573d9dba8-026332b2-2d50-452f-ad0d-50f921c97a9d-7145';
 
 // Environment variable to override the default setup string
 const ENV_SETUP_OVERRIDE = 'RNW_TELEMETRY_SETUP';

--- a/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
@@ -32,12 +32,20 @@ test('nodeArchitecture() is valid', () => {
   expect(value).not.toBeNull();
 });
 
-test('devicePlatform() is valid', () => {
-  const value = basePropUtils.devicePlatform();
+test('deviceClass() is valid', () => {
+  const value = basePropUtils.deviceClass();
   expect(value).toBeDefined();
   expect(value).not.toBe('');
   expect(value).not.toBeNull();
 });
+
+test('nodePlatform() is valid', () => {
+  const value = basePropUtils.nodePlatform();
+  expect(value).toBeDefined();
+  expect(value).not.toBe('');
+  expect(value).not.toBeNull();
+});
+
 
 test('deviceLocale() is valid', async () => {
   const value = await basePropUtils.deviceLocale();
@@ -65,12 +73,6 @@ test('deviceTotalMemory() is valid', () => {
 test('deviceDiskFreeSpace() is valid', () => {
   const value = basePropUtils.deviceDiskFreeSpace();
   expect(value).toBeGreaterThanOrEqual(0);
-});
-
-test('sampleRate() is within valid range', () => {
-  const value = basePropUtils.sampleRate();
-  expect(value).toBeGreaterThanOrEqual(0);
-  expect(value).toBeLessThanOrEqual(100);
 });
 
 test('ciType() is valid', () => {
@@ -134,4 +136,11 @@ test('getSessionId() is a guid', () => {
 
 test('getSessionId() does not change', () => {
   expect(basePropUtils.getSessionId()).toBe(basePropUtils.getSessionId());
+});
+
+test('fullBuildInfo() is valid', () => {
+  const value = basePropUtils.fullBuildInfo();
+  expect(value).toBeDefined();
+  expect(value).not.toBe('');
+  expect(value).not.toBeNull();
 });

--- a/packages/@react-native-windows/telemetry/src/test/errorUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/errorUtils.test.ts
@@ -5,8 +5,6 @@
  * @format
  */
 
-import * as appInsights from 'applicationinsights';
-
 import * as errorUtils from '../utils/errorUtils';
 
 test('tryGetErrorCode() with valid error code', () => {
@@ -206,55 +204,49 @@ test('sanitizeErrorMessage() with standard MSBuild error', () => {
 });
 
 test('sanitizeErrorStackFrame() with empty frame', () => {
-  const emptyFrame: appInsights.Contracts.StackFrame = {
-    level: 0,
-    method: '',
-    fileName: '',
-    assembly: 'asdf',
-    line: 0,
+  const stackFrame = {
+    functionName: '',
+    filePath: '',
+    lineNumber: 0,
+    columnNumber: 0
   };
-  errorUtils.sanitizeErrorStackFrame(emptyFrame);
-  expect(emptyFrame).toEqual({
-    level: 0,
-    assembly: '',
-    fileName: '[path]',
-    method: '',
-    line: 0,
+  errorUtils.sanitizeErrorStackFrame(stackFrame);
+  expect(stackFrame).toEqual({
+    functionName: '',
+    filePath: '[path]',
+    lineNumber: 0,
+    columnNumber: 0
   });
 });
 
 test('sanitizeErrorStackFrame() with assembly name', () => {
-  const frame1: appInsights.Contracts.StackFrame = {
-    method: '',
-    fileName: `${process.cwd()}\\foo.js`,
-    assembly: 'asdf',
-    level: 0,
-    line: 0,
+  const stackFrame = {
+    functionName: '',
+    filePath: `${process.cwd()}\\foo.js`,
+    lineNumber: 10,
+    columnNumber: 14
   };
-  errorUtils.sanitizeErrorStackFrame(frame1);
-  expect(frame1).toEqual({
-    assembly: '',
-    fileName: '[project_dir]\\???.js(6)',
-    method: '',
-    level: 0,
-    line: 0,
+  errorUtils.sanitizeErrorStackFrame(stackFrame);
+  expect(stackFrame).toEqual({
+    functionName: '',
+    filePath: '[project_dir]\\???.js(6)',
+    lineNumber: 10,
+    columnNumber: 14
   });
 });
 
 test('sanitizeErrorStackFrame() with method name', () => {
-  const frame2: appInsights.Contracts.StackFrame = {
-    method: `myMethod (something ${process.cwd()}`,
-    fileName: `${process.cwd()}\\telemetry\\foo.js`,
-    assembly: 'asdf',
-    level: 1,
-    line: 42,
+  const stackFrame = {
+    functionName: `myMethod (something ${process.cwd()}`,
+    filePath: `${process.cwd()}\\telemetry\\foo.js`,
+    lineNumber: 10,
+    columnNumber: 14
   };
-  errorUtils.sanitizeErrorStackFrame(frame2);
-  expect(frame2).toEqual({
-    assembly: '',
-    fileName: '[project_dir]\\???.js(16)',
-    method: 'myMethod',
-    level: 1,
-    line: 42,
+  errorUtils.sanitizeErrorStackFrame(stackFrame);
+  expect(stackFrame).toEqual({
+    functionName: 'myMethod',
+    filePath: '[project_dir]\\???.js(16)',
+    lineNumber: 10,
+    columnNumber: 14
   });
 });

--- a/packages/@react-native-windows/telemetry/src/utils/basePropUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/basePropUtils.ts
@@ -14,22 +14,57 @@ import osLocale from 'os-locale';
 const DeviceIdRegPath = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\SQMClient';
 const DeviceIdRegKey = 'MachineId';
 
+const DeviceIdBuildPath = '"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"';
+const DeviceIdBuildKey = 'BuildLabEx';
+
+/**
+ * Given a path and a key, retrieves the value from the Registry.
+ * @returns If the path and key exist, the requested value from the Registry; empty string otherwise.
+ */
+export async function getValueFromRegistry(path: string, key: string): Promise<string> {
+  try {
+    let regCommand = `${process.env.windir}\\System32\\reg.exe query ${path} /v ${key}`;
+    if (deviceArchitecture() === 'x64') {
+      // Ensure we query the correct registry
+      regCommand += ' /reg:64';
+    }
+    
+    const output = execSync(regCommand).toString();
+    return output;
+  } catch {}
+
+  return '';
+}
+
 /**
  * Gets a telemetry-safe stable device ID.
  * @returns A telemetry-safe stable device ID.
  */
 export async function deviceId(): Promise<string> {
   try {
-    let regCommand = `${process.env.windir}\\System32\\reg.exe query ${DeviceIdRegPath} /v ${DeviceIdRegKey}`;
-    if (deviceArchitecture() === 'x64') {
-      // Ensure we query the correct registry
-      regCommand += ' /reg:64';
-    }
-    const output = execSync(regCommand).toString();
+    const deviceIdValue = await getValueFromRegistry(DeviceIdRegPath, DeviceIdRegKey);
 
-    const result = output.match(/\{([0-9A-Fa-f-]{36})\}/);
+    const result = deviceIdValue.match(/\{([0-9A-Fa-f-]{36})\}/);
     if (result && result.length > 1) {
       return `s:${result[1]}`;
+    }
+  } catch {}
+  return '';
+}
+
+/**
+ * Gets the Windows build name, number and architecture.
+ * @returns A string containing the Windows build name, number and architecture.
+ * e.g. 19569.1000.amd64fre.rs_prerelease.200214-1419
+ */
+export async function fullBuildInfo(): Promise<string> {
+  try {
+    const fullBuildValue = await getValueFromRegistry(DeviceIdBuildPath, DeviceIdBuildKey);
+
+    // Retrieve the build info
+    const match = fullBuildValue.match(/BuildLabEx\s+REG_SZ\s+([^\r\n]+)/);
+    if (match && match.length > 1) {
+      return match[1];
     }
   } catch {}
   return '';
@@ -59,11 +94,30 @@ export function nodeArchitecture(): string {
 }
 
 /**
- * Gets the device platform, like darwin/linux/win32.
+ * Gets the node platform, like darwin/linux/win32.
  * @returns The device platform.
  */
-export function devicePlatform(): string {
+export function nodePlatform(): string {
   return platform();
+}
+
+/**
+ * Gets the OS name, to be filled in the PartA device.deviceClass field.
+ * @returns The device class.
+ */
+export function deviceClass(): string {
+  const node = nodePlatform();
+
+  switch (node) {
+    case 'darwin':
+      return 'Mac';
+    case 'linux':
+      return 'Linux';
+    case 'win32':
+      return 'Windows';
+    default:
+      return node;
+  }
 }
 
 /**
@@ -107,14 +161,6 @@ export function deviceDiskFreeSpace(drivePath?: string | null): number {
     }
   } catch {}
   return -1;
-}
-
-/**
- * Gets the telemetry sample rate.
- * @returns The telemetry sample rate.
- */
-export function sampleRate(): number {
-  return 100;
 }
 
 /**

--- a/packages/@react-native-windows/telemetry/src/utils/errorUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/errorUtils.ts
@@ -4,8 +4,6 @@
  * @format
  */
 
-import * as appInsights from 'applicationinsights';
-
 import * as sanitizeUtils from './sanitizeUtils';
 
 // Note: All CLI commands will set process.exitCode to the numerical value of
@@ -101,6 +99,13 @@ export class CodedError extends Error {
   }
 }
 
+export interface ErrorStackFrame {
+  functionName?: string;
+  filePath?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+}
+
 /**
  * Tries to parse an error code out of an error message.
  * @param msg An error message to process.
@@ -156,16 +161,18 @@ export function sanitizeErrorMessage(msg: string): string {
  * @param frame
  */
 export function sanitizeErrorStackFrame(
-  frame: appInsights.Contracts.StackFrame,
-): void {
-  const parens = frame.method.indexOf('(');
-  if (parens !== -1) {
-    // case 1: method === 'methodName (rootOfThePath'
-    frame.method = frame.method.substr(0, parens).trim();
-  } else {
-    // case 2: method === <no_method> or something without '(', fileName is full path
+  frame: ErrorStackFrame): void {
+
+  if (frame.functionName) {
+    const leftParenthesisIndex = frame.functionName.indexOf('(');
+    if (leftParenthesisIndex !== -1) {
+      // case 1: method === 'methodName (rootOfThePath'
+      frame.functionName = frame.functionName.substr(0, leftParenthesisIndex).trim();
+    } else {
+      // case 2: method === <no_method> or something without '(', fileName is full path
+    }  
   }
-  // anonymize the filename
-  frame.fileName = sanitizeUtils.getAnonymizedPath(frame.fileName);
-  frame.assembly = '';
+
+  // anonymize the filePath
+  frame.filePath = sanitizeUtils.getAnonymizedPath(frame.filePath);
 }

--- a/packages/@react-native-windows/telemetry/src/utils/sanitizeUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/sanitizeUtils.ts
@@ -24,9 +24,14 @@ const knownEnvironmentVariablePaths = [
  * @returns The anonymized path.
  */
 export function getAnonymizedPath(
-  filepath: string,
+  filepath: string | undefined,
   projectRoot?: string,
 ): string {
+
+  if (filepath === undefined) {
+    return '[path]';
+  }
+
   projectRoot = (projectRoot ?? process.cwd())
     .replace(/\//g, '\\')
     .toLowerCase();

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,47 +33,7 @@
     "@azure/core-util" "^1.1.0"
     tslib "^2.2.0"
 
-"@azure/core-auth@^1.4.0", "@azure/core-auth@^1.5.0":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.7.2.tgz#558b7cb7dd12b00beec07ae5df5907d74df1ebd9"
-  integrity sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==
-  dependencies:
-    "@azure/abort-controller" "^2.0.0"
-    "@azure/core-util" "^1.1.0"
-    tslib "^2.6.2"
-
-"@azure/core-rest-pipeline@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz#348290847ca31b9eecf9cf5de7519aaccdd30968"
-  integrity sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==
-  dependencies:
-    "@azure/abort-controller" "^1.0.0"
-    "@azure/core-auth" "^1.4.0"
-    "@azure/core-tracing" "^1.0.1"
-    "@azure/core-util" "^1.0.0"
-    "@azure/logger" "^1.0.0"
-    form-data "^4.0.0"
-    http-proxy-agent "^5.0.0"
-    https-proxy-agent "^5.0.0"
-    tslib "^2.2.0"
-    uuid "^8.3.0"
-
-"@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.1.2.tgz#065dab4e093fb61899988a1cdbc827d9ad90b4ee"
-  integrity sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==
-  dependencies:
-    tslib "^2.6.2"
-
-"@azure/core-util@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.2.0.tgz#3499deba1fc36dda6f1912b791809b6f15d4a392"
-  integrity sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==
-  dependencies:
-    "@azure/abort-controller" "^1.0.0"
-    tslib "^2.2.0"
-
-"@azure/core-util@^1.0.0", "@azure/core-util@^1.1.0":
+"@azure/core-util@^1.1.0":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.9.1.tgz#05ea9505c5cdf29c55ccf99a648c66ddd678590b"
   integrity sha512-OLsq0etbHO1MA7j6FouXFghuHrAFGk+5C1imcpQ2e+0oZhYF07WLA+NW2Vqs70R7d+zOAWiWM3tbE1sXcDN66g==
@@ -81,29 +41,10 @@
     "@azure/abort-controller" "^2.0.0"
     tslib "^2.6.2"
 
-"@azure/logger@^1.0.0":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.1.3.tgz#09a8fd4850b9112865756e92d5e8b728ee457345"
-  integrity sha512-J8/cIKNQB1Fc9fuYqBVnrppiUtW+5WWJPCj/tAokC5LdSTwkWWttN+jsRgw9BLYD7JDBx7PceiqOBxJJ1tQz3Q==
-  dependencies:
-    tslib "^2.6.2"
-
-"@azure/opentelemetry-instrumentation-azure-sdk@^1.0.0-beta.5":
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz#78809e6c005d08450701e5d37f087f6fce2f86eb"
-  integrity sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==
-  dependencies:
-    "@azure/core-tracing" "^1.0.0"
-    "@azure/logger" "^1.0.0"
-    "@opentelemetry/api" "^1.4.1"
-    "@opentelemetry/core" "^1.15.2"
-    "@opentelemetry/instrumentation" "^0.41.2"
-    tslib "^2.2.0"
-
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
-  integrity sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.24.7", "@babel/code-frame@^7.25.7":
+  version "7.25.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.25.7.tgz#438f2c524071531d643c6f0188e1e28f130cebc7"
+  integrity sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==
   dependencies:
     "@babel/highlight" "^7.24.7"
     picocolors "^1.0.0"
@@ -1877,10 +1818,51 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
-"@microsoft/applicationinsights-web-snippet@^1.0.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.2.1.tgz#c158081f8c40ea9ad94475abac15f67182768882"
-  integrity sha512-+Cy9zFqdQgdAbMK1dpm7B+3DUnrByai0Tq6XG9v737HJpW6G1EiNNbTuFeXdPWyGaq6FIx9jxm/SUcxA6/Rxxg==
+"@microsoft/1ds-core-js@4.3.0", "@microsoft/1ds-core-js@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/1ds-core-js/-/1ds-core-js-4.3.0.tgz#5c880614ce352fc66c34ae7fbb16cddb9e5c2fac"
+  integrity sha512-0aP0ko4j0E2HfMNG1TdctGxcX74c4nQMMMV2JyaBYRRlbg1qYSVCUTZO4Ap6Qf65cBjJUCoIzgDMXNSquANwDA==
+  dependencies:
+    "@microsoft/applicationinsights-core-js" "3.3.0"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.2 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.3 < 2.x"
+
+"@microsoft/1ds-post-js@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/1ds-post-js/-/1ds-post-js-4.3.0.tgz#14ff70dc5804b0fa9c23230f7b653a0fba1b2dc3"
+  integrity sha512-a1AflEuB313mfRiNNqkoVYDi4zxnG57zR8KotudtVoov6hiByBIS0KSuf3oE5/woDHWi9ZJjiCDvFwNqNH0YYw==
+  dependencies:
+    "@microsoft/1ds-core-js" "4.3.0"
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.2 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.3 < 2.x"
+
+"@microsoft/applicationinsights-core-js@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.0.tgz#b4e4da3bd49c3d14107f7beb6152d5214324b214"
+  integrity sha512-so0fFTqgZMjClH+MsiRYGspo5fpgwHEUYNMjyzpf9rjrY7FaUH8kkWzrQ3V0Cs4axZwf+WuIndtDOAws7aBmGQ==
+  dependencies:
+    "@microsoft/applicationinsights-shims" "3.0.1"
+    "@microsoft/dynamicproto-js" "^2.0.3"
+    "@nevware21/ts-async" ">= 0.5.2 < 2.x"
+    "@nevware21/ts-utils" ">= 0.11.3 < 2.x"
+
+"@microsoft/applicationinsights-shims@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz#3865b73ace8405b9c4618cc5c571f2fe3876f06f"
+  integrity sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==
+  dependencies:
+    "@nevware21/ts-utils" ">= 0.9.4 < 2.x"
+
+"@microsoft/dynamicproto-js@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz#ae2b408061e3ff01a97078429fc768331e239256"
+  integrity sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==
+  dependencies:
+    "@nevware21/ts-utils" ">= 0.10.4 < 2.x"
 
 "@microsoft/eslint-plugin-sdl@^0.2.0":
   version "0.2.2"
@@ -1890,6 +1872,23 @@
     eslint-plugin-node "11.1.0"
     eslint-plugin-react "7.33.0"
     eslint-plugin-security "1.4.0"
+
+"@nevware21/ts-async@>= 0.5.2 < 2.x":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@nevware21/ts-async/-/ts-async-0.5.2.tgz#a41883dc6ccc4666bdf156e92f35f3003fd3f6f0"
+  integrity sha512-Zf2vUNjCw2vJsiVKhWXA9hCNHsn59AOSGa5jGP4tWrp/vTH9XrI4eG/65khuoAgrS83migj0Xv5/j6fUAz69Zw==
+  dependencies:
+    "@nevware21/ts-utils" ">= 0.11.3 < 2.x"
+
+"@nevware21/ts-utils@>= 0.10.4 < 2.x", "@nevware21/ts-utils@>= 0.9.4 < 2.x":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@nevware21/ts-utils/-/ts-utils-0.10.5.tgz#2ec10c4b5d93db39136e8e11143e7feb311e47e0"
+  integrity sha512-+TEvP0+l/VBR5bJZoYFV+o6aQQ1O6y80uys5AVyyCKeWvrgWu/yNydqSBQNsk4BuEfkayg7R9+HCJRRRIvptTA==
+
+"@nevware21/ts-utils@>= 0.11.3 < 2.x":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@nevware21/ts-utils/-/ts-utils-0.11.3.tgz#d0f032ade9540585a30a6453d962de613566d856"
+  integrity sha512-oipW+tyKN68bREjoESYAzOZiatM+1LF+ez1TX3BaeinhCkI18xsLgmpH9tvwHaVgKf1Tsth25sdbXVtYmgRYvQ==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -2035,51 +2034,6 @@
   integrity sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
-
-"@opentelemetry/api@^1.4.1":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
-  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
-
-"@opentelemetry/core@1.25.1", "@opentelemetry/core@^1.15.2":
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.25.1.tgz#ff667d939d128adfc7c793edae2f6bca177f829d"
-  integrity sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==
-  dependencies:
-    "@opentelemetry/semantic-conventions" "1.25.1"
-
-"@opentelemetry/instrumentation@^0.41.2":
-  version "0.41.2"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz#cae11fa64485dcf03dae331f35b315b64bc6189f"
-  integrity sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==
-  dependencies:
-    "@types/shimmer" "^1.0.2"
-    import-in-the-middle "1.4.2"
-    require-in-the-middle "^7.1.1"
-    semver "^7.5.1"
-    shimmer "^1.2.1"
-
-"@opentelemetry/resources@1.25.1":
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.25.1.tgz#bb9a674af25a1a6c30840b755bc69da2796fefbb"
-  integrity sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==
-  dependencies:
-    "@opentelemetry/core" "1.25.1"
-    "@opentelemetry/semantic-conventions" "1.25.1"
-
-"@opentelemetry/sdk-trace-base@^1.15.2":
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz#cbc1e60af255655d2020aa14cde17b37bd13df37"
-  integrity sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==
-  dependencies:
-    "@opentelemetry/core" "1.25.1"
-    "@opentelemetry/resources" "1.25.1"
-    "@opentelemetry/semantic-conventions" "1.25.1"
-
-"@opentelemetry/semantic-conventions@1.25.1", "@opentelemetry/semantic-conventions@^1.15.2":
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz#0deecb386197c5e9c2c28f2f89f51fb8ae9f145e"
-  integrity sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -2704,11 +2658,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tootallnate/once@2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
-  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
-
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
@@ -3062,11 +3011,6 @@
   dependencies:
     "@types/glob" "~7.2.0"
     "@types/node" "*"
-
-"@types/shimmer@^1.0.2":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
-  integrity sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==
 
 "@types/ssri@*":
   version "7.1.5"
@@ -3513,11 +3457,6 @@ accepts@^1.3.7, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
-  integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -3686,25 +3625,6 @@ appdirsjs@^1.2.4:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/appdirsjs/-/appdirsjs-1.2.7.tgz#50b4b7948a26ba6090d4aede2ae2dc2b051be3b3"
   integrity sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==
-
-applicationinsights@2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.9.1.tgz#769412f809d6a072487e4b41c4c3a29678344d82"
-  integrity sha512-hrpe/OvHFZlq+SQERD1fxaYICyunxzEBh9SolJebzYnIXkyA9zxIR87dZAh+F3+weltbqdIP8W038cvtpMNhQg==
-  dependencies:
-    "@azure/core-auth" "^1.5.0"
-    "@azure/core-rest-pipeline" "1.10.1"
-    "@azure/core-util" "1.2.0"
-    "@azure/opentelemetry-instrumentation-azure-sdk" "^1.0.0-beta.5"
-    "@microsoft/applicationinsights-web-snippet" "^1.0.1"
-    "@opentelemetry/api" "^1.4.1"
-    "@opentelemetry/core" "^1.15.2"
-    "@opentelemetry/sdk-trace-base" "^1.15.2"
-    "@opentelemetry/semantic-conventions" "^1.15.2"
-    cls-hooked "^4.2.2"
-    continuation-local-storage "^3.2.1"
-    diagnostic-channel "1.1.1"
-    diagnostic-channel-publishers "1.0.7"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -3967,25 +3887,10 @@ async-done@~1.3.2:
     process-nextick-args "^2.0.0"
     stream-exhaust "^1.0.1"
 
-async-hook-jl@^1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
-  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
-  dependencies:
-    stack-chain "^1.3.7"
-
 async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
-async-listener@^0.6.0:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
-  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
-  dependencies:
-    semver "^5.3.0"
-    shimmer "^1.1.0"
 
 async-settle@^2.0.0:
   version "2.0.0"
@@ -4711,7 +4616,7 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
-cjs-module-lexer@^1.0.0, cjs-module-lexer@^1.2.2:
+cjs-module-lexer@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz#c485341ae8fd999ca4ee5af2d7a1c9ae01e0099c"
   integrity sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==
@@ -4817,15 +4722,6 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
-
-cls-hooked@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
-  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
-  dependencies:
-    async-hook-jl "^1.7.6"
-    emitter-listener "^1.0.1"
-    semver "^5.4.1"
 
 co@^4.6.0:
   version "4.6.0"
@@ -4992,14 +4888,6 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
-
-continuation-local-storage@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
-  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
-  dependencies:
-    async-listener "^0.6.0"
-    emitter-listener "^1.1.1"
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -5389,18 +5277,6 @@ devtools@6.12.1:
     ua-parser-js "^0.7.21"
     uuid "^8.0.0"
 
-diagnostic-channel-publishers@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.7.tgz#9b7f8d5ee1295481aee19c827d917e96fedf2c4a"
-  integrity sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==
-
-diagnostic-channel@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz#44b60972de9ee055c16216535b0e9db3f6a0efd0"
-  integrity sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==
-  dependencies:
-    semver "^7.5.3"
-
 diff-match-patch@1.0.5, diff-match-patch@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
@@ -5486,13 +5362,6 @@ electron-to-chromium@^1.5.4:
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz#1abf0410c5344b2b829b7247e031f02810d442e6"
   integrity sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==
-
-emitter-listener@^1.0.1, emitter-listener@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
-  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
-  dependencies:
-    shimmer "^1.2.0"
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -7077,15 +6946,6 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-http-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
-  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
-  dependencies:
-    "@tootallnate/once" "2"
-    agent-base "6"
-    debug "4"
-
 http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
@@ -7219,16 +7079,6 @@ import-fresh@^3.2.1, import-fresh@^3.3.0:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
-
-import-in-the-middle@1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz#2a266676e3495e72c04bbaa5ec14756ba168391b"
-  integrity sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==
-  dependencies:
-    acorn "^8.8.2"
-    acorn-import-assertions "^1.9.0"
-    cjs-module-lexer "^1.2.2"
-    module-details-from-path "^1.0.3"
 
 import-lazy@~4.0.0:
   version "4.0.0"
@@ -9216,11 +9066,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-module-details-from-path@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
-  integrity sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -10485,15 +10330,6 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-in-the-middle@^7.1.1:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz#606977820d4b5f9be75e5a108ce34cfed25b3bb4"
-  integrity sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==
-  dependencies:
-    debug "^4.3.5"
-    module-details-from-path "^1.0.3"
-    resolve "^1.22.8"
-
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -10544,7 +10380,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
-resolve@^1.1.6, resolve@^1.10.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.3, resolve@^1.22.8, resolve@^1.3.2, resolve@~1.22.1:
+resolve@^1.1.6, resolve@^1.10.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.3, resolve@^1.3.2, resolve@~1.22.1:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -10754,12 +10590,12 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.4.tgz#13053c0d4aa11d070a2f2872b6b1e3ae1e1971b4"
   integrity sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5 || 7", semver@^7.0.0, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.1, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
+"semver@2 >=2.2.1 || 3.x || 4 || 5 || 7", semver@^7.0.0, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -10906,11 +10742,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-shimmer@^1.1.0, shimmer@^1.2.0, shimmer@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
-  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 side-channel@^1.0.4, side-channel@^1.0.6:
   version "1.0.6"
@@ -11097,11 +10928,6 @@ ssri@^8.0.0, ssri@^8.0.1:
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
     minipass "^3.1.1"
-
-stack-chain@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
-  integrity sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==
 
 stack-utils@^2.0.3:
   version "2.0.6"


### PR DESCRIPTION
## Description

**Combo of PRs to backport into 0.76:**
#13493
#14039 (one line change)

The PR description that follows is mostly from #13493, as the other PR just sets the instrumentation key.

### Type of Change
New feature.

### Why
Enable posting telemetry data to have information that will allow us to take informed decisions on what areas of RNW we should focus, identify customer pains, RNW usage, etc.

Resolves #10473
Resolves #10142
Resolves #10141

### What
- Refactored Telemetry class, by changing all App Insights SDK references to 1DS core+post APIs. The most noticeable changes are: 
  - Replaced TelemetryClient with AppInsightsCore.
  - Refactored post event logic to craft a telemetry item object.
  - Manually parsed stack trace into decomposed frames, as 1DS doesn't provide such functionality (which AppInsights does).
- Refactored some of the testing code to account for the changes in the Telemetry class.

## Testing
All E2E tests on **telemetry.test.ts** are passing after the refactoring.
All other telemetry tests are passing after the refactoring as well.

## Changelog
Yes

_Enables telemetry collection to monitor RNW reliability, performance, and usage._
