### PR TITLE
Adding quotes around codegen tool executeable path and response file …

### DIFF
--- a/change/react-native-windows-d9c1b8cf-e955-456e-82a6-5d21b7df89fe.json
+++ b/change/react-native-windows-d9c1b8cf-e955-456e-82a6-5d21b7df89fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding quotes around codegen tool executeable path and response file path so that users with spaces in their user directory can build cs projects",
+  "packageName": "react-native-windows",
+  "email": "6237394+Swinkid@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/ManagedCodeGen/Microsoft.ReactNative.Managed.CodeGen.targets
+++ b/vnext/PropertySheets/ManagedCodeGen/Microsoft.ReactNative.Managed.CodeGen.targets
@@ -75,7 +75,7 @@
     <WriteLinesToFile File="$(_ReactNativeCodeGenResponseFile)" Lines="@(_ReactNativeCodeGenResponseFileLines)" Overwrite="true" WriteOnlyWhenDifferent="true" Encoding="Unicode"/>
 
     <!-- Execute the code generation /> -->
-    <Exec Command="$(_ReactNativeCodeGenToolExecutable) @$(_ReactNativeCodeGenResponseFile)" />
+    <Exec Command="&quot;$(_ReactNativeCodeGenToolExecutable)&quot; @&quot;$(_ReactNativeCodeGenResponseFile)&quot;" />
 
     <ItemGroup>
       <Compile Include="$(ReactNativeCodeGenFile)"/>

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.targets
@@ -59,7 +59,7 @@
     <WriteLinesToFile File="$(_ReactNativeCodeGenResponseFile)" Lines="@(_ReactNativeCodeGenResponseFileLines)" WriteOnlyWhenDifferent="true" Encoding="Unicode"/>
 
     <!-- Execute teh code generation /> -->
-    <Exec Command="$(_ReactNativeCodeGenToolExecutable) @$(_ReactNativeCodeGenResponseFile)" />
+    <Exec Command="&quot;$(_ReactNativeCodeGenToolExecutable)&quot; @&quot;$(_ReactNativeCodeGenResponseFile)&quot;" />
 
     <ItemGroup>
       <Compile Include="$(ReactNativeCodeGenFile)"/>


### PR DESCRIPTION
## Description
Currently if you run CodeGen / react-native run-windows it will fail If you have a space in your user directory. I.e. in my case my directory was C:\Users\Alex Noble. The space in between Alex and Noble would trick CodeGen executable into thinking it was another parameter. Apologies if this is the wrong way to tackle this issue, new to the react-native-windows project and this is how I solved it on my machine.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Motivation for this change was to allow users who have a space in their user directory to be able to build a c# project.

Resolves [Add Relevant Issue Here]

### What
Added quotes around the directories used in the CodeGen Exec

## Screenshots
![image](https://github.com/user-attachments/assets/85ca987e-3ae5-4a18-990c-9beabed742db)

## Changelog
Should this change be included in the release notes:  yes

Fixed issue with managed codegen target failing when run from path with spaces
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14100)