### PR TITLE
Bump .NET Target version in Microsoft.ReactNative.Test.Website.csproj

### DIFF
--- a/change/react-native-windows-57b89f93-f274-467b-b4eb-a6a61fd19c46.json
+++ b/change/react-native-windows-57b89f93-f274-467b-b4eb-a6a61fd19c46.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bump dotnet target version",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/TestWebSite/Microsoft.ReactNative.Test.Website.csproj
+++ b/vnext/TestWebSite/Microsoft.ReactNative.Test.Website.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IntDir>$(IntDir)$(TargetFramework)\</IntDir>


### PR DESCRIPTION
## Description

Bump target .NET version to 8.0 as 7.0 was being marked as deprecated according to CI error messages. 

### Why
Unblock CI.

### What
See above.

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14108)