### PR TITLE
[0.76] Bump .NET Target version in Microsoft.ReactNative.Test.Website.csproj

### DIFF
--- a/change/react-native-windows-45a51f09-4657-4298-85de-5d12dfb87b91.json
+++ b/change/react-native-windows-45a51f09-4657-4298-85de-5d12dfb87b91.json
@@ -1,6 +1,6 @@
 {
-  "type": "prerelease",
-  "comment": "bump dotnet target version",
+  "type": "patch",
+  "comment": "Bump .NET Target version in Microsoft.ReactNative.Test.Website.csproj (#14108)",
   "packageName": "react-native-windows",
   "email": "yajurgrover24@gmail.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-57b89f93-f274-467b-b4eb-a6a61fd19c46.json
+++ b/change/react-native-windows-57b89f93-f274-467b-b4eb-a6a61fd19c46.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bump dotnet target version",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/TestWebSite/Microsoft.ReactNative.Test.Website.csproj
+++ b/vnext/TestWebSite/Microsoft.ReactNative.Test.Website.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IntDir>$(IntDir)$(TargetFramework)\</IntDir>


### PR DESCRIPTION
## Description

Backports #14108 to 0/76

## Changelog
Should this change be included in the release notes: no