### PR TITLE
[0.74] Bump .NET Target version in Microsoft.ReactNative.Test.Website.csproj

### DIFF
--- a/change/react-native-windows-57b89f93-f274-467b-b4eb-a6a61fd19c46.json
+++ b/change/react-native-windows-57b89f93-f274-467b-b4eb-a6a61fd19c46.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "bump dotnet target version",
   "packageName": "react-native-windows",
   "email": "yajurgrover24@gmail.com",


### PR DESCRIPTION
## Description

Backports #14108 to 0.74.

It looks like the change to Microsoft.ReactNative.Test.Website.csproj was already backported in https://github.com/microsoft/react-native-windows/pull/14105 - keeping this PR to bring in the change file as well.

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14118)