### PR TITLE
Re-enable most Desktop integration tests

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -102,13 +102,7 @@ jobs:
                 (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
                 (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
                 (FullyQualifiedName!=RNTesterIntegrationTests::WebSocketBlob)&
-                (FullyQualifiedName!=WebSocketIntegrationTest::SendReceiveSsl)&
-                (FullyQualifiedName!=Microsoft::React::Test::HttpOriginPolicyIntegrationTest)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::Dummy)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::Fetch)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::XHRSample)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::Blob)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::Logging)
+                (FullyQualifiedName!=WebSocketIntegrationTest::SendReceiveSsl)
             #6799 -
             #       HostFunctionTest              - Crashes under JSI/V8
             #       HostObjectProtoTest           - Crashes under JSI/V8

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -91,12 +91,6 @@ jobs:
             #12714 -  Disable for first deployment of test website.
             #         RNTesterIntegrationTests::WebSocket
             #         RNTesterIntegrationTests::WebSocketBlob
-            ##13897 - Reneable RNTesterIntegrationTests
-            #         RNTesterIntegrationTests::Dummy
-            #         RNTesterIntegrationTests::Fetch
-            #         RNTesterIntegrationTests::XHRSample
-            #         RNTesterIntegrationTests::Blob
-            #         RNTesterIntegrationTests::Logging
             - name: Desktop.IntegrationTests.Filter
               value: >
                 (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&

--- a/change/react-native-windows-36e1f61c-649e-4cbd-b2c3-022ce931ae9d.json
+++ b/change/react-native-windows-36e1f61c-649e-4cbd-b2c3-022ce931ae9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Re-enable most Desktop integration tests",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -5,7 +5,6 @@
 
 #include <Threading/MessageQueueThreadFactory.h>
 #include <cxxreact/Instance.h>
-#include "ChakraRuntimeHolder.h"
 #include "DesktopTestInstance.h"
 #include "Modules/TestDevSettingsModule.h"
 #include "Modules/TestImageLoaderModule.h"
@@ -70,8 +69,6 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
 
   // Update settings.
   devSettings->platformName = "windows";
-
-  // Set to JSIEngineOverride::Chakra when testing the Chakra.dll JSI runtime.
   devSettings->jsiEngineOverride = JSIEngineOverride::V8;
 
   auto instanceWrapper = CreateReactInstance(

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -72,7 +72,7 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
   devSettings->platformName = "windows";
 
   // Set to JSIEngineOverride::Chakra when testing the Chakra.dll JSI runtime.
-  devSettings->jsiEngineOverride = JSIEngineOverride::Chakra;
+  devSettings->jsiEngineOverride = JSIEngineOverride::V8;
 
   auto instanceWrapper = CreateReactInstance(
       std::make_shared<facebook::react::Instance>(),

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -4,7 +4,6 @@
 #include <CppUnitTest.h>
 
 #include <CppRuntimeOptions.h>
-#include <Test/WebSocketServer.h>
 #include "TestRunner.h"
 
 using namespace Microsoft::React::Test;
@@ -176,14 +175,7 @@ TEST_CLASS (RNTesterIntegrationTests) {
   BEGIN_TEST_METHOD_ATTRIBUTE(WebSocket)
   END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(WebSocket) {
-    // Should behave the same as IntegrationTests/websocket_integration_test_server.js
-    auto server = std::make_shared<WebSocketServer>(5555, false /*useTLS*/);
-    server->SetMessageFactory([](string &&message) -> string { return message + "_response"; });
-    server->Start();
-
     TestComponent("WebSocketTest");
-
-    server->Stop();
   }
 
   BEGIN_TEST_METHOD_ATTRIBUTE(AccessibilityManager)

--- a/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
+++ b/vnext/Desktop.IntegrationTests/React.Windows.Desktop.IntegrationTests.vcxproj
@@ -35,6 +35,8 @@
     <UseWinUI3 Condition="'$(UseWinUI3)' == ''">true</UseWinUI3>
     <!-- Desktop can use WinUI3 in Old Arch so disable the check. -->
     <ForcePaperUseWinUI3 Condition="'$(UseWinUI3)'=='true'">true</ForcePaperUseWinUI3>
+    <UseV8>true</UseV8>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
@@ -148,9 +150,10 @@
     <PackageReference Include="ReactWindows.OpenSSL.StdCall.Static" Version="1.0.2-p.5" />
     <!-- TODO: Remove!!! -->
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
-    <!-- We're transitively pulling in Microsoft.WindowsAppSDK, and it depends on Microsoft.Web.WebView2, which 
+    <!-- We're transitively pulling in Microsoft.WindowsAppSDK, and it depends on Microsoft.Web.WebView2, which
         doesn't get pulled in the same way, so we need to add it explicitly. -->
     <PackageReference Include="Microsoft.Web.WebView2" Version="$(WebView2PackageVersion)" Condition="'$(UseWinUI3)'=='true'" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="Test">

--- a/vnext/Desktop.IntegrationTests/packages.lock.json
+++ b/vnext/Desktop.IntegrationTests/packages.lock.json
@@ -20,6 +20,12 @@
         "resolved": "2.0.230706.1",
         "contentHash": "l0D7oCw/5X+xIKHqZTi62TtV+1qeSz7KVluNFdrJ9hXsst4ghvqQ/Yhura7JqRdZWBXAuDS0G0KwALptdoxweQ=="
       },
+      "ReactNative.V8Jsi.Windows": {
+        "type": "Direct",
+        "requested": "[0.71.8, )",
+        "resolved": "0.71.8",
+        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
+      },
       "ReactWindows.OpenSSL.StdCall.Static": {
         "type": "Direct",
         "requested": "[1.0.2-p.5, )",
@@ -64,11 +70,6 @@
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
-      "ReactNative.V8Jsi.Windows": {
-        "type": "Transitive",
-        "resolved": "0.71.8",
-        "contentHash": "ksHjshj05AMAQ/v7Wet5Dwcwn9Up2BTOIrTv1yEW7+D23FQX0yILW5Zw0bmlWtV8MEtdY611z+06U3Xvu2ygSA=="
-      },
       "common": {
         "type": "Project",
         "dependencies": {
@@ -81,8 +82,8 @@
       "folly": {
         "type": "Project",
         "dependencies": {
-          "boost": "[1.83.0, )",
-          "fmt": "[1.0.0, )"
+          "Fmt": "[1.0.0, )",
+          "boost": "[1.83.0, )"
         }
       },
       "follywin32": {

--- a/vnext/TestWebSite/packages.lock.json
+++ b/vnext/TestWebSite/packages.lock.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0": {}
+    "net8.0": {}
   }
 }


### PR DESCRIPTION
## Description

Re-enable integration tests excluded from CI during the upgrade to React Native 0.76.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The disabled tests are required for proper validation of `react-native-win32.dll`.

Resolves #13897

### What
- Switch desktop integration tests' JS engine to V8.
- Re-enable the following tests in CI:
  ```
  (FullyQualifiedName!=RNTesterIntegrationTests::Dummy)&
  (FullyQualifiedName!=RNTesterIntegrationTests::Fetch)&
  (FullyQualifiedName!=RNTesterIntegrationTests::XHRSample)&
  (FullyQualifiedName!=RNTesterIntegrationTests::Blob)&
  (FullyQualifiedName!=RNTesterIntegrationTests::Logging)
  ```

## Testing
Ran the referred set of tests locally. All of them succed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14147)