### PR TITLE
Add linter exception to generated headers for Office builds

### DIFF
--- a/change/@react-native-windows-automation-0671783d-ada6-43fb-9882-81d449c16124.json
+++ b/change/@react-native-windows-automation-0671783d-ada6-43fb-9882-81d449c16124.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add the new generated headers",
+  "packageName": "@react-native-windows/automation",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/change/@react-native-windows-automation-channel-243f361c-0d3e-471e-a30f-bbaec98e4a20.json
+++ b/change/@react-native-windows-automation-channel-243f361c-0d3e-471e-a30f-bbaec98e4a20.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add the new generated headers",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/change/@react-native-windows-automation-commands-638e11af-371a-497c-8d4a-c794b3f6c67b.json
+++ b/change/@react-native-windows-automation-commands-638e11af-371a-497c-8d4a-c794b3f6c67b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add the new generated headers",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/change/@react-native-windows-codegen-2deb0a55-0a7b-44b0-b458-4b105d90fc28.json
+++ b/change/@react-native-windows-codegen-2deb0a55-0a7b-44b0-b458-4b105d90fc28.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add linter exception to generated headers for Office builds",
+  "packageName": "@react-native-windows/codegen",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-8df1764d-3313-4ea7-b978-0a2d329bb515.json
+++ b/change/react-native-windows-8df1764d-3313-4ea7-b978-0a2d329bb515.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "add the new generated headers",
-  "packageName": "react-native-windows",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-8df1764d-3313-4ea7-b978-0a2d329bb515.json
+++ b/change/react-native-windows-8df1764d-3313-4ea7-b978-0a2d329bb515.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add the new generated headers",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-a9362be4-db26-4085-87d2-96580e418d6c.json
+++ b/change/react-native-windows-a9362be4-db26-4085-87d2-96580e418d6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add the new generated headers",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -24,7 +24,8 @@ const headerTemplate = `/*
  * in a way that also verifies at compile time that the native module matches the interface required
  * by the TurboModule JS spec.
  */
-#pragma once`;
+#pragma once
+// clang-format off`;
 
 const specTemplate = `::_MODULE_CUSTOM_TYPES_REFLECTION_::
 struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {

--- a/packages/sample-apps/codegen/NativeMyModuleDataTypes.g.h
+++ b/packages/sample-apps/codegen/NativeMyModuleDataTypes.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <string>
 #include <optional>

--- a/packages/sample-apps/codegen/NativeMyModuleSpec.g.h
+++ b/packages/sample-apps/codegen/NativeMyModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 // #include "NativeMyModuleDataTypes.g.h" before this file to use the generated type definition
 #include <NativeModules.h>

--- a/vnext/codegen/NativeAccessibilityInfoSpec.g.h
+++ b/vnext/codegen/NativeAccessibilityInfoSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeAccessibilityManagerSpec.g.h
+++ b/vnext/codegen/NativeAccessibilityManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeActionSheetManagerSpec.g.h
+++ b/vnext/codegen/NativeActionSheetManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeAppStateSpec.g.h
+++ b/vnext/codegen/NativeAppStateSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeAppThemeSpec.g.h
+++ b/vnext/codegen/NativeAppThemeSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeAppearanceSpec.g.h
+++ b/vnext/codegen/NativeAppearanceSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeBlobModuleSpec.g.h
+++ b/vnext/codegen/NativeBlobModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeBugReportingSpec.g.h
+++ b/vnext/codegen/NativeBugReportingSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeClipboardSpec.g.h
+++ b/vnext/codegen/NativeClipboardSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDOMSpec.g.h
+++ b/vnext/codegen/NativeDOMSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDevLoadingViewSpec.g.h
+++ b/vnext/codegen/NativeDevLoadingViewSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDevMenuSpec.g.h
+++ b/vnext/codegen/NativeDevMenuSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDevSettingsSpec.g.h
+++ b/vnext/codegen/NativeDevSettingsSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDeviceEventManagerSpec.g.h
+++ b/vnext/codegen/NativeDeviceEventManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDeviceInfoSpec.g.h
+++ b/vnext/codegen/NativeDeviceInfoSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeDialogManagerWindowsSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerWindowsSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeFileReaderModuleSpec.g.h
+++ b/vnext/codegen/NativeFileReaderModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeFrameRateLoggerSpec.g.h
+++ b/vnext/codegen/NativeFrameRateLoggerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeHeadlessJsTaskSupportSpec.g.h
+++ b/vnext/codegen/NativeHeadlessJsTaskSupportSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeI18nManagerSpec.g.h
+++ b/vnext/codegen/NativeI18nManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeIdleCallbacksSpec.g.h
+++ b/vnext/codegen/NativeIdleCallbacksSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeImageLoaderIOSSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderIOSSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeImageStoreAndroidSpec.g.h
+++ b/vnext/codegen/NativeImageStoreAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeImageStoreIOSSpec.g.h
+++ b/vnext/codegen/NativeImageStoreIOSSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeIntentAndroidSpec.g.h
+++ b/vnext/codegen/NativeIntentAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeIntersectionObserverSpec.g.h
+++ b/vnext/codegen/NativeIntersectionObserverSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeJSCHeapCaptureSpec.g.h
+++ b/vnext/codegen/NativeJSCHeapCaptureSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeJSCSamplingProfilerSpec.g.h
+++ b/vnext/codegen/NativeJSCSamplingProfilerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeKeyboardObserverSpec.g.h
+++ b/vnext/codegen/NativeKeyboardObserverSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeLinkingManagerSpec.g.h
+++ b/vnext/codegen/NativeLinkingManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeLogBoxSpec.g.h
+++ b/vnext/codegen/NativeLogBoxSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeMicrotasksSpec.g.h
+++ b/vnext/codegen/NativeMicrotasksSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeModalManagerSpec.g.h
+++ b/vnext/codegen/NativeModalManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeMutationObserverSpec.g.h
+++ b/vnext/codegen/NativeMutationObserverSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeNetworkingAndroidSpec.g.h
+++ b/vnext/codegen/NativeNetworkingAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeNetworkingIOSSpec.g.h
+++ b/vnext/codegen/NativeNetworkingIOSSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativePerformanceSpec.g.h
+++ b/vnext/codegen/NativePerformanceSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativePermissionsAndroidSpec.g.h
+++ b/vnext/codegen/NativePermissionsAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativePlatformConstantsAndroidSpec.g.h
+++ b/vnext/codegen/NativePlatformConstantsAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativePlatformConstantsIOSSpec.g.h
+++ b/vnext/codegen/NativePlatformConstantsIOSSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativePlatformConstantsWindowsSpec.g.h
+++ b/vnext/codegen/NativePlatformConstantsWindowsSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeReactDevToolsRuntimeSettingsModuleSpec.g.h
+++ b/vnext/codegen/NativeReactDevToolsRuntimeSettingsModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeReactDevToolsSettingsManagerSpec.g.h
+++ b/vnext/codegen/NativeReactDevToolsSettingsManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeReactNativeFeatureFlagsSpec.g.h
+++ b/vnext/codegen/NativeReactNativeFeatureFlagsSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeRedBoxSpec.g.h
+++ b/vnext/codegen/NativeRedBoxSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeSampleTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeSampleTurboModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeSegmentFetcherSpec.g.h
+++ b/vnext/codegen/NativeSegmentFetcherSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeSettingsManagerSpec.g.h
+++ b/vnext/codegen/NativeSettingsManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeShareModuleSpec.g.h
+++ b/vnext/codegen/NativeShareModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeSoundManagerSpec.g.h
+++ b/vnext/codegen/NativeSoundManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeSourceCodeSpec.g.h
+++ b/vnext/codegen/NativeSourceCodeSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeTimingSpec.g.h
+++ b/vnext/codegen/NativeTimingSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeToastAndroidSpec.g.h
+++ b/vnext/codegen/NativeToastAndroidSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeUIManagerSpec.g.h
+++ b/vnext/codegen/NativeUIManagerSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeVibrationSpec.g.h
+++ b/vnext/codegen/NativeVibrationSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/vnext/codegen/NativeWebSocketModuleSpec.g.h
+++ b/vnext/codegen/NativeWebSocketModuleSpec.g.h
@@ -7,6 +7,7 @@
  * by the TurboModule JS spec.
  */
 #pragma once
+// clang-format off
 
 #include <NativeModules.h>
 #include <tuple>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,9 +2847,9 @@
   integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/node@^18.0.0":
-  version "18.19.64"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.64.tgz#122897fb79f2a9ec9c979bded01c11461b2b1478"
-  integrity sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==
+  version "18.19.66"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.66.tgz#0937a47904ceba5994eedf5cf4b6d503d8d6136c"
+  integrity sha512-14HmtUdGxFUalGRfLLn9Gc1oNWvWh5zNbsyOLo5JV6WARSeN1QcEBKRnZm9QqNfrutgsl/hY4eJW63aZ44aBCg==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
## Description
Add linter exception to generated headers for Office builds by adding `// clang-format off`

## Testing
No functional code changes. This only adds a comment to the generated headers.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14157)