### PR TITLE
Re-enable WebSocket desktop integration tests

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -88,14 +88,9 @@ jobs:
 
             #5059 - Disable failing or intermittent tests (IntegrationTestHarness,WebSocket,Logging).
             #10732 -  WebSocketIntegrationTest::SendReceiveSsl fails on Windows Server 2022.
-            #12714 -  Disable for first deployment of test website.
-            #         RNTesterIntegrationTests::WebSocket
-            #         RNTesterIntegrationTests::WebSocketBlob
             - name: Desktop.IntegrationTests.Filter
               value: >
                 (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::WebSocketBlob)&
                 (FullyQualifiedName!=WebSocketIntegrationTest::SendReceiveSsl)
             #6799 -
             #       HostFunctionTest              - Crashes under JSI/V8


### PR DESCRIPTION
## Description

Attempt to re-enable WebSocket Desktop integration tests in continuous integration.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The tests were disabled when the test website was first deployed.
Most likely, a duplicate attempt to reserve the test WebSocket port (5555) was being made.

Resolves [Add Relevant Issue Here]

### What

Remove WebSocket tests from the Desktop.IntegrationTests.Filter CI skip list.

## Testing

- `RNTesterIntegrationTests::WebSocket`
- `RNTesterIntegrationTests::WebSocketBlob`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14162)