### PR TITLE
[Telemetry] Add `RnwNewArch` to MSBuildProperties

### DIFF
--- a/change/react-native-windows-87a27036-cad7-4e7e-a5e1-9f1a77329392.json
+++ b/change/react-native-windows-87a27036-cad7-4e7e-a5e1-9f1a77329392.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add RnwNewArch to MSBuildProperties",
+  "packageName": "react-native-windows",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/PropertySheets/OutputMSBuildProperties.targets
+++ b/vnext/PropertySheets/OutputMSBuildProperties.targets
@@ -19,6 +19,7 @@
         "UseExperimentalNuGet": "$(UseExperimentalNuGet)",
         "UseHermes": "$(UseHermes)",
         "UseWinUI3": "$(UseWinUI3)",
+        "UseFabric": "$(UseFabric)",
         "RnwNewArch": "$(RnwNewArch)"
       }
       </MSBuildPropertiesJSON>

--- a/vnext/PropertySheets/OutputMSBuildProperties.targets
+++ b/vnext/PropertySheets/OutputMSBuildProperties.targets
@@ -18,7 +18,8 @@
         "WindowsTargetPlatformVersion": "$(WindowsTargetPlatformVersion)",
         "UseExperimentalNuGet": "$(UseExperimentalNuGet)",
         "UseHermes": "$(UseHermes)",
-        "UseWinUI3": "$(UseWinUI3)"
+        "UseWinUI3": "$(UseWinUI3)",
+        "RnwNewArch": "$(RnwNewArch)"
       }
       </MSBuildPropertiesJSON>
     </PropertyGroup>


### PR DESCRIPTION
## Description

Add `RnwNewArch` and `UseFabric` properties to MSBuildProperties, indicating if the project is using Paper or Fabric.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
By using telemetry data, we want to determine the adoption level of Fabric.

Resolves #14047

### What
Included `RnwNewArch` and `UseFabric` in the properties written into msproperties.g.json (via OutputMSBuildProperties.targets), which are picked up by `run-windows` to pass all the properties as `extraProps` for telemetry logging.

## Screenshots
![image](https://github.com/user-attachments/assets/a6e73c61-7848-4798-8dff-6cd4386c08c4)

## Testing
Ran `run-windows` in a debugger and verified that `RnwNewArch` and `UseFabric` are written into msproperties.g.json and they are passed to `Telemetry.trackCommandEvent()`.

## Changelog
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14208)