### PR TITLE
[0.72] Fix calls to std::mutex::lock

### DIFF
--- a/change/react-native-windows-908658ce-9dd6-444b-9d6b-b49cd12b2bdd.json
+++ b/change/react-native-windows-908658ce-9dd6-444b-9d6b-b49cd12b2bdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix calls to std::mutex::lock",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -57,6 +57,12 @@
       <PreprocessorDefinitions Condition="'$(UseV8)'=='true'">USE_V8;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(UseFabric)'=='true'">USE_FABRIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>JSI_VERSION=10;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        To address the crash on the first call to std::mutex::lock.
+        See: https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
+             https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio
+      -->
+      <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Cherry pick #14223
 
## Description

Fix failing calls to std::mutex::lock.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

There are some reports that a first call to std::mutex::lock fail.
The issue seems to be related to ABI incompatibility between the RNW DLL and the VCLib DLL.

### What

To address this issue we define the `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` preprocessor definition.
See:
- https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
- https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio

## Changelog
Add `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` preprocessor definition to fix failing calls to std::mutex::lock.
