### PR TITLE
Log error code from hermes.dll load failure

### DIFF
--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -39,7 +39,14 @@ void NAPI_CDECL removeInspectorPage(int32_t pageId) noexcept;
 
 class HermesFuncResolver : public IFuncResolver {
  public:
-  HermesFuncResolver() : libHandle_(LoadLibraryAsPeerFirst(L"hermes.dll")) {}
+  HermesFuncResolver(){
+    libHandle_ = LoadLibraryAsPeerFirst(L"hermes.dll");
+    
+    // If hermes.dll failed to load, catch the last Win32 error and surface it.
+    if (libHandle_ == nullptr) {
+      CRASH_ON_ERROR(GetLastError());
+    }
+  }
 
   FuncPtr getFuncPtr(const char *funcName) override {
     return reinterpret_cast<FuncPtr>(GetProcAddress(libHandle_, funcName));


### PR DESCRIPTION
## Description
Surface an error code indicating why hermes.dll didn't load.

### Type of Change
_Erase all that don't apply._
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
We currently are seeing cases where hermes.dll is not loaded. However, Watson cabs can't tell what is the root cause of the loading failure.

### What
Added a `CRASH_ON_ERROR` check right after hermes.dll loading attempt, calling `GetLastError()` to retrieve the `LoadLibrary` Win32 API error.

## Screenshots
N/A

## Testing
Ran `run-windows`, both in a successful scenario and a failure scenario (in this case, intentionally removed hermes.dll from the app files, then verified the app crashes at the newly introduced code).

## Changelog
No

Add a brief summary of the change to use in the release notes for the next release.