### PR TITLE
[0.76] [Telemetry] Add `RnwNewArch` to MSBuildProperties

### DIFF
--- a/change/react-native-windows-3ad43108-ecfc-453c-93a8-4759ba78c932.json
+++ b/change/react-native-windows-3ad43108-ecfc-453c-93a8-4759ba78c932.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add RnwNewArch to MSBuildProperties",
+  "packageName": "react-native-windows",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/PropertySheets/OutputMSBuildProperties.targets
+++ b/vnext/PropertySheets/OutputMSBuildProperties.targets
@@ -18,7 +18,9 @@
         "WindowsTargetPlatformVersion": "$(WindowsTargetPlatformVersion)",
         "UseExperimentalNuGet": "$(UseExperimentalNuGet)",
         "UseHermes": "$(UseHermes)",
-        "UseWinUI3": "$(UseWinUI3)"
+        "UseWinUI3": "$(UseWinUI3)",
+        "UseFabric": "$(UseFabric)",
+        "RnwNewArch": "$(RnwNewArch)"
       }
       </MSBuildPropertiesJSON>
     </PropertyGroup>


### PR DESCRIPTION
## Description

**Backport #14208 to 0.76.**

Add `RnwNewArch` and `UseFabric` properties to MSBuildProperties, indicating if the project is using Paper or Fabric.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
By using telemetry data, we want to determine the adoption level of Fabric.

Resolves #14047

### What
Included `RnwNewArch` and `UseFabric` in the properties written into msproperties.g.json (via OutputMSBuildProperties.targets), which are picked up by `run-windows` to pass all the properties as `extraProps` for telemetry logging.

## Screenshots
![image](https://github.com/user-attachments/assets/a6e73c61-7848-4798-8dff-6cd4386c08c4)

## Testing
Ran `run-windows` in a debugger and verified that `RnwNewArch` and `UseFabric` are written into msproperties.g.json and they are passed to `Telemetry.trackCommandEvent()`.

## Changelog
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14208)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14237)