### PR TITLE
[0.76] [Telemetry] Bug fix in `codedError.data` from `trackException()`

### DIFF
--- a/change/@react-native-windows-telemetry-371e0e76-e562-4be7-b257-2ca2afc87270.json
+++ b/change/@react-native-windows-telemetry-371e0e76-e562-4be7-b257-2ca2afc87270.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Fix bug in error telemetry collection.",
   "packageName": "@react-native-windows/telemetry",
   "email": "14967941+danielayala94@users.noreply.github.com",

--- a/change/@react-native-windows-telemetry-990667a5-918a-4348-8861-ce4ad8fc7a47.json
+++ b/change/@react-native-windows-telemetry-990667a5-918a-4348-8861-ce4ad8fc7a47.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bug in error telemetry collection.",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
@@ -22,6 +22,18 @@ import * as errorUtils from '../utils/errorUtils';
 import * as projectUtils from '../utils/projectUtils';
 import * as versionUtils from '../utils/versionUtils';
 
+class CustomTestError extends Error {
+  // Declare a mock errno field, so it is picked up by trackException() (see syscallExceptionFieldsToCopy)
+  // to copy it into codedError.data.
+  errno: string;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'CustomTestError';
+    this.errno = '123';
+  }
+}
+
 export class TelemetryTest extends Telemetry {
   protected static hasTestTelemetryProviders: boolean;
   protected static testTelemetryProvidersRan: boolean;
@@ -391,8 +403,16 @@ function verifyTestCommandTelemetryProcessor(
             : 'Unknown',
         );
 
+        // If the exception type is not CodedError but any data got copied into envelope.CodedError.data,
+        // for instance autolinking error info, build the expected CodedError.data.
+        let expectedCodedErrorData = {};
+        if (expectedError instanceof CustomTestError) {
+          expectedCodedErrorData = {errno: expectedError.errno};
+        }
+
         expect(codedError.data).toStrictEqual(
-          (expectedError as errorUtils.CodedError).data ?? {},
+          (expectedError as errorUtils.CodedError).data ??
+            expectedCodedErrorData,
         );
       } else {
         // If this is not error scenario, it must be a command successful event.
@@ -687,6 +707,32 @@ test.each(testTelemetryOptions)(
       await promiseDelay(100);
       a(process.cwd());
     });
+
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+    });
+  },
+);
+
+test.each(testTelemetryOptions)(
+  'A custom Error-based object with MS Build error info is copied into codedError.data appropriately by trackException()',
+  async options => {
+    await TelemetryTest.startTest(options);
+
+    const expectedError = new CustomTestError('some message');
+
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryInitializer(
+      verifyTestCommandTelemetryProcessor(
+        caughtErrors,
+        'Unknown',
+        expectedError,
+      ),
+    );
+
+    await runTestCommandE2E(() => testCommandBody(expectedError));
 
     TelemetryTest.endTest(() => {
       // Check if any errors were thrown

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -463,7 +463,7 @@ export class Telemetry {
     const syscallExceptionFieldsToCopy = ['errno', 'syscall', 'code'];
     for (const f of syscallExceptionFieldsToCopy) {
       if ((error as any)[f]) {
-        codedErrorStruct.data.codedError.data[f] = (error as any)[f];
+        codedErrorStruct.data[f] = (error as any)[f];
       }
     }
 


### PR DESCRIPTION
## Description
**Backports #14191 to 0.76.**

This PR eliminates the risk of writing into undefined struct fields in `trackException()`.

### Type of Change
Bug fix

### Why
Error telemetry instances were lost when hitting MS Build errors sometimes, plus avoid unnecesssary CLI error noise.

Resolves #14184 

### What
One-line change:
`codedErrorStruct.data[f] = (error as any)[f];`

instead of:
`codedErrorStruct.data.codedError.data[f] = (error as any)[f];`

**Context:**
In error telemetry instances, `codedError` contains relevant information about an exception thrown from the RNW CLI.
There are two ways to populate `codedError`: either a `errorUtils.CodedError` object is passed to `trackException()`, or a MSBuild error was hit, and the `Error` object contains any of the following fields: `errno`, `syscall` or `code`. It's in the second scenario where things go wrong.

In `trackException()`, `codedErrorStruct` copies the exception data from the `Error` object that was passed as parameter. This corresponds to `codedError.data` in the telemetry envelope. However, the MSBuild info was attempted to be copied into `codedError.data.codedError.data`, causing the Telemetry instance to throw.

## Screenshots
N/A

## Testing
Added a unit test that makes use of a `CustomErrorTest` object, based on `Error` but different from `CodedError`, to re-create the conditions where the bug was caught.

## Changelog
Yes - Fix bug in error telemetry collection.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14191)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14238)