### PR TITLE
Create RNW NuGet Release yml from classic pipeline

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -1,0 +1,106 @@
+name: RNW NuGet Release $(Date:yyyyMMdd).$(Rev:r)
+
+trigger: none
+
+resources:
+  pipelines:
+  - pipeline: 'Publish'
+    project: 'ReactNative'
+    source: 'Publish'
+    trigger:
+      branches:
+        include:
+        - -1espublish
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling-Release
+    stages:
+    - stage: PushToPrivateAdoStage
+      displayName: ADO - react-native
+      jobs:
+      - job: PushPackages
+        displayName: Push packages
+        condition: succeeded()
+        timeoutInMinutes: 0
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: 'Publish'
+            artifactName: 'ReactWindows-final-nuget'
+            targetPath: '$(Pipeline.Workspace)/ReactWindows-final-nuget'
+        steps:
+        - task: NuGetToolInstaller@1
+          displayName: 'Use NuGet '
+        - task: NuGetAuthenticate@1
+          displayName: NuGet Authenticate
+          inputs:
+            nuGetServiceConnections: ms/react-native ADO Feed
+        - task: CmdLine@2
+          displayName: NuGet push (react-native)
+          inputs:
+            script: nuget.exe push *.nupkg -ApiKey AzureArtifacts -Source https://pkgs.dev.azure.com/ms/_packaging/react-native/nuget/v3/index.json -NonInteractive -Verbosity Detailed -SkipDuplicate -NoSymbols
+            workingDirectory: $(System.DefaultWorkingDirectory)/Publish/ReactWindows-final-nuget
+    - stage: PushToPublicAdoStage
+      displayName: ADO - react-native-public
+      jobs:
+      - job: PushPackages
+        displayName: Push packages
+        condition: succeeded()
+        timeoutInMinutes: 0
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: 'Publish'
+            artifactName: 'ReactWindows-final-nuget'
+            targetPath: '$(Pipeline.Workspace)/ReactWindows-final-nuget'
+        steps:
+        - task: NuGetToolInstaller@1
+          displayName: 'Use NuGet '
+        - task: NuGetAuthenticate@1
+          displayName: NuGet Authenticate
+          inputs:
+            nuGetServiceConnections: ms/react-native-public ADO Feed
+        - task: CmdLine@2
+          displayName: NuGet push (react-native-public)
+          inputs:
+            script: nuget.exe push *.nupkg -ApiKey AzureArtifacts -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -NonInteractive -Verbosity Detailed -SkipDuplicate -NoSymbols
+            workingDirectory: $(System.DefaultWorkingDirectory)/Publish/ReactWindows-final-nuget
+    - stage: PushToNuGetStage
+      displayName: nuget.org - Push nuget packages
+      variables:
+      - group: RNW Secrets
+      jobs:
+      - job: PushPackages
+        displayName: Push packages
+        condition: and(succeeded(), endsWith(variables['Build.SourceBranchName'],'-stable'))
+        timeoutInMinutes: 0
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: 'Publish'
+            artifactName: 'ReactWindows-final-nuget'
+            targetPath: '$(Pipeline.Workspace)/ReactWindows-final-nuget'
+        steps:
+        - task: NuGetToolInstaller@1
+          displayName: 'Use NuGet '
+        - task: CmdLine@2
+          displayName: NuGet SetApiKey (nuget.org)
+          inputs:
+            script: nuget.exe SetApiKey $(nugetorg-apiKey-push)
+            workingDirectory: $(System.DefaultWorkingDirectory)/Publish/ReactWindows-final-nuget
+        - task: CmdLine@2
+          displayName: NuGet push (nuget.org)
+          inputs:
+            script: nuget.exe push .\Microsoft.ReactNative.*.nupkg -Source https://api.nuget.org/v3/index.json -SkipDuplicate -NoSymbol -NonInteractive -Verbosity Detailed
+            workingDirectory: $(System.DefaultWorkingDirectory)/Publish/ReactWindows-final-nuget


### PR DESCRIPTION
## Description
Created a new release.yml pipeline which is responsible for pushing the final nuget packages to the various ADO/NuGet feeds.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Compliance.

Closes #13904

### What
Exported the existing classic pipeline to yml using the 1ES tooling.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14244)