### PR TITLE
[0.76] [Telemetry] Expand field sanitization to codedError.data

### DIFF
--- a/change/@react-native-windows-telemetry-673ad5b4-2241-4057-9a19-15acccc82774.json
+++ b/change/@react-native-windows-telemetry-673ad5b4-2241-4057-9a19-15acccc82774.json
@@ -1,6 +1,6 @@
 {
-  "type": "prerelease",
-  "comment": "Expand sanitization checks for error telemetry instances",
+  "type": "patch",
+  "comment": "Expand telemetry field sanitization to codedError.data",
   "packageName": "@react-native-windows/telemetry",
   "email": "14967941+danielayala94@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@react-native-windows-telemetry-d7dc63f1-c900-4229-bcb4-8d7cd683293c.json
+++ b/change/@react-native-windows-telemetry-d7dc63f1-c900-4229-bcb4-8d7cd683293c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expand sanitization checks for error telemetry instances",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -467,6 +467,9 @@ export class Telemetry {
       }
     }
 
+    // Scrub any potential PII present in codedError.data array, as long as the data is a string.
+    codedErrorStruct.data = Telemetry.sanitizeAny(codedErrorStruct.data);
+
     // Break down TS Error object into Exception Data
     const exceptionData = Telemetry.convertErrorIntoExceptionData(error);
 
@@ -530,5 +533,27 @@ export class Telemetry {
     }
 
     return exceptionData;
+  }
+
+  static sanitizeAny(data: any): any {
+    if (Array.isArray(data)) {
+      // This is an array, sanitize each element recursively.
+      return data.map(item => Telemetry.sanitizeAny(item));
+    } else if (typeof data === 'object' && data !== null) {
+      // This is an object, sanitize each field recursively.
+      const sanitizedObject: Record<string, any> = {};
+      for (const key in data) {
+        if (Object.prototype.hasOwnProperty.call(data, key)) {
+          sanitizedObject[key] = Telemetry.sanitizeAny(data[key]);
+        }
+      }
+      return sanitizedObject;
+    } else if (typeof data === 'string') {
+      // The base case: this is a string, sanitize it.
+      return errorUtils.sanitizeErrorMessage(data);
+    }
+
+    // Not a string, return the data unchanged.
+    return data;
   }
 }


### PR DESCRIPTION
## Description
**Backports #14161 to 0.76**

Expand sanitization checks in telemetry, in this case error telemetry instances (and more specifically, all the string fields in `codedError.data`).

### Type of Change
Bug fix.

### Why
In telemetry error instances, certain fields may potentially contain file paths. This requires sanitization checks - they already exist for other telemetry fields.

Resolves #14158 

### What
In `Telemetry.trackException()`, take the `codedError` struct (i.e., a struct that contains error information), check each field in the struct if it's a string. If it is, perform sanitization; this will replace any filepaths with `[path]`.

## Screenshots
N/A

## Testing
Added a unit test to verify a codedError.data struct containing:
fieldWithPath - sanitization will modify remove a filepath with `[path]`.
fieldWithNoPath - a string that won't be modified.
fieldWithNoString - non-string, won't be modified.

## Changelog
Yes

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14161)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14248)