### PR TITLE
std::aligned_storage is deprecated

### DIFF
--- a/change/react-native-windows-94cad441-d079-4e22-bfcc-f2beb900bad1.json
+++ b/change/react-native-windows-94cad441-d079-4e22-bfcc-f2beb900bad1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "std::aligned_storage is deprecated",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -283,7 +283,9 @@ struct JsiAbiRuntime : facebook::jsi::Runtime {
     ~ValueRef() noexcept;
     operator facebook::jsi::Value const &() const noexcept;
 
-    using StoreType = std::aligned_storage_t<sizeof(DataPointerValue)>;
+    struct alignas(std::max_align_t) StoreType {
+        std::byte buffer[sizeof(DataPointerValue)];
+    };
     static void InitValueRef(JsiValueRef const &data, facebook::jsi::Value *value, StoreType *store) noexcept;
 
    private:
@@ -307,7 +309,9 @@ struct JsiAbiRuntime : facebook::jsi::Runtime {
     ~PropNameIDRef() noexcept;
     operator facebook::jsi::PropNameID const &() const noexcept;
 
-    using StoreType = std::aligned_storage_t<sizeof(DataPointerValue)>;
+    struct alignas(std::max_align_t) StoreType {
+        std::byte buffer[sizeof(DataPointerValue)];
+    };
 
    private:
     StoreType m_pointerStore{};

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -284,7 +284,7 @@ struct JsiAbiRuntime : facebook::jsi::Runtime {
     operator facebook::jsi::Value const &() const noexcept;
 
     struct alignas(std::max_align_t) StoreType {
-        std::byte buffer[sizeof(DataPointerValue)];
+      std::byte buffer[sizeof(DataPointerValue)];
     };
     static void InitValueRef(JsiValueRef const &data, facebook::jsi::Value *value, StoreType *store) noexcept;
 
@@ -310,7 +310,7 @@ struct JsiAbiRuntime : facebook::jsi::Runtime {
     operator facebook::jsi::PropNameID const &() const noexcept;
 
     struct alignas(std::max_align_t) StoreType {
-        std::byte buffer[sizeof(DataPointerValue)];
+      std::byte buffer[sizeof(DataPointerValue)];
     };
 
    private:


### PR DESCRIPTION
See [P1413 - Deprecate std::aligned_storage and std::aligned_union](https://wg21.link/p1413)  for background.

tl;dr: std::aligned_storage and std::aligned_union are deprecated because the API is error prone. One should just use a std::byte array with the proper alignas attribute.

alignas does not propagate through type alias. In those cases we need to introduce a new type. See
https://developercommunity.visualstudio.com/t/accepts-invalid-alignas-in-alias-decla/1345176

This is currently blocking Office from moving to C++23
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14253)