### PR TITLE
[Telemetry] Address package name limitations - Take 2

### DIFF
--- a/change/@react-native-windows-telemetry-f67eede7-8e2c-46b7-9ce9-5d664dfcd76e.json
+++ b/change/@react-native-windows-telemetry-f67eede7-8e2c-46b7-9ce9-5d664dfcd76e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Address package name limitations for telemetry",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -11,6 +11,7 @@ import * as basePropUtils from './utils/basePropUtils';
 import * as versionUtils from './utils/versionUtils';
 import * as errorUtils from './utils/errorUtils';
 import * as projectUtils from './utils/projectUtils';
+import * as nameUtils from './utils/nameUtils';
 
 export interface TelemetryOptions {
   setupString: string;
@@ -246,10 +247,15 @@ export class Telemetry {
       return true;
     }
 
-    if (forceRefresh === true || !Telemetry.versionsProp[name]) {
+    // Process the package name to comply with the backend requirements
+    const packageName = nameUtils.isValidTelemetryPackageName(name)
+      ? name
+      : nameUtils.cleanTelemetryPackageName(name);
+
+    if (forceRefresh === true || !Telemetry.versionsProp[packageName]) {
       const value = await getValue();
       if (value) {
-        Telemetry.versionsProp[name] = value;
+        Telemetry.versionsProp[packageName] = value;
         return true;
       }
     }

--- a/packages/@react-native-windows/telemetry/src/test/nameUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/nameUtils.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as nameUtils from '../utils/nameUtils';
+
+test('Verify telemetry package name is valid', () => {
+  expect(nameUtils.isValidTelemetryPackageName('package')).toBe(true);
+  expect(nameUtils.isValidTelemetryPackageName('@react')).toBe(false);
+  expect(nameUtils.isValidTelemetryPackageName('react-native')).toBe(false);
+  expect(nameUtils.isValidTelemetryPackageName('react_native')).toBe(true);
+  expect(nameUtils.isValidTelemetryPackageName('react_native/cli')).toBe(false);
+});
+
+test('Verify telemetry package name cleaning', () => {
+  expect(nameUtils.cleanTelemetryPackageName('package')).toBe('package');
+  expect(nameUtils.cleanTelemetryPackageName('@react')).toBe('_react');
+  expect(nameUtils.cleanTelemetryPackageName('react-native')).toBe(
+    'react_native',
+  );
+  expect(nameUtils.cleanTelemetryPackageName('react_native')).toBe(
+    'react_native',
+  );
+  expect(nameUtils.cleanTelemetryPackageName('react_native/cli')).toBe(
+    'react_native_cli',
+  );
+  expect(nameUtils.cleanTelemetryPackageName('@react-native-windows/cli')).toBe(
+    '_react_native_windows_cli',
+  );
+});

--- a/packages/@react-native-windows/telemetry/src/test/nameUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/nameUtils.test.ts
@@ -13,6 +13,18 @@ test('Verify telemetry package name is valid', () => {
   expect(nameUtils.isValidTelemetryPackageName('react-native')).toBe(false);
   expect(nameUtils.isValidTelemetryPackageName('react_native')).toBe(true);
   expect(nameUtils.isValidTelemetryPackageName('react_native/cli')).toBe(false);
+
+  // Check for size limits. A valid package name has 100 characters or less.
+  expect(
+    nameUtils.isValidTelemetryPackageName(
+      'react_native_react_native_react_native_react_native_react_native_react_native_react_native_react_nat',
+    ),
+  ).toBe(true);
+  expect(
+    nameUtils.isValidTelemetryPackageName(
+      'react_native_react_native_react_native_react_native_react_native_react_native_react_native_react_nati',
+    ),
+  ).toBe(false);
 });
 
 test('Verify telemetry package name cleaning', () => {
@@ -29,5 +41,22 @@ test('Verify telemetry package name cleaning', () => {
   );
   expect(nameUtils.cleanTelemetryPackageName('@react-native-windows/cli')).toBe(
     '_react_native_windows_cli',
+  );
+
+  expect(
+    nameUtils.cleanTelemetryPackageName(
+      'react_native_react_native_react_native_react_native_react_native_react_native_react_native_react_nat',
+    ),
+  ).toBe(
+    'react_native_react_native_react_native_react_native_react_native_react_native_react_native_react_nat',
+  );
+
+  // Truncate a package name with 101 characters, to the first 100.
+  expect(
+    nameUtils.cleanTelemetryPackageName(
+      'react_native_react_native_react_native_react_native_react_native_react_native_react_native_react_nati',
+    ),
+  ).toBe(
+    'react_native_react_native_react_native_react_native_react_native_react_native_react_native_react_nat',
   );
 });

--- a/packages/@react-native-windows/telemetry/src/utils/nameUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/nameUtils.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+export function isValidTelemetryPackageName(name: string): boolean {
+  // Accepted characters: alphanumeric, underscore, dot, starts with letter.
+  // Size: 1-100 characters.
+  if (name.match(/^[a-zA-Z][a-zA-Z0-9_.]{0,99}$/gi)) {
+    return true;
+  }
+  return false;
+}
+
+export function cleanTelemetryPackageName(str: string): string {
+  return str.replace(/[^a-zA-Z0-9_.]/g, '_');
+}

--- a/packages/@react-native-windows/telemetry/src/utils/nameUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/nameUtils.ts
@@ -14,5 +14,5 @@ export function isValidTelemetryPackageName(name: string): boolean {
 }
 
 export function cleanTelemetryPackageName(str: string): string {
-  return str.replace(/[^a-zA-Z0-9_.]/g, '_');
+  return str.replace(/[^a-zA-Z0-9_.]/g, '_').slice(0, 100);
 }


### PR DESCRIPTION
## Description
Fix to ensure that telemetry package names contain only the following characters: alphanumeric, underscore, dot. Also, make sure it starts with letter, and it has 100 characters or less.

Resolves #14218 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The telemetry backend doesn't like that some of the packages contain characters like `@` and `-`. This is problematic when trying to create dimensions that depend on the version of packages like:

`react-native-windows`
`@react-native-community/cli`

### What
- Added a condition to process package names in case it's not compliant with the rules described previously.
- Introduced a new telemetry helper (nameUtils) with a couple of functions to verify and process package names. Replace all "bad" characters with **underscores**.

## Screenshots
N/A

## Testing
Ran the telemetry tests, and verified in the telemetry backend that all package versions are uploaded.

## Changelog
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14252)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14259)