### PR TITLE
[0.74] Crash when running RNW on windows server 2016

### DIFF
--- a/change/react-native-windows-db1edeae-cd39-4b02-9676-e41d36724426.json
+++ b/change/react-native-windows-db1edeae-cd39-4b02-9676-e41d36724426.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix crash running on server 2016",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description
Office still supports Windows Server 2016 so we need to use run time dynamic linking to call SetThreadDescription
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14276)