### PR TITLE
Remove Paper-only code from Fabric builds of Microsoft.ReactNative

### DIFF
--- a/change/react-native-windows-73433f3d-c91f-4ae8-9618-75adc965a722.json
+++ b/change/react-native-windows-73433f3d-c91f-4ae8-9618-75adc965a722.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove Paper-only code from Fabric builds of Microsoft.ReactNative",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -149,9 +149,6 @@
       -->
       <PreprocessorDefinitions>CORE_ABI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </Midl>
-    <Midl>
-      <PreprocessorDefinitions Condition="'$(UseFabric)' == 'true'">USE_FABRIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </Midl>
   </ItemDefinitionGroup>
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <ItemGroup>

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -65,7 +65,7 @@ struct ReactContext {
     m_handle.EmitJSEvent(eventEmitterName, eventName, MakeJSValueWriter(std::forward<TArgs>(args)...));
   }
 
-#if !defined(CORE_ABI) && !defined(__APPLE__) && !defined(CXXUNITTESTS)
+#if !defined(CORE_ABI) && !defined(USE_FABRIC) && !defined(__APPLE__) && !defined(CXXUNITTESTS)
   // Dispatch eventName event to the view.
   // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -9,7 +9,6 @@
 #include <IReactContext.h>
 #include <React.h>
 #include <Views/DevMenu.h>
-#include <Views/ShadowNodeBase.h>
 #include <windows.h>
 #include <windowsx.h>
 #include <winrt/Windows.UI.Core.h>

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "IReactContext.h"
 #include "DynamicWriter.h"
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 #include "XamlUIService.h"
 #endif
 
@@ -121,7 +121,7 @@ LoadingState ReactContext::LoadingState() noexcept {
   };
 }
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 // Deprecated: Use XamlUIService directly.
 void ReactContext::DispatchEvent(
     xaml::FrameworkElement const &view,

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -46,7 +46,7 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   IInspectable JSRuntime() noexcept;
   LoadingState LoadingState() noexcept;
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   void DispatchEvent(
       xaml::FrameworkElement const &view,
       hstring const &eventName,

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -5,7 +5,7 @@ import "IJSValueWriter.idl"; // The import is to be deprecated with IReactContex
 import "IReactNotificationService.idl";
 import "IReactPropertyBag.idl";
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 #include "NamespaceRedirect.h" // The include is to be deprecated with IReactContext::DispatchEvent
 #endif
 
@@ -185,7 +185,7 @@ namespace Microsoft.ReactNative
       "It is an experimental property that may be removed or changed in a future version.")
     Object JSRuntime { get; };
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
     [deprecated("Use @XamlUIService.DispatchEvent instead", deprecate, 1)]
     DOC_STRING("Deprecated property. Use @XamlUIService.DispatchEvent instead. It will be removed in a future version.")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -3,7 +3,7 @@
 
 import "IReactContext.idl";
 import "IReactModuleBuilder.idl";
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 import "IViewManager.idl";
 #endif
 
@@ -14,7 +14,7 @@ namespace Microsoft.ReactNative
   DOC_STRING("Provides information about a custom native module. See @IReactModuleBuilder.")
   delegate Object ReactModuleProvider(IReactModuleBuilder moduleBuilder);
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   DOC_STRING("Provides information about a custom view manager. See @IViewManager.")
   delegate IViewManager ReactViewManagerProvider();
 #endif
@@ -32,7 +32,7 @@ namespace Microsoft.ReactNative
     "NOTE: TurboModules using JSI directly will not run correctly while using @ReactInstanceSettings.UseWebDebugger")
     void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
     DOC_STRING("Adds a custom view manager. See @ReactViewManagerProvider.")
     void AddViewManager(String viewManagerName, ReactViewManagerProvider viewManagerProvider);
 #endif

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -188,16 +188,11 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="ABICxxModule.h" />
-    <ClInclude Include="ABIViewManager.h" />
     <ClInclude Include="Base\CxxReactIncludes.h" />
     <ClInclude Include="Base\FollyIncludes.h" />
     <ClInclude Include="ReactHost\JSCallInvokerScheduler.h" />
     <ClInclude Include="Utils\ShadowNodeTypeUtils.h" />
     <ClInclude Include="Utils\BatchingEventEmitter.h" />
-    <ClInclude Include="DevMenuControl.h">
-      <DependentUpon>DevMenuControl.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </ClInclude>
     <ClInclude Include="DocString.h" />
     <ClInclude Include="DynamicReader.h">
       <DependentUpon>IJSValueReader.idl</DependentUpon>
@@ -208,7 +203,6 @@
     <ClInclude Include="JSDispatcherWriter.h">
       <DependentUpon>IJSValueWriter.idl</DependentUpon>
     </ClInclude>
-    <ClInclude Include="GlyphViewManager.h" />
     <ClInclude Include="HResult.h" />
     <ClInclude Include="IReactDispatcher.h">
       <DependentUpon>IReactDispatcher.idl</DependentUpon>
@@ -265,20 +259,14 @@
     <ClInclude Include="Modules\ImageViewManagerModule.h" />
     <ClInclude Include="Modules\LinkingManagerModule.h" />
     <ClInclude Include="Modules\LogBoxModule.h" />
-    <ClInclude Include="Modules\NativeUIManager.h" />
     <ClInclude Include="Modules\ReactRootViewTagGenerator.h" />
     <ClInclude Include="Modules\TimingModule.h" />
-    <ClInclude Include="Modules\PaperUIManagerModule.h" />
     <ClInclude Include="NativeModulesProvider.h" />
     <ClInclude Include="ReactHost\IReactInstance.h" />
-    <ClInclude Include="ReactHost\ViewManagerProvider.h" />
     <ClInclude Include="RedBoxErrorInfo.h" />
     <ClInclude Include="RedBoxErrorFrameInfo.h" />
     <ClInclude Include="TurboModulesProvider.h" />
     <ClInclude Include="Pch\pch.h" />
-    <ClInclude Include="ReactApplication.h">
-      <DependentUpon>ReactApplication.idl</DependentUpon>
-    </ClInclude>
     <ClInclude Include="IReactContext.h">
       <DependentUpon>IReactContext.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -317,7 +305,6 @@
       <DependentUpon>Timer.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
-    <ClInclude Include="Utils\AccessibilityUtils.h" />
     <ClInclude Include="Utils\Helpers.h" />
     <ClInclude Include="Utils\KeyboardUtils.h" />
     <ClInclude Include="Utils\LocalBundleReader.h" />
@@ -331,9 +318,57 @@
     <ClInclude Include="Utils\UwpScriptStore.h" />
     <ClInclude Include="Utils\ValueUtils.h" />
     <ClInclude Include="Utils\XamlIslandUtils.h" />
+    <ClInclude Include="Utils\XamlUtils.h" />
+    <ClInclude Include="Views\DevMenu.h" />
+    <ClInclude Include="ReactPackageBuilder.h">
+      <DependentUpon>IReactPackageBuilder.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="IReactPropertyBag.h">
+      <DependentUpon>IReactPropertyBag.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="RedBox.h" />
+    <ClInclude Include="ReactSupport.h" />
+    <ClInclude Include="TestHook.h" />
+    <ClInclude Include="QuirkSettings.h">
+      <DependentUpon>QuirkSettings.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="ReactPointerEventArgs.h">
+      <DependentUpon>ReactPointerEventArgs.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="XamlUIService.h">
+      <DependentUpon>XamlUIService.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+  </ItemGroup>
+  <!-- Paper-only ClInclude -->
+  <ItemGroup Condition="'$(UseFabric)' != 'true'">
+    <ClInclude Include="ABIViewManager.h" />
+    <ClInclude Include="DevMenuControl.h">
+      <DependentUpon>DevMenuControl.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="GlyphViewManager.h" />
+    <ClInclude Include="LayoutService.h">
+      <DependentUpon>LayoutService.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="Modules\NativeUIManager.h" />
+    <ClInclude Include="Modules\PaperUIManagerModule.h" />
+    <ClInclude Include="ReactApplication.h">
+      <DependentUpon>ReactApplication.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ReactHost\ViewManagerProvider.h" />
+    <ClInclude Include="ReactRootView.h">
+      <DependentUpon>ReactRootView.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
+    <ClInclude Include="Utils\AccessibilityUtils.h" />
+    <ClInclude Include="ViewManagersProvider.h" />
     <ClInclude Include="Views\ActivityIndicatorViewManager.h" />
     <ClInclude Include="Views\ControlViewManager.h" />
-    <ClInclude Include="Views\DevMenu.h" />
     <ClInclude Include="Views\DynamicAutomationPeer.h" />
     <ClInclude Include="Views\DynamicAutomationProperties.h" />
     <ClInclude Include="Views\DynamicValueProvider.h" />
@@ -384,55 +419,17 @@
     <ClInclude Include="Views\ViewViewManager.h" />
     <ClInclude Include="Views\VirtualTextViewManager.h" />
     <ClInclude Include="Views\XamlFeatures.h" />
-    <ClInclude Include="XamlLoadState.h" />
-    <ClInclude Include="LayoutService.h">
-      <DependentUpon>LayoutService.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClInclude>
-    <ClInclude Include="XamlUIService.h">
-      <DependentUpon>XamlUIService.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClInclude>
-    <ClInclude Include="ReactPackageBuilder.h">
-      <DependentUpon>IReactPackageBuilder.idl</DependentUpon>
-    </ClInclude>
-    <ClInclude Include="IReactPropertyBag.h">
-      <DependentUpon>IReactPropertyBag.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClInclude>
-    <ClInclude Include="ReactRootView.h">
-      <DependentUpon>ReactRootView.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClInclude>
-    <ClInclude Include="RedBox.h" />
-    <ClInclude Include="ReactSupport.h" />
-    <ClInclude Include="TestHook.h" />
-    <ClInclude Include="QuirkSettings.h">
-      <DependentUpon>QuirkSettings.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClInclude>
-    <ClInclude Include="ViewManagersProvider.h" />
     <ClInclude Include="XamlHelper.h">
       <DependentUpon>XamlHelper.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="XamlLoadState.h" />
     <ClInclude Include="XamlView.h" />
-    <ClInclude Include="ReactPointerEventArgs.h">
-      <DependentUpon>ReactPointerEventArgs.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABICxxModule.cpp" />
-    <ClCompile Include="ABIViewManager.cpp" />
-    <ClCompile Include="Base\CoreUIManagers.cpp" />
     <ClCompile Include="Utils\BatchingEventEmitter.cpp" />
     <ClCompile Include="CxxReactUWP\JSBigString.cpp" />
-    <ClCompile Include="DevMenuControl.cpp">
-      <DependentUpon>DevMenuControl.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </ClCompile>
-    <ClCompile Include="GlyphViewManager.cpp" />
     <ClCompile Include="Modules\AccessibilityInfoModule.cpp" />
     <ClCompile Include="Modules\AlertModule.cpp" />
     <ClCompile Include="Modules\Animated\AdditionAnimatedNode.cpp" />
@@ -467,8 +464,6 @@
     <ClCompile Include="Modules\ImageViewManagerModule.cpp" />
     <ClCompile Include="Modules\LinkingManagerModule.cpp" />
     <ClCompile Include="Modules\LogBoxModule.cpp" />
-    <ClCompile Include="Modules\NativeUIManager.cpp" />
-    <ClCompile Include="Modules\PaperUIManagerModule.cpp" />
     <ClCompile Include="ReactPointerEventArgs.cpp">
       <DependentUpon>ReactPointerEventArgs.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -476,11 +471,7 @@
     <ClCompile Include="Pch\pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="ReactApplication.cpp">
-      <DependentUpon>ReactApplication.idl</DependentUpon>
-    </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-    <ClCompile Include="Utils\AccessibilityUtils.cpp" />
     <ClCompile Include="Utils\KeyboardUtils.cpp" />
     <ClCompile Include="Utils\LocalBundleReader.cpp" />
     <ClCompile Include="Utils\ResourceBrushUtils.cpp" />
@@ -488,6 +479,37 @@
     <ClCompile Include="Utils\UwpScriptStore.cpp" />
     <ClCompile Include="Utils\ValueUtils.cpp" />
     <ClCompile Include="Utils\XamlIslandUtils.cpp" />
+    <ClCompile Include="ReactSupport.cpp" />
+    <ClCompile Include="TestHook.cpp" />
+    <ClCompile Include="XamlUIService.cpp">
+      <DependentUpon>XamlUIService.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+  </ItemGroup>
+  <!-- Paper-only ClCompile -->
+  <ItemGroup Condition="'$(UseFabric)' != 'true'">
+    <ClCompile Include="ABIViewManager.cpp" />
+    <ClCompile Include="Base\CoreUIManagers.cpp" />
+    <ClCompile Include="DevMenuControl.cpp">
+      <DependentUpon>DevMenuControl.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="GlyphViewManager.cpp" />
+    <ClCompile Include="LayoutService.cpp">
+      <DependentUpon>LayoutService.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="Modules\NativeUIManager.cpp" />
+    <ClCompile Include="Modules\PaperUIManagerModule.cpp" />
+    <ClCompile Include="ReactApplication.cpp">
+      <DependentUpon>ReactApplication.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="ReactRootView.cpp">
+      <DependentUpon>ReactRootView.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="Utils\AccessibilityUtils.cpp" />
+    <ClCompile Include="ViewManagersProvider.cpp" />
     <ClCompile Include="Views\ActivityIndicatorViewManager.cpp" />
     <ClCompile Include="Views\ConfigureBundlerDlg.cpp" />
     <ClCompile Include="Views\ControlViewManager.cpp" />
@@ -536,53 +558,41 @@
     <ClCompile Include="Views\ViewViewManager.cpp" />
     <ClCompile Include="Views\VirtualTextViewManager.cpp" />
     <ClCompile Include="Views\XamlFeatures.cpp" />
-    <ClCompile Include="XamlLoadState.cpp" />
-    <ClCompile Include="XamlView.cpp" />
-    <ClCompile Include="LayoutService.cpp">
-      <DependentUpon>LayoutService.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClCompile>
-    <ClCompile Include="XamlUIService.cpp">
-      <DependentUpon>XamlUIService.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClCompile>
-    <ClCompile Include="ReactRootView.cpp">
-      <DependentUpon>ReactRootView.idl</DependentUpon>
-      <SubType>Code</SubType>
-    </ClCompile>
-    <ClCompile Include="ReactSupport.cpp" />
-    <ClCompile Include="TestHook.cpp" />
-    <ClCompile Include="ViewManagersProvider.cpp" />
     <ClCompile Include="XamlHelper.cpp">
       <DependentUpon>XamlHelper.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="XamlLoadState.cpp" />
+    <ClCompile Include="XamlView.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="DesktopWindowMessage.idl" />
+    <Midl Include="DocString.idl" />
+    <Midl Include="ReactPointerEventArgs.idl" />
+    <Midl Include="XamlUIService.idl">
+      <SubType>Designer</SubType>
+    </Midl>
+  </ItemGroup>
+  <!-- Paper-only Midl -->
+  <ItemGroup Condition="'$(UseFabric)' != 'true'">
     <Midl Include="DevMenuControl.idl">
       <DependentUpon>DevMenuControl.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
-    <Midl Include="DocString.idl" />
     <Midl Include="IViewManager.idl" />
     <Midl Include="IViewManagerCore.idl" />
+    <Midl Include="LayoutService.idl">
+      <SubType>Designer</SubType>
+    </Midl>
     <Midl Include="ReactApplication.idl" />
+    <Midl Include="ReactRootView.idl">
+      <SubType>Designer</SubType>
+    </Midl>
     <Midl Include="Views\cppwinrt\AccessibilityAction.idl" />
     <Midl Include="Views\cppwinrt\Effects.idl" />
     <Midl Include="Views\cppwinrt\DynamicAutomationPeer.idl" />
     <Midl Include="Views\cppwinrt\ViewPanel.idl" />
-    <Midl Include="LayoutService.idl">
-      <SubType>Designer</SubType>
-    </Midl>
-    <Midl Include="XamlUIService.idl">
-      <SubType>Designer</SubType>
-    </Midl>
-    <Midl Include="ReactRootView.idl">
-      <SubType>Designer</SubType>
-    </Midl>
     <Midl Include="XamlHelper.idl" />
-    <Midl Include="ReactPointerEventArgs.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="microsoft.reactnative.def" />
@@ -621,7 +631,7 @@
       <Project>{a9d95a91-4db7-4f72-beb6-fe8a5c89bfbd}</Project>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseFabric)' != 'true'">
     <Page Include="DevMenuControl.xaml">
       <SubType>Designer</SubType>
     </Page>

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -3,9 +3,11 @@
 
 #include "pch.h"
 #include "AccessibilityInfoModule.h"
+#ifndef USE_FABRIC
 #include <UI.Xaml.Automation.Peers.h>
 #include <UI.Xaml.Controls.h>
 #include <XamlUtils.h>
+#endif
 #include <uiautomationcore.h>
 #include <uiautomationcoreapi.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
@@ -50,6 +52,7 @@ void AccessibilityInfo::setAccessibilityFocus(double /*reactTag*/) noexcept {
 
 void AccessibilityInfo::announceForAccessibility(std::wstring announcement) noexcept {
   m_context.UIDispatcher().Post([context = m_context, announcement = std::move(announcement)] {
+#ifndef USE_FABRIC
     // Windows requires a specific element to announce from. Unfortunately the react-native API does not provide a tag
     // So we need to find something to raise the notification event from.
     xaml::UIElement element{nullptr};
@@ -77,6 +80,7 @@ void AccessibilityInfo::announceForAccessibility(std::wstring announcement) noex
         xaml::Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
         hstr,
         hstr);
+#endif
   });
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -5,12 +5,15 @@
 #include "AlertModule.h"
 #include "Unicode.h"
 
+#ifndef USE_FABRIC
 #include <UI.Xaml.Controls.Primitives.h>
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Media.h>
 #include <UI.Xaml.Shapes.h>
 #include <Utils/ValueUtils.h>
 #include <XamlUtils.h>
+#endif
+
 #include <winrt/Windows.UI.ViewManagement.h>
 #include "Utils/Helpers.h"
 
@@ -36,6 +39,7 @@ void Alert::showAlert(
   });
 }
 
+#ifndef USE_FABRIC
 void Alert::ProcessPendingAlertRequestsXaml() noexcept {
   const auto &pendingAlert = pendingAlerts.front();
   const auto &args = pendingAlert.args;
@@ -155,8 +159,7 @@ void Alert::ProcessPendingAlertRequestsXaml() noexcept {
         ProcessPendingAlertRequests();
       });
 }
-
-#ifdef USE_FABRIC
+#else
 void Alert::ProcessPendingAlertRequestsMessageDialog() noexcept {
   const auto &pendingAlert = pendingAlerts.front();
   const auto &args = pendingAlert.args;
@@ -220,10 +223,11 @@ void Alert::ProcessPendingAlertRequests() noexcept {
   if (pendingAlerts.empty())
     return;
 
+#ifndef USE_FABRIC
   if (xaml::TryGetCurrentUwpXamlApplication()) {
     ProcessPendingAlertRequestsXaml();
   }
-#ifdef USE_FABRIC
+#else
   else {
     // If we don't have xaml loaded, fallback to using MessageDialog
     ProcessPendingAlertRequestsMessageDialog();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -50,7 +50,7 @@ comp::Compositor NativeAnimatedNodeManager::Compositor() const noexcept {
         compositionContext);
   }
 #endif
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   // TODO: Islands - need to get the XamlView associated with this animation in order to
   // use the compositor Microsoft::ReactNative::GetCompositor(xamlView)
   return Microsoft::ReactNative::GetCompositor();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -3,13 +3,13 @@
 
 #include "pch.h"
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
+#include <Views/ShadowNodeBase.h>
 #endif
 
 #include <Utils/Helpers.h>
-#include <Views/ShadowNodeBase.h>
 #include <Views/XamlFeatures.h>
 #include "NativeAnimatedNodeManager.h"
 #include "PropsAnimatedNode.h"
@@ -84,9 +84,11 @@ void PropsAnimatedNode::DisconnectFromView(int64_t viewTag) {
     }
 
     if (m_centerPointAnimation) {
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
       if (const auto target = GetUIElement()) {
         target.StopAnimation(m_centerPointAnimation);
       }
+#endif
       m_centerPointAnimation = nullptr;
     }
     m_needsCenterPointAnimation = false;
@@ -140,6 +142,7 @@ void PropsAnimatedNode::UpdateView() {
   }
 }
 
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 static void EnsureUIElementDirtyForRender(xaml::UIElement uiElement) {
   auto compositeMode = uiElement.CompositeMode();
   switch (compositeMode) {
@@ -153,16 +156,19 @@ static void EnsureUIElementDirtyForRender(xaml::UIElement uiElement) {
   }
   uiElement.CompositeMode(compositeMode);
 }
+#endif
 
 void PropsAnimatedNode::StartAnimations() {
   assert(m_useComposition);
   if (m_expressionAnimations.size()) {
     AnimationView view = GetAnimationView();
     if (view) {
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
       // Work around for https://github.com/microsoft/microsoft-ui-xaml/issues/2511
       if (view.m_element) {
         EnsureUIElementDirtyForRender(view.m_element);
       }
+#endif
       for (const auto &anim : m_expressionAnimations) {
         if (anim.second.Target() == L"Translation.X") {
           m_subchannelPropertySet.StartAnimation(L"TranslationX", anim.second);
@@ -177,18 +183,20 @@ void PropsAnimatedNode::StartAnimations() {
           m_subchannelPropertySet.StartAnimation(L"ScaleY", anim.second);
           StartAnimation(view, m_scaleCombined);
         } else if (anim.second.Target() == L"Rotation") {
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
           if (view.m_element) {
             view.m_element.RotationAxis(m_rotationAxis);
-#ifdef USE_FABRIC
-          } else {
+          }
+#else
+          if (view.m_componentView) {
             auto visual =
                 winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(
                     view.m_componentView
                         .as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>()
                         ->Visual());
             visual.RotationAxis(m_rotationAxis);
-#endif
           }
+#endif
           StartAnimation(view, anim.second);
         } else {
           StartAnimation(view, anim.second);
@@ -322,20 +330,18 @@ void PropsAnimatedNode::MakeAnimation(int64_t valueNodeTag, FacadeType facadeTyp
   }
 }
 
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 Microsoft::ReactNative::ShadowNodeBase *PropsAnimatedNode::GetShadowNodeBase() {
-#ifndef CORE_ABI
   if (const auto uiManager = Microsoft::ReactNative::GetNativeUIManager(m_context).lock()) {
     if (const auto nativeUIManagerHost = uiManager->getHost()) {
       return static_cast<Microsoft::ReactNative::ShadowNodeBase *>(
           nativeUIManagerHost->FindShadowNodeForTag(m_connectedViewTag));
     }
   }
-#endif
   return nullptr;
 }
 
 xaml::UIElement PropsAnimatedNode::GetUIElement() {
-#ifndef CORE_ABI
   if (IsRS5OrHigher()) {
     if (const auto shadowNodeBase = GetShadowNodeBase()) {
       if (const auto shadowNodeView = shadowNodeBase->GetView()) {
@@ -343,12 +349,12 @@ xaml::UIElement PropsAnimatedNode::GetUIElement() {
       }
     }
   }
-#endif
   return nullptr;
 }
+#endif
 
 void PropsAnimatedNode::CommitProps() {
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   if (const auto node = GetShadowNodeBase()) {
     if (!node->m_zombie) {
       node->updateProperties(m_props);
@@ -358,43 +364,35 @@ void PropsAnimatedNode::CommitProps() {
 }
 
 PropsAnimatedNode::AnimationView PropsAnimatedNode::GetAnimationView() {
-#ifdef USE_FABRIC
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
+  if (IsRS5OrHigher()) {
+    if (const auto shadowNodeBase = GetShadowNodeBase()) {
+      if (const auto shadowNodeView = shadowNodeBase->GetView()) {
+        return {shadowNodeView.as<xaml::UIElement>()};
+      }
+    }
+  }
+#else
   if (auto fabricuiManager = FabricUIManager::FromProperties(m_context.Properties())) {
     auto componentView = fabricuiManager->GetViewRegistry().findComponentViewWithTag(
         static_cast<facebook::react::Tag>(m_connectedViewTag));
     if (componentView) {
-      return {nullptr, componentView};
+      return {componentView};
     }
   }
-#endif // USE_FABRIC
-#ifndef CORE_ABI
-  if (IsRS5OrHigher()) {
-    if (const auto shadowNodeBase = GetShadowNodeBase()) {
-      if (const auto shadowNodeView = shadowNodeBase->GetView()) {
-#ifdef USE_FABRIC
-        return {shadowNodeView.as<xaml::UIElement>(), nullptr};
-#else
-        return {shadowNodeView.as<xaml::UIElement>()};
 #endif
-      }
-    }
-  }
-#endif // CORE_ABI
-
-#ifdef USE_FABRIC
-  return {nullptr, nullptr};
-#else
   return {nullptr};
-#endif
 }
 
 void PropsAnimatedNode::StartAnimation(
     const AnimationView &view,
     const comp::CompositionAnimation &animation) noexcept {
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   if (view.m_element) {
     view.m_element.StartAnimation(animation);
-#ifdef USE_FABRIC
-  } else if (view.m_componentView) {
+  }
+#else
+  if (view.m_componentView) {
     auto baseComponentView =
         view.m_componentView.as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
     auto visual = winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(
@@ -414,17 +412,16 @@ void PropsAnimatedNode::StartAnimation(
       }
       visual.StartAnimation(targetProp, animation);
     }
-#endif
   }
+#endif
 }
 
 comp::CompositionPropertySet PropsAnimatedNode::EnsureCenterPointPropertySet(const AnimationView &view) noexcept {
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   if (view.m_element) {
     return GetShadowNodeBase()->EnsureTransformPS();
   }
-#endif
-#ifdef USE_FABRIC
+#else
   if (view.m_componentView) {
     return view.m_componentView.as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>()
         ->EnsureCenterPointPropertySet();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
@@ -36,23 +36,26 @@ class PropsAnimatedNode final : public AnimatedNode {
 
  private:
   struct AnimationView {
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
     xaml::UIElement m_element;
-#ifdef USE_FABRIC
+#else
     winrt::Microsoft::ReactNative::ComponentView m_componentView;
 #endif
     operator bool() const noexcept {
-#ifdef USE_FABRIC
-      return m_element || m_componentView;
-#else
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
       return m_element != nullptr;
+#else
+      return m_componentView != nullptr;
 #endif
     }
   };
 
   void CommitProps();
   void MakeAnimation(int64_t valueNodeTag, FacadeType facadeType);
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   Microsoft::ReactNative::ShadowNodeBase *GetShadowNodeBase();
   xaml::UIElement GetUIElement();
+#endif
   AnimationView GetAnimationView();
   void StartAnimation(const AnimationView &view, const comp::CompositionAnimation &animation) noexcept;
   comp::CompositionPropertySet EnsureCenterPointPropertySet(const AnimationView &view) noexcept;

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -8,14 +8,15 @@
 #include "ReactHost/ReactInstanceWin.h"
 #include "ReactNativeHost.h"
 #include "Utils/Helpers.h"
-#include "XamlUtils.h"
 
 #ifdef USE_FABRIC
 #include <Fabric/Composition/CompositionContextHelper.h>
 #include <Fabric/Composition/CompositionUIService.h>
 #include <winrt/Windows.UI.Composition.h>
-#endif
+#else
 #include <UI.Xaml.Controls.Primitives.h>
+#include "XamlUtils.h"
+#endif
 
 namespace Microsoft::ReactNative {
 
@@ -121,7 +122,7 @@ void LogBox::ShowOnUIThread() noexcept {
   auto host = React::implementation::ReactNativeHost::GetReactNativeHost(m_context.Properties());
   if (!host)
     return;
-
+#ifndef USE_FABRIC
   if (!IsFabricEnabled(m_context.Properties().Handle())) {
     m_logBoxContent = React::ReactRootView();
     m_logBoxContent.ComponentName(L"LogBox");
@@ -170,7 +171,7 @@ void LogBox::ShowOnUIThread() noexcept {
     m_popup.Child(m_logBoxContent);
     m_popup.IsOpen(true);
   }
-#ifdef USE_FABRIC
+#else
   else {
     RegisterWndClass();
 
@@ -212,7 +213,7 @@ void LogBox::HideOnUIThread() noexcept {
   if (m_hwnd) {
     ::ShowWindow(m_hwnd, SW_HIDE);
   }
-#endif // USE_FABRIC
+#else // USE_FABRIC
   if (m_popup) {
     m_popup.Closed(m_tokenClosed);
     m_sizeChangedRevoker.revoke();
@@ -220,6 +221,7 @@ void LogBox::HideOnUIThread() noexcept {
     m_popup = nullptr;
     m_logBoxContent = nullptr;
   }
+#endif // USE_FABRIC
 }
 
 void LogBox::Initialize(React::ReactContext const &reactContext) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
@@ -32,9 +32,10 @@ struct LogBox : public std::enable_shared_from_this<LogBox> {
   winrt::Microsoft::ReactNative::ReactContext m_context;
 #ifdef USE_FABRIC
   HWND m_hwnd{nullptr};
-#endif // USE_FABRIC
+#else
   xaml::Controls::Primitives::Popup m_popup{nullptr};
   winrt::Microsoft::ReactNative::ReactRootView m_logBoxContent{nullptr};
+#endif // USE_FABRIC
   xaml::FrameworkElement::SizeChanged_revoker m_sizeChangedRevoker;
   winrt::event_token m_tokenClosed;
 };

--- a/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
@@ -6,7 +6,10 @@
 
 #include <DevSettings.h>
 #include <folly/dynamic.h>
+
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 #include "XamlView.h"
+#endif
 
 #include <functional>
 #include <string>
@@ -15,7 +18,9 @@ namespace Microsoft::ReactNative {
 
 struct INativeUIManager;
 class ExpressionAnimationStore;
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 struct IXamlRootView;
+#endif
 
 typedef unsigned int LiveReloadCallbackCookie;
 typedef unsigned int ErrorCallbackCookie;

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -22,10 +22,7 @@
 #undef GetCurrentTime
 #endif
 
-#ifndef CORE_ABI
-// The IReactInstance.h brings dependency on XAML. Exclude it for the UI technology independent code.
 #include <IReactInstance.h>
-#endif
 
 #include <Shared/IReactRootView.h>
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -66,11 +66,16 @@
 #include <react/runtime/TimerManager.h>
 #endif
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 #include <LayoutService.h>
+#include <XamlUIService.h>
+#include "Modules/NativeUIManager.h"
+#include "Modules/PaperUIManagerModule.h"
+#endif
+
+#ifndef CORE_ABI
 #include <Utils/UwpPreparedScriptStore.h>
 #include <Utils/UwpScriptStore.h>
-#include <XamlUIService.h>
 #include "ConfigureBundlerDlg.h"
 #include "Modules/AccessibilityInfoModule.h"
 #include "Modules/AlertModule.h"
@@ -81,8 +86,6 @@
 #include "Modules/I18nManagerModule.h"
 #include "Modules/LinkingManagerModule.h"
 #include "Modules/LogBoxModule.h"
-#include "Modules/NativeUIManager.h"
-#include "Modules/PaperUIManagerModule.h"
 #else
 #include "Modules/DesktopTimingModule.h"
 #endif
@@ -163,7 +166,7 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
                                                       UIBatchCompleteCallbackProperty())) {
                     (*callback)(instance->m_reactContext->Properties());
                   }
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
                   if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
                     uiManager->onBatchComplete();
                   }
@@ -188,7 +191,7 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
                                                   UIBatchCompleteCallbackProperty())) {
                 (*callback)(instance->m_reactContext->Properties());
               }
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
               if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
                 uiManager->onBatchComplete();
               }
@@ -346,15 +349,16 @@ void ReactInstanceWin::LoadModules(
   }
 #endif
 
-#ifndef CORE_ABI
-
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   if (!IsBridgeless()) {
     registerTurboModule(
         L"UIManager",
         // TODO: Use MakeTurboModuleProvider after it satisfies ReactNativeSpecs::UIManagerSpec
         winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::UIManager>());
   }
+#endif
 
+#ifndef CORE_ABI
   registerTurboModule(
       L"AccessibilityInfo",
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::AccessibilityInfo>());
@@ -496,7 +500,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
 void ReactInstanceWin::InitDevMenu() noexcept {
   Microsoft::ReactNative::DevMenuManager::InitDevMenu(m_reactContext, [weakReactHost = m_weakReactHost]() noexcept {
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
     Microsoft::ReactNative::ShowConfigureBundlerDialog(weakReactHost);
 #endif // CORE_ABI
   });
@@ -753,7 +757,7 @@ void ReactInstanceWin::InitializeWithBridge() noexcept {
   InitUIQueue();
   InitUIMessageThread();
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   // InitUIManager uses m_legacyReactInstance
   InitUIManager();
 #endif
@@ -1144,7 +1148,7 @@ bool ReactInstanceWin::IsBridgeless() noexcept {
       winrt::Microsoft::ReactNative::ReactPropertyBag(m_reactContext->Properties()));
 }
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 void ReactInstanceWin::InitUIManager() noexcept {
   std::vector<std::unique_ptr<Microsoft::ReactNative::IViewManager>> viewManagers;
 
@@ -1445,12 +1449,14 @@ void ReactInstanceWin::AttachMeasuredRootView(
   if (!useFabric || m_useWebDebugger) {
     int64_t rootTag = -1;
 
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
     if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*m_reactContext).lock()) {
       rootTag = uiManager->AddMeasuredRootView(rootView);
       rootView->SetTag(rootTag);
     } else {
       assert(false);
     }
+#endif
 
     std::string jsMainModuleName = rootView->JSComponentName();
     folly::dynamic params = folly::dynamic::array(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -111,7 +111,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   void InitNativeMessageThread() noexcept;
   void InitUIMessageThread() noexcept;
   void SetupHMRClient() noexcept;
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   void InitUIManager() noexcept;
 #endif
 

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -25,7 +25,7 @@ using namespace winrt;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 using namespace xaml;
 using namespace xaml::Controls;
 #endif
@@ -88,7 +88,7 @@ ReactNativeHostProperty() noexcept {
 IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   auto modulesProvider = std::make_shared<NativeModulesProvider>();
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   auto viewManagersProvider = std::make_shared<ViewManagersProvider>();
 #endif
 
@@ -106,7 +106,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
 
   m_packageBuilder = make<ReactPackageBuilder>(
       modulesProvider,
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
       viewManagersProvider,
 #endif
       turboModulesProvider,
@@ -168,7 +168,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   reactOptions.SetJsiEngine(static_cast<Mso::React::JSIEngine>(m_instanceSettings.JSIEngineOverride()));
 
   reactOptions.ModuleProvider = modulesProvider;
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   reactOptions.ViewManagerProvider = viewManagersProvider;
 #endif
   reactOptions.TurboModuleProvider = turboModulesProvider;

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -16,7 +16,7 @@ namespace winrt::Microsoft::ReactNative {
 
 ReactPackageBuilder::ReactPackageBuilder(
     std::shared_ptr<NativeModulesProvider> const &modulesProvider,
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
     std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
 #endif
     std::shared_ptr<TurboModulesProvider> const &turboModulesProvider,
@@ -26,7 +26,7 @@ ReactPackageBuilder::ReactPackageBuilder(
 #endif
     bool isWebDebugging) noexcept
     : m_modulesProvider{modulesProvider},
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
       m_viewManagersProvider{viewManagersProvider},
 #endif
       m_turboModulesProvider{turboModulesProvider},
@@ -42,7 +42,7 @@ void ReactPackageBuilder::AddModule(hstring const &moduleName, ReactModuleProvid
   m_modulesProvider->AddModuleProvider(moduleName, moduleProvider);
 }
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 void ReactPackageBuilder::AddViewManager(
     hstring const &viewManagerName,
     ReactViewManagerProvider const &viewManagerProvider) noexcept {

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -4,7 +4,7 @@
 
 #include "NativeModulesProvider.h"
 #include "TurboModulesProvider.h"
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 #include "ViewManagersProvider.h"
 #endif
 #include "winrt/Microsoft.ReactNative.h"
@@ -26,7 +26,7 @@ struct ReactPackageBuilder : winrt::implements<
                                  > {
   ReactPackageBuilder(
       std::shared_ptr<NativeModulesProvider> const &modulesProvider,
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
       std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
 #endif
       std::shared_ptr<TurboModulesProvider> const &turboModulesProvider,
@@ -39,7 +39,7 @@ struct ReactPackageBuilder : winrt::implements<
 
  public: // IReactPackageBuilder
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   void AddViewManager(hstring const &viewManagerName, ReactViewManagerProvider const &viewManagerProvider) noexcept;
 #endif
   void AddTurboModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
@@ -52,7 +52,7 @@ struct ReactPackageBuilder : winrt::implements<
 
  private:
   std::shared_ptr<NativeModulesProvider> m_modulesProvider;
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   std::shared_ptr<ViewManagersProvider> m_viewManagersProvider;
 #endif
   std::shared_ptr<TurboModulesProvider> m_turboModulesProvider;

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
@@ -14,8 +14,6 @@
 #endif // USE_FABRIC
 
 namespace winrt {
-using namespace xaml::Controls::Primitives;
-using namespace xaml::Media;
 using namespace Windows::Foundation::Metadata;
 } // namespace winrt
 

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -10,7 +10,7 @@
 #include "IReactDispatcher.h"
 #include "Modules/DevSettingsModule.h"
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 #include <XamlUtils.h>
 #include "DevMenuControl.h"
 #include "UI.Xaml.Controls.Primitives.h"
@@ -37,7 +37,7 @@ struct IDevMenu {
   virtual void Show() noexcept = 0;
 };
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 bool IsCtrlShiftD(winrt::Windows::System::VirtualKey key) noexcept {
   return (
       key == winrt::Windows::System::VirtualKey::D &&
@@ -116,7 +116,7 @@ const wchar_t *HermesProfilerLabel(Mso::CntPtr<Mso::React::IReactContext> const 
                                                                       : L"Stop and copy trace path to clipboard";
 }
 
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
 struct InAppXamlDevMenu : public IDevMenu, public std::enable_shared_from_this<InAppXamlDevMenu> {
   InAppXamlDevMenu(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) : m_context(reactContext) {}
 
@@ -348,7 +348,7 @@ struct WindowsPopupMenuDevMenu : public IDevMenu, public std::enable_shared_from
 DevMenuManager::DevMenuManager(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) : m_context(reactContext) {}
 
 void DevMenuManager::Init() noexcept {
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   auto uiDispatcher = React::implementation::ReactDispatcher::GetUIDispatcher(m_context->Properties());
   uiDispatcher.Post([weakThis = weak_from_this()]() {
     if (auto strongThis = weakThis.lock()) {
@@ -396,7 +396,7 @@ std::shared_ptr<IDevMenu> GetOrCreateDevMenu(Mso::CntPtr<Mso::React::IReactConte
       .GetOrCreate(
           DevMenuImplProperty(),
           [reactContext]() -> std::shared_ptr<IDevMenu> {
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
             if (xaml::TryGetCurrentUwpXamlApplication()) {
               auto devMenu = std::make_shared<InAppXamlDevMenu>(reactContext);
               return devMenu;

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.h
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.h
@@ -21,7 +21,7 @@ struct DevMenuManager : public std::enable_shared_from_this<DevMenuManager> {
  private:
   void Init() noexcept;
   const Mso::CntPtr<Mso::React::IReactContext> m_context;
-#ifndef CORE_ABI
+#if !defined(CORE_ABI) && !defined(USE_FABRIC)
   winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_coreDispatcherAKARevoker{};
   xaml::UIElement::KeyDown_revoker m_keyDownRevoker;
 #endif

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -4,17 +4,28 @@
 #include "pch.h"
 #include "XamlUIService.h"
 #include "XamlUIService.g.cpp"
+
+#ifndef USE_FABRIC
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
-#include "DynamicWriter.h"
 #include "ShadowNodeBase.h"
 #include "Views/ShadowNodeBase.h"
+#endif
+
+#include "DynamicWriter.h"
 #include "XamlView.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
 XamlUIService::XamlUIService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context(context) {}
 
+/*static*/ winrt::Microsoft::ReactNative::XamlUIService XamlUIService::FromContext(IReactContext context) {
+  return context.Properties()
+      .Get(XamlUIService::XamlUIServiceProperty().Handle())
+      .try_as<winrt::Microsoft::ReactNative::XamlUIService>();
+}
+
+#ifndef USE_FABRIC
 xaml::DependencyObject XamlUIService::ElementFromReactTag(int64_t reactTag) noexcept {
   if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
     auto shadowNode = uiManager->getHost()->FindShadowNodeForTag(reactTag);
@@ -24,12 +35,6 @@ xaml::DependencyObject XamlUIService::ElementFromReactTag(int64_t reactTag) noex
     return static_cast<::Microsoft::ReactNative::ShadowNodeBase *>(shadowNode)->GetView();
   }
   return nullptr;
-}
-
-/*static*/ winrt::Microsoft::ReactNative::XamlUIService XamlUIService::FromContext(IReactContext context) {
-  return context.Properties()
-      .Get(XamlUIService::XamlUIServiceProperty().Handle())
-      .try_as<winrt::Microsoft::ReactNative::XamlUIService>();
 }
 
 void XamlUIService::DispatchEvent(
@@ -64,6 +69,7 @@ winrt::Microsoft::ReactNative::ReactRootView XamlUIService::GetReactRootView(
   }
   return nullptr;
 }
+#endif
 
 /*static*/ ReactPropertyId<XamlUIService> XamlUIService::XamlUIServiceProperty() noexcept {
   static ReactPropertyId<XamlUIService> uiManagerProperty{L"ReactNative.UIManager", L"XamlUIManager"};

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -15,14 +15,17 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
   XamlUIService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
   static ReactPropertyId<XamlUIService> XamlUIServiceProperty() noexcept;
 
-  xaml::DependencyObject ElementFromReactTag(int64_t reactTag) noexcept;
   static winrt::Microsoft::ReactNative::XamlUIService FromContext(IReactContext context);
+
+#ifndef USE_FABRIC
+  xaml::DependencyObject ElementFromReactTag(int64_t reactTag) noexcept;
   void DispatchEvent(
       xaml::FrameworkElement const &view,
       hstring const &eventName,
       JSValueArgWriter const &eventDataArgWriter) noexcept;
 
   winrt::Microsoft::ReactNative::ReactRootView GetReactRootView(xaml::FrameworkElement const &view) noexcept;
+#endif
 
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
   static void SetAccessibleRoot(

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -19,6 +19,7 @@ namespace Microsoft.ReactNative
     DOC_STRING("Use this method to get access to the @XamlUIService associated with the @IReactContext.")
     static XamlUIService FromContext(IReactContext context);
 
+#ifndef USE_FABRIC
     DOC_STRING("Gets the backing XAML element from a react tag.")
     XAML_NAMESPACE.DependencyObject ElementFromReactTag(Int64 reactTag);
 
@@ -27,6 +28,7 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Gets the @ReactRootView view for a given element.")
     ReactRootView GetReactRootView(XAML_NAMESPACE.FrameworkElement view);
+#endif
 
     DOC_STRING(
       "Sets the @Windows.UI.Xaml.XamlRoot element for the app. "

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -73,6 +73,9 @@
       -->
       <PreprocessorDefinitions>_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Midl>
+      <PreprocessorDefinitions Condition="'$(UseFabric)' == 'true'">USE_FABRIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </Midl>
   </ItemDefinitionGroup>
 
   <PropertyGroup>

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -329,6 +329,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\BorderPrimitive.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsinspector-modern\TracingAgent.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\codegen\rnwcoreJSI-generated.cpp" />
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\jsinspector-modern\tracing\PerformanceTracer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description

Removes most of the Paper-only code from Fabric builds of Microsoft.ReactNative. This is only a first pass - there may be more that needs to be removed (or stuff that needs to be put back in).

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
Besides nearly doubling the size of the binary files, all of the Paper-only code is functionally useless in Fabric builds, which at worse is dead weight, and at best is confusing to developers.

Resolves #13405

### What
Updated project files to not load/compile paper-only modules. Updated modules that are used by both to correctly only include the Paper or Fabric code they need.

## Screenshots

None, but here are some preliminary binary size numbers for x64 release:

| File | Paper | Fabric (Before) | Fabric (After) |
|:-|:-:|:-:|:-:|
| Microsoft.ReactNative.dll | 4.02 MB | 8.32 MB | 6.47 MB (🔻1.85 MB / 22% ) |
| Microsoft.ReactNative.winmd | 64.0 KB | 121.0 KB | 92.0KB (🔻29 KB / 24%) |

## Testing
Verified all existing tests still pass and fabric apps work.

## Changelog
Should this change be included in the release notes: _yes_

Remove Paper-only code from Fabric builds of Microsoft.ReactNative
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14289)