### PR TITLE
[0.74] RNIsland UIA fragment root should report parents fragment root

### DIFF
--- a/.ado/templates/enable-fabric-experimental-feature.yml
+++ b/.ado/templates/enable-fabric-experimental-feature.yml
@@ -5,7 +5,7 @@ steps:
       $nsm.AddNamespace('ns', $experimentalFeatures.DocumentElement.NamespaceURI)
 
       $xmlNode = $experimentalFeatures.CreateElement("PropertyGroup");
-      $xmlNode.InnerXml = "<UseFabric>true</UseFabric><UseWinUI3>true</UseWinUI3><UseExperimentalWinUI3>true</UseExperimentalWinUI3>"
+      $xmlNode.InnerXml = "<UseFabric>true</UseFabric><UseWinUI3>true</UseWinUI3>"
 
       $experimentalFeatures.DocumentElement.AppendChild($xmlNode);
 

--- a/.ado/templates/enable-fabric-experimental-feature.yml
+++ b/.ado/templates/enable-fabric-experimental-feature.yml
@@ -5,7 +5,7 @@ steps:
       $nsm.AddNamespace('ns', $experimentalFeatures.DocumentElement.NamespaceURI)
 
       $xmlNode = $experimentalFeatures.CreateElement("PropertyGroup");
-      $xmlNode.InnerXml = "<UseFabric>true</UseFabric><UseWinUI3>true</UseWinUI3>"
+      $xmlNode.InnerXml = "<UseFabric>true</UseFabric><UseWinUI3>true</UseWinUI3><UseExperimentalWinUI3>true</UseExperimentalWinUI3>"
 
       $experimentalFeatures.DocumentElement.AppendChild($xmlNode);
 

--- a/change/react-native-windows-e6272cc4-e143-4cf9-98d1-b81bb73e7cb5.json
+++ b/change/react-native-windows-e6272cc4-e143-4cf9-98d1-b81bb73e7cb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "RNIsland UIA fragment root should report parents fragment root.",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-ed7b2b09-74fa-4fe0-9de3-57c3ae856148.json
+++ b/change/react-native-windows-ed7b2b09-74fa-4fe0-9de3-57c3ae856148.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update WinUI3ExperimentalVersion from 1.6.240701003-experimental2 to 1.7.250109001-experimental2",
+  "packageName": "react-native-windows",
+  "email": "50150435+JesseCol@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
+    <UseExperimentalWinUI3>true</UseExperimentalWinUI3>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -2,6 +2,7 @@
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
     <UseExperimentalWinUI3>true</UseExperimentalWinUI3>
+    <WindowsAppSdkAutoInitialize>false</WindowsAppSdkAutoInitialize>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
@@ -36,7 +36,7 @@ HRESULT __stdcall CompositionRootAutomationProvider::GetRuntimeId(SAFEARRAY **pR
   if (*pRetVal == nullptr)
     return E_OUTOFMEMORY;
 
-  auto rgiRuntimeId = static_cast<int*>((*pRetVal)->pvData);
+  auto rgiRuntimeId = static_cast<int *>((*pRetVal)->pvData);
 
   rgiRuntimeId[0] = UiaAppendRuntimeId;
   rgiRuntimeId[1] = LODWORD(id);
@@ -170,16 +170,16 @@ HRESULT __stdcall CompositionRootAutomationProvider::get_FragmentRoot(IRawElemen
 
   *pRetVal = nullptr;
 
-  if (m_island)
-  {
+#ifdef USE_EXPERIMENTAL_WINUI3
+  if (m_island) {
     auto parentRoot = m_island.FragmentRootAutomationProvider();
     auto spFragment = parentRoot.try_as<IRawElementProviderFragmentRoot>();
-    if (spFragment)
-    {
+    if (spFragment) {
       *pRetVal = spFragment.detach();
       return S_OK;
     }
   }
+#endif
 
   return S_OK;
 }
@@ -286,6 +286,7 @@ HRESULT __stdcall CompositionRootAutomationProvider::Navigate(
       }
     }
   } else if (direction == NavigateDirection_Parent) {
+#ifdef USE_EXPERIMENTAL_WINUI3
     if (m_island) {
       auto parent = m_island.ParentAutomationProvider();
       auto spFragment = parent.try_as<IRawElementProviderFragment>();
@@ -294,6 +295,7 @@ HRESULT __stdcall CompositionRootAutomationProvider::Navigate(
         return S_OK;
       }
     }
+#endif
   }
 
   *pRetVal = nullptr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
@@ -30,8 +30,6 @@ HRESULT __stdcall CompositionRootAutomationProvider::GetRuntimeId(SAFEARRAY **pR
   if (!m_island)
     return E_FAIL;
 
-  auto id = reinterpret_cast<INT_PTR>(winrt::get_unknown(m_island));
-
   *pRetVal = SafeArrayCreateVector(VT_I4, 0, 3);
   if (*pRetVal == nullptr)
     return E_OUTOFMEMORY;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
@@ -27,6 +27,21 @@ HRESULT __stdcall CompositionRootAutomationProvider::GetRuntimeId(SAFEARRAY **pR
 
   *pRetVal = nullptr;
 
+  if (!m_island)
+    return E_FAIL;
+
+  auto id = reinterpret_cast<INT_PTR>(winrt::get_unknown(m_island));
+
+  *pRetVal = SafeArrayCreateVector(VT_I4, 0, 3);
+  if (*pRetVal == nullptr)
+    return E_OUTOFMEMORY;
+
+  auto rgiRuntimeId = static_cast<int*>((*pRetVal)->pvData);
+
+  rgiRuntimeId[0] = UiaAppendRuntimeId;
+  rgiRuntimeId[1] = LODWORD(id);
+  rgiRuntimeId[2] = HIDWORD(id);
+
   return S_OK;
 }
 
@@ -153,8 +168,18 @@ HRESULT __stdcall CompositionRootAutomationProvider::get_FragmentRoot(IRawElemen
   if (pRetVal == nullptr)
     return E_POINTER;
 
-  AddRef();
-  *pRetVal = this;
+  *pRetVal = nullptr;
+
+  if (m_island)
+  {
+    auto parentRoot = m_island.FragmentRootAutomationProvider();
+    auto spFragment = parentRoot.try_as<IRawElementProviderFragmentRoot>();
+    if (spFragment)
+    {
+      *pRetVal = spFragment.detach();
+      return S_OK;
+    }
+  }
 
   return S_OK;
 }
@@ -260,7 +285,17 @@ HRESULT __stdcall CompositionRootAutomationProvider::Navigate(
         return S_OK;
       }
     }
+  } else if (direction == NavigateDirection_Parent) {
+    if (m_island) {
+      auto parent = m_island.ParentAutomationProvider();
+      auto spFragment = parent.try_as<IRawElementProviderFragment>();
+      if (spFragment) {
+        *pRetVal = spFragment.detach();
+        return S_OK;
+      }
+    }
   }
+
   *pRetVal = nullptr;
   return S_OK;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
@@ -39,8 +39,14 @@ HRESULT __stdcall CompositionRootAutomationProvider::GetRuntimeId(SAFEARRAY **pR
   auto rgiRuntimeId = static_cast<int *>((*pRetVal)->pvData);
 
   rgiRuntimeId[0] = UiaAppendRuntimeId;
-  rgiRuntimeId[1] = LODWORD(id);
-  rgiRuntimeId[2] = HIDWORD(id);
+  rgiRuntimeId[1] = 0;
+  rgiRuntimeId[2] = 0;
+
+  if (auto rootView = m_wkRootView.get()) {
+    auto tag = rootView->RootTag();
+    rgiRuntimeId[1] = LODWORD(tag);
+    rgiRuntimeId[2] = HIDWORD(tag);
+  }
 
   return S_OK;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
@@ -43,7 +43,7 @@ HRESULT __stdcall CompositionRootAutomationProvider::GetRuntimeId(SAFEARRAY **pR
   rgiRuntimeId[2] = 0;
 
   if (auto rootView = m_wkRootView.get()) {
-    auto tag = rootView->RootTag();
+    auto tag = rootView.RootTag();
     rgiRuntimeId[1] = LODWORD(tag);
     rgiRuntimeId[2] = HIDWORD(tag);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
@@ -42,13 +42,13 @@ ContentIslandComponentView::ContentIslandComponentView(
 
 void ContentIslandComponentView::OnMounted() noexcept {
 #ifdef USE_EXPERIMENTAL_WINUI3
-  m_childContentLink = winrt::Microsoft::UI::Content::ChildContentLink::Create(
+  m_childSiteLink = winrt::Microsoft::UI::Content::ChildSiteLink::Create(
       rootComponentView()->parentContentIsland(),
       winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(Visual())
           .as<winrt::Microsoft::UI::Composition::ContainerVisual>());
-  m_childContentLink.ActualSize({m_layoutMetrics.frame.size.width, m_layoutMetrics.frame.size.height});
+  m_childSiteLink.ActualSize({m_layoutMetrics.frame.size.width, m_layoutMetrics.frame.size.height});
   if (m_islandToConnect) {
-    m_childContentLink.Connect(m_islandToConnect);
+    m_childSiteLink.Connect(m_islandToConnect);
     m_islandToConnect = nullptr;
   }
 
@@ -82,8 +82,10 @@ void ContentIslandComponentView::ParentLayoutChanged() noexcept {
     if (auto strongThis = wkThis.get()) {
       auto clientRect = strongThis->getClientRect();
 
-      strongThis->m_childContentLink.OffsetOverride(
-          {static_cast<float>(clientRect.left), static_cast<float>(clientRect.top)});
+      strongThis->m_childSiteLink.LocalToParentTransformMatrix(
+          winrt::Windows::Foundation::Numerics::make_float4x4_translation(
+              static_cast<float>(clientRect.left), static_cast<float>(clientRect.top), 0.0f));
+
       strongThis->m_layoutChangePosted = false;
     }
   });
@@ -114,8 +116,8 @@ void ContentIslandComponentView::updateLayoutMetrics(
     facebook::react::LayoutMetrics const &layoutMetrics,
     facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept {
 #ifdef USE_EXPERIMENTAL_WINUI3
-  if (m_childContentLink) {
-    m_childContentLink.ActualSize({layoutMetrics.frame.size.width, layoutMetrics.frame.size.height});
+  if (m_childSiteLink) {
+    m_childSiteLink.ActualSize({layoutMetrics.frame.size.width, layoutMetrics.frame.size.height});
     ParentLayoutChanged();
   }
 #endif
@@ -124,9 +126,9 @@ void ContentIslandComponentView::updateLayoutMetrics(
 
 void ContentIslandComponentView::Connect(const winrt::Microsoft::UI::Content::ContentIsland &contentIsland) noexcept {
 #ifdef USE_EXPERIMENTAL_WINUI3
-  if (m_childContentLink) {
+  if (m_childSiteLink) {
     m_islandToConnect = nullptr;
-    m_childContentLink.Connect(contentIsland);
+    m_childSiteLink.Connect(contentIsland);
   } else {
     m_islandToConnect = contentIsland;
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
@@ -55,7 +55,7 @@ struct ContentIslandComponentView : ContentIslandComponentViewT<ContentIslandCom
   winrt::event_token m_unmountedToken;
   std::vector<winrt::Microsoft::ReactNative::ComponentView::LayoutMetricsChanged_revoker> m_layoutMetricChangedRevokers;
 #ifdef USE_EXPERIMENTAL_WINUI3
-  winrt::Microsoft::UI::Content::ChildContentLink m_childContentLink{nullptr};
+  winrt::Microsoft::UI::Content::ChildSiteLink m_childSiteLink{nullptr};
 #endif
 };
 

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -4,15 +4,16 @@
 
     <!-- 
       Internal versions are located at: https://microsoft.visualstudio.com/DefaultCollection/ProjectReunion/_artifacts/feed/Project.Reunion.nuget.internal/NuGet/Microsoft.WindowsAppSDK/versions
-      For local testing of internal versions, modify the WinUI3Version, and comment out the addition nuget source in NuGet.Config
+      For local testing of internal versions, modify WinUI3ExperimentalVersion, and comment out the addition nuget source in NuGet.Config
     -->
-    <!-- This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI3Version Condition="'$(WinUI3Version)'=='' AND '$(UseExperimentalWinUI3)'=='true'">1.6.240701003-experimental2</WinUI3Version>
-    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.5.240227000</WinUI3Version>
+    <WinUI3ExperimentalVersion Condition="'$(WinUI3ExperimentalVersion)'==''">1.7.250109001-experimental2</WinUI3ExperimentalVersion>
+    <!-- This value is also used by the CLI, see /packages/@react-native-windows/cli/.../autolinkWindows.ts -->
+    <WinUI3Version Condition="'$(WinUI3Version)'=='' AND '$(UseExperimentalWinUI3)'=='true'">$(WinUI3ExperimentalVersion)</WinUI3Version>
+    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.6.240923002</WinUI3Version>
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI2x versioning">
-		<!--This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
+		<!--This value is also used by the CLI, see /packages/@react-native-windows/cli/.../autolinkWindows.ts -->
     <WinUI2xVersion Condition="'$(WinUI2xVersion)'==''">2.8.0</WinUI2xVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description
This fixes the UIA tree when a ReactNativeIsland is embedded inside other UI.

With this change the desktop dll will be built using the experimental WinAppSDK dll, as we are relying on using new APIs in that version of WinAppSDK.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14301)