### PR TITLE
Initial support for UIA and tab navigation for a child Island

### DIFF
--- a/change/react-native-windows-96dd8a87-4b77-4f7e-bf40-fb214350e0f3.json
+++ b/change/react-native-windows-96dd8a87-4b77-4f7e-bf40-fb214350e0f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Basic support for stitching the UIA tree for a ContentIslandComponentView's child",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -32,47 +32,7 @@ CompositionDynamicAutomationProvider::CompositionDynamicAutomationProvider(
 CompositionDynamicAutomationProvider::CompositionDynamicAutomationProvider(
     const winrt::Microsoft::ReactNative::Composition::ComponentView &componentView,
     const winrt::Microsoft::UI::Content::ChildSiteLink &childSiteLink) noexcept
-    : m_view{componentView}, m_childSiteLink{childSiteLink} {
-  // These events are raised in response to the child ContentIsland asking for providers.
-  // For example, the ContentIsland.FragmentRootAutomationProvider property will return
-  // the provider we provide here in FragmentRootAutomationProviderRequested.
-
-  m_fragmentRootAutomationProviderRequestedRevoker = m_childSiteLink.FragmentRootAutomationProviderRequested(
-      [this](
-          const winrt::Microsoft::UI::Content::IContentSiteAutomation &,
-          const winrt::Microsoft::UI::Content::ContentSiteAutomationProviderRequestedEventArgs &args) {
-        // The child island's fragment tree doesn't have its own root.
-        // Here's how we can provide the correct root to the child's UIA logic.
-        winrt::com_ptr<IRawElementProviderFragmentRoot> fragmentRoot = nullptr;
-        HRESULT hr = this->get_FragmentRoot(fragmentRoot.put());
-        args.AutomationProvider(fragmentRoot.as<IInspectable>());
-        args.Handled(true);
-      });
-
-  m_parentAutomationProviderRequestedRevoker = m_childSiteLink.ParentAutomationProviderRequested(
-      [this](
-          const winrt::Microsoft::UI::Content::IContentSiteAutomation &,
-          const winrt::Microsoft::UI::Content::ContentSiteAutomationProviderRequestedEventArgs &args) {
-        args.AutomationProvider(*this);
-        args.Handled(true);
-      });
-
-  m_nextSiblingAutomationProviderRequestedRevoker = m_childSiteLink.NextSiblingAutomationProviderRequested(
-      [](const winrt::Microsoft::UI::Content::IContentSiteAutomation &,
-         const winrt::Microsoft::UI::Content::ContentSiteAutomationProviderRequestedEventArgs &args) {
-        // The ContentIsland will always be the one and only child of this node, so it won't have siblings.
-        args.AutomationProvider(nullptr);
-        args.Handled(true);
-      });
-
-  m_previousSiblingAutomationProviderRequestedRevoker = m_childSiteLink.PreviousSiblingAutomationProviderRequested(
-      [](const winrt::Microsoft::UI::Content::IContentSiteAutomation &,
-         const winrt::Microsoft::UI::Content::ContentSiteAutomationProviderRequestedEventArgs &args) {
-        // The ContentIsland will always be the one and only child of this node, so it won't have siblings.
-        args.AutomationProvider(nullptr);
-        args.Handled(true);
-      });
-}
+    : m_view{componentView}, m_childSiteLink{childSiteLink} {}
 #endif // USE_EXPERIMENTAL_WINUI3
 
 HRESULT __stdcall CompositionDynamicAutomationProvider::Navigate(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
@@ -95,14 +95,6 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
 #ifdef USE_EXPERIMENTAL_WINUI3
   // Non-null when this UIA node is the peer of a ContentIslandComponentView.
   winrt::Microsoft::UI::Content::ChildSiteLink m_childSiteLink{nullptr};
-  winrt::Microsoft::UI::Content::ChildSiteLink::FragmentRootAutomationProviderRequested_revoker
-      m_fragmentRootAutomationProviderRequestedRevoker;
-  winrt::Microsoft::UI::Content::ChildSiteLink::ParentAutomationProviderRequested_revoker
-      m_parentAutomationProviderRequestedRevoker;
-  winrt::Microsoft::UI::Content::ChildSiteLink::NextSiblingAutomationProviderRequested_revoker
-      m_nextSiblingAutomationProviderRequestedRevoker;
-  winrt::Microsoft::UI::Content::ChildSiteLink::PreviousSiblingAutomationProviderRequested_revoker
-      m_previousSiblingAutomationProviderRequestedRevoker;
 #endif
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
@@ -25,6 +25,12 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
   CompositionDynamicAutomationProvider(
       const winrt::Microsoft::ReactNative::Composition::ComponentView &componentView) noexcept;
 
+#ifdef USE_EXPERIMENTAL_WINUI3
+  CompositionDynamicAutomationProvider(
+      const winrt::Microsoft::ReactNative::Composition::ComponentView &componentView,
+      const winrt::Microsoft::UI::Content::ChildSiteLink &childContentLink) noexcept;
+#endif // USE_EXPERIMENTAL_WINUI3
+
   // inherited via IRawElementProviderFragment
   virtual HRESULT __stdcall Navigate(NavigateDirection direction, IRawElementProviderFragment **pRetVal) override;
   virtual HRESULT __stdcall GetRuntimeId(SAFEARRAY **pRetVal) override;
@@ -86,6 +92,18 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
  private:
   ::Microsoft::ReactNative::ReactTaggedView m_view;
   std::vector<winrt::com_ptr<IRawElementProviderSimple>> m_selectionItems;
+#ifdef USE_EXPERIMENTAL_WINUI3
+  // Non-null when this UIA node is the peer of a ContentIslandComponentView.
+  winrt::Microsoft::UI::Content::ChildSiteLink m_childSiteLink{nullptr};
+  winrt::Microsoft::UI::Content::ChildSiteLink::FragmentRootAutomationProviderRequested_revoker
+      m_fragmentRootAutomationProviderRequestedRevoker;
+  winrt::Microsoft::UI::Content::ChildSiteLink::ParentAutomationProviderRequested_revoker
+      m_parentAutomationProviderRequestedRevoker;
+  winrt::Microsoft::UI::Content::ChildSiteLink::NextSiblingAutomationProviderRequested_revoker
+      m_nextSiblingAutomationProviderRequestedRevoker;
+  winrt::Microsoft::UI::Content::ChildSiteLink::PreviousSiblingAutomationProviderRequested_revoker
+      m_previousSiblingAutomationProviderRequestedRevoker;
+#endif
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
@@ -11,11 +11,14 @@
 #include <UI.Xaml.Controls.h>
 #include <Utils/ValueUtils.h>
 #include <winrt/Microsoft.UI.Content.h>
+#include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.UI.Composition.h>
 #include "CompositionContextHelper.h"
 #include "RootComponentView.h"
 
 #include "Composition.ContentIslandComponentView.g.cpp"
+
+#include "CompositionDynamicAutomationProvider.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
@@ -47,6 +50,21 @@ void ContentIslandComponentView::OnMounted() noexcept {
       winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(Visual())
           .as<winrt::Microsoft::UI::Composition::ContainerVisual>());
   m_childSiteLink.ActualSize({m_layoutMetrics.frame.size.width, m_layoutMetrics.frame.size.height});
+
+  m_navigationHost = winrt::Microsoft::UI::Input::InputFocusNavigationHost::GetForSiteLink(m_childSiteLink);
+
+  m_departFocusRequestedRevoker =
+      m_navigationHost.DepartFocusRequested(winrt::auto_revoke, [wkThis = get_weak()](const auto &, const auto &args) {
+        if (auto strongThis = wkThis.get()) {
+          const bool next = (args.Request().Reason() == winrt::Microsoft::UI::Input::FocusNavigationReason::First);
+          strongThis->rootComponentView()->TryMoveFocus(next);
+          args.Result(winrt::Microsoft::UI::Input::FocusNavigationResult::Moved);
+        }
+      });
+
+  // This must be set before connecting the child content island.
+  m_childSiteLink.AutomationTreeOption(winrt::Microsoft::UI::Content::AutomationTreeOptions::FragmentBased);
+
   if (m_islandToConnect) {
     m_childSiteLink.Connect(m_islandToConnect);
     m_islandToConnect = nullptr;
@@ -70,6 +88,9 @@ void ContentIslandComponentView::OnMounted() noexcept {
 
 void ContentIslandComponentView::OnUnmounted() noexcept {
   m_layoutMetricChangedRevokers.clear();
+#ifdef USE_EXPERIMENTAL_WINUI3
+  m_departFocusRequestedRevoker.revoke();
+#endif
 }
 
 void ContentIslandComponentView::ParentLayoutChanged() noexcept {
@@ -89,6 +110,41 @@ void ContentIslandComponentView::ParentLayoutChanged() noexcept {
       strongThis->m_layoutChangePosted = false;
     }
   });
+#endif
+}
+
+winrt::IInspectable ContentIslandComponentView::EnsureUiaProvider() noexcept {
+#ifdef USE_EXPERIMENTAL_WINUI3
+  if (m_uiaProvider == nullptr) {
+    m_uiaProvider = winrt::make<winrt::Microsoft::ReactNative::implementation::CompositionDynamicAutomationProvider>(
+        *get_strong(), m_childSiteLink);
+  }
+  return m_uiaProvider;
+#else
+  return Super::EnsureUiaProvider();
+#endif
+}
+
+bool ContentIslandComponentView::focusable() const noexcept {
+#ifdef USE_EXPERIMENTAL_WINUI3
+  // We don't have a way to check to see if the ContentIsland has focusable content,
+  // so we'll always return true.  We'll have to handle the case where the content doesn't have
+  // focusable content in the OnGotFocus handler.
+  return true;
+#else
+  return Super::focusable();
+#endif
+}
+
+void ContentIslandComponentView::onGotFocus(
+    const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
+#ifdef USE_EXPERIMENTAL_WINUI3
+  (void)args;
+  // TODO: Need to make sure we handle shift-tab as well (which should use "Last" instead of "First")
+  m_navigationHost.NavigateFocus(winrt::Microsoft::UI::Input::FocusNavigationRequest::Create(
+      winrt::Microsoft::UI::Input::FocusNavigationReason::First));
+#else
+  return Super::onGotFocus(args);
 #endif
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
@@ -62,7 +62,9 @@ void ContentIslandComponentView::OnMounted() noexcept {
         }
       });
 
-  // This must be set before connecting the child content island.
+  // This automation mode must be set before connecting the child content island.
+  // It puts the child content into a mode where it won't own its own framework root.  Instead, the child island's
+  // automation peers will use the same framework root as the automation peer of this ContentIslandComponentView.
   m_childSiteLink.AutomationTreeOption(winrt::Microsoft::UI::Content::AutomationTreeOptions::FragmentBased);
 
   if (m_islandToConnect) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
@@ -8,6 +8,7 @@
 
 #include <Microsoft.ReactNative.Cxx/ReactContext.h>
 #include <winrt/Microsoft.UI.Content.h>
+#include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.UI.Composition.h>
 #include "CompositionHelpers.h"
 #include "CompositionViewComponentView.h"
@@ -37,6 +38,12 @@ struct ContentIslandComponentView : ContentIslandComponentViewT<ContentIslandCom
 
   void prepareForRecycle() noexcept override;
 
+  bool focusable() const noexcept override;
+
+  winrt::IInspectable EnsureUiaProvider() noexcept override;
+
+  void onGotFocus(const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept override;
+
   ContentIslandComponentView(
       const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
@@ -56,6 +63,8 @@ struct ContentIslandComponentView : ContentIslandComponentViewT<ContentIslandCom
   std::vector<winrt::Microsoft::ReactNative::ComponentView::LayoutMetricsChanged_revoker> m_layoutMetricChangedRevokers;
 #ifdef USE_EXPERIMENTAL_WINUI3
   winrt::Microsoft::UI::Content::ChildSiteLink m_childSiteLink{nullptr};
+  winrt::Microsoft::UI::Input::InputFocusNavigationHost m_navigationHost{nullptr};
+  winrt::Microsoft::UI::Input::InputFocusNavigationHost::DepartFocusRequested_revoker m_departFocusRequestedRevoker;
 #endif
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
@@ -64,7 +64,14 @@ struct ContentIslandComponentView : ContentIslandComponentViewT<ContentIslandCom
 #ifdef USE_EXPERIMENTAL_WINUI3
   winrt::Microsoft::UI::Content::ChildSiteLink m_childSiteLink{nullptr};
   winrt::Microsoft::UI::Input::InputFocusNavigationHost m_navigationHost{nullptr};
-  winrt::Microsoft::UI::Input::InputFocusNavigationHost::DepartFocusRequested_revoker m_departFocusRequestedRevoker;
+  winrt::event_token m_navigationHostDepartFocusRequestedToken{};
+
+  // Automation
+  void ConfigureChildSiteLinkAutomation() noexcept;
+  winrt::event_token m_fragmentRootAutomationProviderRequestedToken{};
+  winrt::event_token m_parentAutomationProviderRequestedToken{};
+  winrt::event_token m_nextSiblingAutomationProviderRequestedToken{};
+  winrt::event_token m_previousSiblingAutomationProviderRequestedToken{};
 #endif
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.cpp
@@ -14,8 +14,10 @@ int32_t LostFocusEventArgs::OriginalSource() noexcept {
   return m_originalSource;
 }
 
-GotFocusEventArgs::GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView &originalSource)
-    : m_originalSource(originalSource ? originalSource.Tag() : -1) {}
+GotFocusEventArgs::GotFocusEventArgs(
+    const winrt::Microsoft::ReactNative::ComponentView &originalSource,
+    winrt::Microsoft::ReactNative::FocusNavigationDirection direction)
+    : m_originalSource(originalSource ? originalSource.Tag() : -1), m_direction(direction) {}
 int32_t GotFocusEventArgs::OriginalSource() noexcept {
   return m_originalSource;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/FocusManager.h
@@ -21,11 +21,19 @@ struct LostFocusEventArgs
 
 struct GotFocusEventArgs
     : winrt::implements<GotFocusEventArgs, winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs> {
-  GotFocusEventArgs(const winrt::Microsoft::ReactNative::ComponentView &originalSource);
+  GotFocusEventArgs(
+      const winrt::Microsoft::ReactNative::ComponentView &originalSource,
+      winrt::Microsoft::ReactNative::FocusNavigationDirection direction);
   int32_t OriginalSource() noexcept;
+
+  winrt::Microsoft::ReactNative::FocusNavigationDirection Direction() const noexcept {
+    return m_direction;
+  }
 
  private:
   const int32_t m_originalSource;
+  winrt::Microsoft::ReactNative::FocusNavigationDirection m_direction{
+      winrt::Microsoft::ReactNative::FocusNavigationDirection::None};
 };
 
 struct LosingFocusEventArgs

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -76,7 +76,9 @@ void RootComponentView::updateLayoutMetrics(
 winrt::Microsoft::ReactNative::ComponentView RootComponentView::GetFocusedComponent() noexcept {
   return m_focusedComponent;
 }
-void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &value) noexcept {
+void RootComponentView::SetFocusedComponent(
+    const winrt::Microsoft::ReactNative::ComponentView &value,
+    winrt::Microsoft::ReactNative::FocusNavigationDirection direction) noexcept {
   if (m_focusedComponent == value)
     return;
 
@@ -90,7 +92,7 @@ void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative:
     if (auto rootView = m_wkRootView.get()) {
       winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(rootView)->TrySetFocus();
     }
-    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value);
+    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value, direction);
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(value)->onGotFocus(args);
   }
 
@@ -151,7 +153,7 @@ bool RootComponentView::TrySetFocusedComponent(
 
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(losingFocusArgs.NewFocusedComponent())
         ->rootComponentView()
-        ->SetFocusedComponent(gettingFocusArgs.NewFocusedComponent());
+        ->SetFocusedComponent(gettingFocusArgs.NewFocusedComponent(), direction);
   }
 
   return true;
@@ -241,7 +243,7 @@ void RootComponentView::start(const winrt::Microsoft::ReactNative::ReactNativeIs
 }
 
 void RootComponentView::stop() noexcept {
-  SetFocusedComponent(nullptr);
+  SetFocusedComponent(nullptr, winrt::Microsoft::ReactNative::FocusNavigationDirection::None);
   if (m_visualAddedToIsland) {
     if (auto rootView = m_wkRootView.get()) {
       winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(rootView)->RemoveRenderedVisual(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
@@ -27,7 +27,9 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
   winrt::Microsoft::ReactNative::ComponentView GetFocusedComponent() noexcept;
-  void SetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &value) noexcept;
+  void SetFocusedComponent(
+      const winrt::Microsoft::ReactNative::ComponentView &value,
+      winrt::Microsoft::ReactNative::FocusNavigationDirection direction) noexcept;
   bool TrySetFocusedComponent(
       const winrt::Microsoft::ReactNative::ComponentView &view,
       winrt::Microsoft::ReactNative::FocusNavigationDirection direction) noexcept;


### PR DESCRIPTION
## Description
This change stiches together the UIA tree between a React Native content and a child island it might be hosting.  It also provides initial support for tab navigation into and out of a child island.

Not working yet:
* ElementFromProvider / UIA hit testing doesn't work yet, only tree navigation so far.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
This is progress toward the goal of RNW being able to properly host a XamlIsland so a RNW fabric app can use Xaml controls.

## Screenshots
When UseWinUI3Experimental, we can traverse the UIA tree downward into Xaml and upward back to RNW:

![RnwXamlUia](https://github.com/user-attachments/assets/e2ddfa0d-7732-4470-90c5-a0411373075a)

## Testing
I've tested this manually using the Playground-Composition app with UseWinUI3Experimental set to true.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14305)