### PR TITLE
Fix crash when currently focused element gets marked as enableFocusRing=false

### DIFF
--- a/change/react-native-windows-9fae9acd-d5a6-48d1-9d63-c333ad09ca76.json
+++ b/change/react-native-windows-9fae9acd-d5a6-48d1-9d63-c333ad09ca76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash when currently focused element gets marked as enableFocusRing=false",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -168,11 +168,14 @@ void ComponentView::updateProps(
       m_componentHostingFocusVisual->hostFocusVisual(false, get_strong());
     }
 
-    if (m_componentHostingFocusVisual->m_focusPrimitive->m_focusInnerPrimitive) {
-      m_componentHostingFocusVisual->m_focusPrimitive->m_focusInnerPrimitive->updateProps(oldViewProps, newViewProps);
-    }
-    if (m_componentHostingFocusVisual->m_focusPrimitive->m_focusOuterPrimitive) {
-      m_componentHostingFocusVisual->m_focusPrimitive->m_focusOuterPrimitive->updateProps(oldViewProps, newViewProps);
+    // We have to check m_componentHostingFocusVisual again, as it can be set to null by above hostFocusVisual call
+    if (m_componentHostingFocusVisual) {
+      if (m_componentHostingFocusVisual->m_focusPrimitive->m_focusInnerPrimitive) {
+        m_componentHostingFocusVisual->m_focusPrimitive->m_focusInnerPrimitive->updateProps(oldViewProps, newViewProps);
+      }
+      if (m_componentHostingFocusVisual->m_focusPrimitive->m_focusOuterPrimitive) {
+        m_componentHostingFocusVisual->m_focusPrimitive->m_focusOuterPrimitive->updateProps(oldViewProps, newViewProps);
+      }
     }
   }
   if ((m_flags & ComponentViewFeatures::ShadowProps) == ComponentViewFeatures::ShadowProps) {


### PR DESCRIPTION
## Description
Null dereference crash when currently focused element gets marked as enableFocusRing=false.  

There is a check that `m_componentHostingFocusVisual` is non-null, but it happens before we call `hostFocusVisual(false)` if enableFocusRing is false.  That call will set `m_componentHostingFocusVisual` to null.

Fix is to check `m_componentHostingFocusVisual` after the call to `hostFocusVisual(false)`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14306)