### PR TITLE
Merge New and Old Arch Microsoft.ReactNative Nuget packages

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -307,6 +307,7 @@ jobs:
 
             ${{ if eq(matrix.useNuGet, true) }}:
               dependsOn:
+                - UniversalBuild${{ matrix.platform }}Release
                 - UniversalBuild${{ matrix.platform }}ReleaseFabric
 
             variables: [template: ../variables/windows.yml]

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -26,6 +26,14 @@
               BuildPlatform: x86
               UseFabric: false
               CreateApiDocs: true
+            - Name: X86Release
+              BuildConfiguration: Release
+              BuildPlatform: x86
+              UseFabric: false
+            - Name: Arm64Release
+              BuildConfiguration: Release
+              BuildPlatform: ARM64
+              UseFabric: false
             - Name: X64DebugFabric
               BuildConfiguration: Debug
               BuildPlatform: x64
@@ -44,6 +52,10 @@
               UseFabric: true
         - BuildEnvironment: SecurePullRequest
           Matrix:
+            - Name: X64Release
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              UseFabric: false
             - Name: X64ReleaseFabric
               BuildConfiguration: Release
               BuildPlatform: x64

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -440,9 +440,9 @@ extends:
           - template: .ado/templates/prep-and-pack-nuget.yml@self
             parameters:
               artifactName: ReactWindows
+              artifactName2: ReactWindowsFabric
               publishCommitId: $(publishCommitId)
               npmVersion: $(npmVersion)
-              nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
               packMicrosoftReactNative: true
               packMicrosoftReactNativeCxx: true
               packMicrosoftReactNativeManaged: true
@@ -463,38 +463,12 @@ extends:
                 - platform: ARM64
                   configuration: Debug
 
-          - template: .ado/templates/prep-and-pack-nuget.yml@self
-            parameters:
-              artifactName: ReactWindowsFabric
-              publishCommitId: $(publishCommitId)
-              npmVersion: $(npmVersion)-Fabric
-              nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
-              packMicrosoftReactNative: true
-              packMicrosoftReactNativeCxx: true
-              # packMicrosoftReactNativeManaged: true
-              # packMicrosoftReactNativeManagedCodeGen: true
-              ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-                signMicrosoft: false # Temporarily disabled for all builds, see issue #14030
-              slices:
-                - platform: x64
-                  configuration: Release
-                - platform: x86
-                  configuration: Release
-                - platform: ARM64
-                  configuration: Release
-                - platform: x64
-                  configuration: Debug
-                - platform: x86
-                  configuration: Debug
-                - platform: ARM64
-                  configuration: Debug
 
           - template: .ado/templates/prep-and-pack-nuget.yml@self
             parameters:
               artifactName: Desktop
               publishCommitId: $(publishCommitId)
               npmVersion: $(npmVersion)
-              nugetroot: $(System.DefaultWorkingDirectory)\Desktop
               packDesktop: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
                 signMicrosoft: false # Temporarily disabled for all builds, see issue #14030
@@ -517,7 +491,6 @@ extends:
               artifactName: DesktopFabric
               publishCommitId: $(publishCommitId)
               npmVersion: $(npmVersion)-Fabric
-              nugetroot: $(System.DefaultWorkingDirectory)\Desktop
               packDesktop: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
                 signMicrosoft: false # Temporarily disabled for all builds, see issue #14030

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,6 +1,8 @@
 parameters:
   - name: artifactName
     type: string
+  - name: artifactName2
+    type: string
   - name: slices
     type: object
 
@@ -14,7 +16,7 @@ parameters:
     # Note: NuGet pack expects platform-specific file separators ('\' on Windows).
   - name: nugetroot
     type: string
-    default: $(System.DefaultWorkingDirectory)\ReactWindows
+    default: $(System.DefaultWorkingDirectory)\NugetRoot
 
   - name: packDesktop
     type: boolean
@@ -62,7 +64,13 @@ steps:
       displayName: 'Download ${{ parameters.artifactName }}.${{ slice.platform }}.${{ slice.configuration }}'
       inputs:
         artifact: ${{ parameters.artifactName }}.${{ slice.platform }}.${{ slice.configuration }}
-        path: ${{parameters.nugetroot}}/${{ slice.platform }}/${{ slice.configuration }}
+        path: ${{parameters.nugetroot}}/${{ parameters.artifactName }}/${{ slice.platform }}/${{ slice.configuration }}
+    - ${{ if ne(parameters.artifactName2, '') }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download ${{ parameters.artifactName2 }}.${{ slice.platform }}.${{ slice.configuration }}'
+        inputs:
+          artifact: ${{ parameters.artifactName2 }}.${{ slice.platform }}.${{ slice.configuration }}
+          path: ${{parameters.nugetroot}}/${{ parameters.artifactName2 }}/${{ slice.platform }}/${{ slice.configuration }}
 
   - task: PowerShell@2
     displayName: Copy MSRN Resources to NuGet layout

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -3,6 +3,7 @@ parameters:
     type: string
   - name: artifactName2
     type: string
+    default: ''
   - name: slices
     type: object
 

--- a/.ado/templates/prep-and-pack-single.yml
+++ b/.ado/templates/prep-and-pack-single.yml
@@ -49,7 +49,7 @@ steps:
         -slices (ConvertFrom-Json '${{ parameters.slices }}')
         -debug
       displayName: '${{ parameters.outputPackage }} - Strip slices from nuspec'
-      workingDirectory: $(System.DefaultWorkingDirectory)/ReactWindows
+      workingDirectory: $(System.DefaultWorkingDirectory)/NugetRoot
 
   - ${{ if eq(parameters.codesignBinaries, true) }}:
     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
@@ -102,7 +102,7 @@ steps:
     inputs:
       command: pack
       verbosityPack: 'Detailed'
-      packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/${{ parameters.outputPackage }}.nuspec
+      packagesToPack: $(System.DefaultWorkingDirectory)/NugetRoot/${{ parameters.outputPackage }}.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
       buildProperties: version=${{ parameters.packageVersion }};id=${{ parameters.outputPackage }};${{ parameters.buildProperties }}
 

--- a/.ado/templates/prep-and-pack-single.yml
+++ b/.ado/templates/prep-and-pack-single.yml
@@ -41,6 +41,9 @@ parameters:
 
 steps:
 
+  - powershell: gci $(System.DefaultWorkingDirectory)/NugetRoot
+    displayName: List files in NugetRoot
+
   - ${{ if ne(parameters.slices, '') }}:
     - powershell: >
         .\StripAdditionalPlatformsFromNuspec.ps1
@@ -61,7 +64,7 @@ steps:
         AuthAKVName: 'rnw-keyvault' 
         AuthCertName: 'React-Native-ESRP-App-Authentication' 
         AuthSignCertName: 'React-Native-PRSS-Authentication'
-        FolderPath: $(System.DefaultWorkingDirectory)/ReactWindows
+        FolderPath: $(System.DefaultWorkingDirectory)/NugetRoot
         # Recursively finds files matching these patterns:
         ${{ if ne(parameters.binariesToSign, '') }}:
           Pattern: ${{ parameters.binariesToSign }}

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -47,8 +47,9 @@ steps:
   - ${{ if eq(parameters.useNuGet, true) }}:
     - template: prep-and-pack-nuget.yml
       parameters:
-        artifactName: ReactWindowsFabric
-        npmVersion: $(npmVersion)-Fabric
+        artifactName: ReactWindows
+        artifactName2: ReactWindowsFabric
+        npmVersion: $(npmVersion)
         packMicrosoftReactNative: true
         packMicrosoftReactNativeCxx: true
         slices:

--- a/change/react-native-windows-e2a858e1-d434-4940-89a0-2468df697134.json
+++ b/change/react-native-windows-e2a858e1-d434-4940-89a0-2468df697134.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Merge New and Old Arch Microsoft.ReactNative Nuget packages",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.PackageReferences.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.PackageReferences.props
@@ -5,18 +5,8 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Only include Microsoft.ReactNative.* NuGet packages that C++ (app and lib) projects need when using UseExperimentalNuget. -->
-  <Choose>
-    <When Condition="'$(RnwNewArch)' == 'true'">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.ReactNative" Version="$(ReactNativeWindowsVersion)-Fabric" />
-        <PackageReference Include="Microsoft.ReactNative.Cxx" Version="$(ReactNativeWindowsVersion)-Fabric" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-       <ItemGroup>
-        <PackageReference Include="Microsoft.ReactNative" Version="$(ReactNativeWindowsVersion)" />
-        <PackageReference Include="Microsoft.ReactNative.Cxx" Version="$(ReactNativeWindowsVersion)" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ReactNative" Version="$(ReactNativeWindowsVersion)" />
+    <PackageReference Include="Microsoft.ReactNative.Cxx" Version="$(ReactNativeWindowsVersion)" />
+  </ItemGroup>
 </Project>

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.CodeGen.nuspec
@@ -18,6 +18,6 @@
     <file src="$nugetroot$\Microsoft.ReactNative.Managed.CodeGen.targets" target="build"/>
     <file src="$nugetroot$\Microsoft.ReactNative.VersionCheck.targets" target="build"/>
 
-    <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed.CodeGen\Publish\**" target="tools"/>
+    <file src="$nugetroot$\ReactWindows\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed.CodeGen\Publish\**" target="tools"/>
   </files>
 </package>

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
@@ -26,39 +26,39 @@
     <file src="$nugetroot$\Microsoft.ReactNative.Managed.targets" target="build"/>
     <file src="$nugetroot$\Microsoft.ReactNative.VersionCheck.targets" target="build"/>
 
-    <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed\ref\Microsoft.ReactNative.Managed.dll" target="ref\uap10.0"/>
-    <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.xml" target="ref\uap10.0"/> 
+    <file src="$nugetroot$\ReactWindows\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed\ref\Microsoft.ReactNative.Managed.dll" target="ref\uap10.0"/>
+    <file src="$nugetroot$\ReactWindows\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.xml" target="ref\uap10.0"/> 
 
     <!-- Include in Microsoft.ReactNative.Managed -->
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-arm64\native" />
 
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\ReactWindows\x86\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\ReactWindows\x86\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\ReactWindows\x86\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x86\native" />
 
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\x64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\x64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\x64\Release\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x64\native" />
 
     <!-- Include in Microsoft.ReactNative.Managed.Debug -->
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-arm64\native" />
 
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\ReactWindows\x86\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\ReactWindows\x86\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\ReactWindows\x86\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x86\native" />
 
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\x64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.dll" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\x64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pdb" target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\x64\Debug\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.pri" target="runtimes\win10-x64\native" />
 
     <!-- XBF files need to be included for Debug since they are not embedded in the PRI -->
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm64\native" />
+    <file src="$nugetroot$\ReactWindows\x86\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x86\native" />
+    <file src="$nugetroot$\ReactWindows\x64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x64\native" />
 
   </files>
 </package>

--- a/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.VersionCheck.targets
@@ -66,8 +66,6 @@
 
     <PropertyGroup>
       <_ReactNativeWindowsVersionCheckNugetVersion>$$nuGetPackageVersion$$</_ReactNativeWindowsVersionCheckNugetVersion>
-      <!-- Strip out the -Fabric qualifier from the version string if present -->
-      <_ReactNativeWindowsVersionCheckNugetVersion>$(_ReactNativeWindowsVersionCheckNugetVersion.Replace('-Fabric', ''))</_ReactNativeWindowsVersionCheckNugetVersion>
     </PropertyGroup>
    
     <!-- Validate package.json file -->

--- a/vnext/Scripts/Microsoft.ReactNative.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.nuspec
@@ -19,48 +19,50 @@
     <file src="$nugetroot$\Microsoft.ReactNative.targets" target="build\native"/>
     <file src="$nugetroot$\Microsoft.ReactNative.VersionCheck.targets" target="build\native"/>
 
-    <file src="$nugetroot$\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative\Microsoft.ReactNative.winmd"   target="lib\uap10.0"/>
+    <file src="$nugetroot$\ReactWindows\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative\Microsoft.ReactNative.winmd" target="lib\uap10.0\oldarch"/>
+    <file src="$nugetroot$\ReactWindowsFabric\$baseplatform$\$baseconfiguration$\Microsoft.ReactNative\Microsoft.ReactNative.winmd" target="lib\uap10.0\newarch"/>
     <!-- 
     Uncomment once we are producing doc xml file
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml"   target="lib\uap10.0"/> 
+    <file src="$nugetroot$\ReactWindows\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml" target="lib\uap10.0\oldarch"/> 
+    <file src="$nugetroot$\ReactWindowsFabric\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.xml" target="lib\uap10.0\newarch"/> 
     -->
 
     <!-- Included in Microsoft.ReactNative -->
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\arm64" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-arm64\native\oldarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindowsFabric\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-arm64\native\newarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\arm64\oldarch" />
+    <file src="$nugetroot$\ReactWindowsFabric\ARM64\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\arm64\newarch" />
 
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x86" />
+    <file src="$nugetroot$\ReactWindows\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x86\native\oldarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindowsFabric\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x86\native\newarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindows\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x86\oldarch" />
+    <file src="$nugetroot$\ReactWindowsFabric\x86\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x86\newarch" />
 
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x64" />
+    <file src="$nugetroot$\ReactWindows\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x64\native\oldarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindowsFabric\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x64\native\newarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindows\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x64\oldarch" />
+    <file src="$nugetroot$\ReactWindowsFabric\x64\Release\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x64\newarch" />
 
     <!-- Included in Microsoft.ReactNative.Debug -->
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\arm64" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-arm64\native\oldarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindowsFabric\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-arm64\native\newarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\arm64\oldarch" />
+    <file src="$nugetroot$\ReactWindowsFabric\ARM64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\arm64\newarch" />
 
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x86" />
+    <file src="$nugetroot$\ReactWindows\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x86\native\oldarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindowsFabric\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x86\native\newarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindows\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x86\oldarch" />
+    <file src="$nugetroot$\ReactWindowsFabric\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x86\newarch" />
 
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.dll" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pdb" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.pri" target="runtimes\win10-x64\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x64" />
+    <file src="$nugetroot$\ReactWindows\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x64\native\oldarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindowsFabric\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.*" target="runtimes\win10-x64\native\newarch" exclude="**\*.exp;**\*.lib;**\*.winmd" />
+    <file src="$nugetroot$\ReactWindows\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x64\oldarch" />
+    <file src="$nugetroot$\ReactWindowsFabric\x64\Debug\Microsoft.ReactNative\Microsoft.ReactNative.lib" target="lib\x64\newarch" />
 
     <!-- XBF files need to be included for Debug since they are not embedded in the PRI -->
-    <file src="$nugetroot$\ARM64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm64\native" />
-    <file src="$nugetroot$\x86\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x86\native" />
-    <file src="$nugetroot$\x64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x64\native" />
+    <file src="$nugetroot$\ReactWindows\ARM64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-arm64\native\oldarch" />
+    <file src="$nugetroot$\ReactWindows\x86\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x86\native\oldarch" />
+    <file src="$nugetroot$\ReactWindows\x64\Debug\Microsoft.ReactNative\**\*.xbf"  target="runtimes\win10-x64\native\oldarch" />
 
   </files>
 </package>

--- a/vnext/Scripts/Microsoft.ReactNative.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.targets
@@ -5,17 +5,21 @@
   <PropertyGroup>
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
-    <_rnwFolder>$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native\</_rnwFolder>
+    <RnwNewArch Condition="'$(RnwNewArch)'==''">false</RnwNewArch>
+
+    <_rnwFolder>$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(Native-Platform)\native</_rnwFolder>
+    <_rnwArch Condition="'$(RnwNewArch)'=='true'">newarch</_rnwArch>
+    <_rnwArch Condition="'$(_rnwArch)'==''">oldarch</_rnwArch>
   </PropertyGroup>
   
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ReactNative.winmd" Private="false">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\$(_rnwArch)\Microsoft.ReactNative.winmd" Private="false">
       <Implementation>Microsoft.ReactNative.dll</Implementation>
     </Reference>
     
-    <ReferenceCopyLocalPaths Condition="Exists('$(_rnwFolder)Microsoft.ReactNative.dll')" Include="$(_rnwFolder)Microsoft.ReactNative.dll" />
-    <ReferenceCopyLocalPaths Condition="Exists('$(_rnwFolder)Microsoft.ReactNative.pri')" Include="$(_rnwFolder)Microsoft.ReactNative.pri" />
-    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug'" Include="$(_rnwFolder)**\*.xbf" />
+    <ReferenceCopyLocalPaths Condition="Exists('$(_rnwFolder)\$(_rnwArch)\Microsoft.ReactNative.dll')" Include="$(_rnwFolder)\$(_rnwArch)\Microsoft.ReactNative.dll" />
+    <ReferenceCopyLocalPaths Condition="Exists('$(_rnwFolder)\$(_rnwArch)\Microsoft.ReactNative.pri')" Include="$(_rnwFolder)\$(_rnwArch)\Microsoft.ReactNative.pri" />
+    <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug'" Include="$(_rnwFolder)\$(_rnwArch)\**\*.xbf" />
 
   </ItemGroup>
 

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -15,23 +15,23 @@
   </metadata>
   <files>
 
-    <file src="$nugetroot$\x86\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\x64\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\ARM64EC\Debug\React.Windows.Desktop.DLL\react-native-win32.*"      target="lib\debug\ARM64EC"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\x86\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\x64\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\ARM64EC\Release\React.Windows.Desktop.DLL\react-native-win32.*"    target="lib\ship\ARM64EC"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\x86\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x86"/>
-    <file src="$nugetroot$\x64\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x64"/>
-    <file src="$nugetroot$\ARM64EC\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"   target="lib\debug\ARM64EC"/>
-    <file src="$nugetroot$\x86\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x86"/>
-    <file src="$nugetroot$\x64\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x64"/>
-    <file src="$nugetroot$\ARM64EC\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\ship\ARM64EC"/>
+    <file src="$nugetroot$\Desktop*\x86\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x64\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\ARM64EC\Debug\React.Windows.Desktop.DLL\react-native-win32.*"      target="lib\debug\ARM64EC"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x86\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x64\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\ARM64EC\Release\React.Windows.Desktop.DLL\react-native-win32.*"    target="lib\ship\ARM64EC"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x86\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x86"/>
+    <file src="$nugetroot$\Desktop*\x64\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x64"/>
+    <file src="$nugetroot$\Desktop*\ARM64EC\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"   target="lib\debug\ARM64EC"/>
+    <file src="$nugetroot$\Desktop*\x86\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x86"/>
+    <file src="$nugetroot$\Desktop*\x64\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x64"/>
+    <file src="$nugetroot$\Desktop*\ARM64EC\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\ship\ARM64EC"/>
 
-    <file src="$nugetroot$\x86\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\x64\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\x86\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\x64\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x86\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x64\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x86\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop*\x64\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
 
     <file src="$nugetroot$\inc\callinvoker\ReactCommon\CallInvoker.h" target="inc\ReactCommon"/>
     <file src="$nugetroot$\inc\callinvoker\ReactCommon\SchedulerPriority.h" target="inc\ReactCommon"/>


### PR DESCRIPTION
## Description

This PR combines the separate standard (Old Arch, Paper, UWP) versions and the `-Fabric` (New Arch, Fabric, WinAppSDK) `Microsoft.ReactNative` NuGet packages into one hybrid package with both sets of binaries.

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
It is currently an implementation detail that we have two separate "versions" of Microsoft.ReactNative.dll - one for Old Arch and one for New Arch - same named DLL, but a different API surface. Maintaining two different package versions for these makes it harder for us to do future work for New Arch and still support Old Arch. In particular it's holding back our ability to support C# for New Arch projects.

Resolves #13940

### What
Updated the NuGet creation pipelines and nuspec files to use both the sets of build artifacts for the `Microsoft.ReactNative` packages together into one NuGet package, rather than creating each separately. Also changed some of the intermediate paths when creating the NuGet packages. 

**Note:** One side effect of this is that to build a NuGet, we need **both** the New and Old Arch builds for a platform configuration to have been built in order to build the NuGet.

Also updated the appropriate targets so both New and Old projects download the one package but load the correct set of binaries based on their use of the `RnwNewArch` flag in their build.

**Final Note**: This changes apply to the `Microsoft.ReactNative` NuGet package - I have left all other pacakges as-is for now.

## Screenshots
N/A

## Testing
Verified new CLI apps still build with new NuGet.

## Changelog
Should this change be included in the release notes: _yes_

Merge New and Old Arch Microsoft.ReactNative Nuget packages
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14311)