### PR TITLE
Only build OfficeReact.Win32 with UseFabric enabled

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -75,12 +75,24 @@ jobs:
             #12714 -  Disable for first deployment of test website.
             #         RNTesterIntegrationTests::WebSocket
             #         RNTesterIntegrationTests::WebSocketBlob
+            #14217 - Reneable RNTesterIntegrationTests
+            #         RNTesterIntegrationTests::Dummy
+            #         RNTesterIntegrationTests::Fetch
+            #         RNTesterIntegrationTests::XHRSample
+            #         RNTesterIntegrationTests::Blob
+            #         RNTesterIntegrationTests::Logging
             - name: Desktop.IntegrationTests.Filter
               value: >
                 (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
                 (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
                 (FullyQualifiedName!=RNTesterIntegrationTests::WebSocketBlob)&
-                (FullyQualifiedName!=WebSocketIntegrationTest::SendReceiveSsl)
+                (FullyQualifiedName!=WebSocketIntegrationTest::SendReceiveSsl)&
+                (FullyQualifiedName!=Microsoft::React::Test::HttpOriginPolicyIntegrationTest)&
+                (FullyQualifiedName!=RNTesterIntegrationTests::Dummy)&
+                (FullyQualifiedName!=RNTesterIntegrationTests::Fetch)&
+                (FullyQualifiedName!=RNTesterIntegrationTests::XHRSample)&
+                (FullyQualifiedName!=RNTesterIntegrationTests::Blob)&
+                (FullyQualifiedName!=RNTesterIntegrationTests::Logging)
             #6799 -
             #       HostFunctionTest              - Crashes under JSI/V8
             #       HostObjectProtoTest           - Crashes under JSI/V8

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -18,31 +18,23 @@ parameters:
           - Name: X64Debug
             BuildConfiguration: Debug
             BuildPlatform: x64
-            UseFabric: false
           - Name: X64Release
             BuildConfiguration: Release
             BuildPlatform: x64
-            UseFabric: false
           - Name: X86Debug
             BuildConfiguration: Debug
             BuildPlatform: x86
-            UseFabric: false
           - Name: ARM64ECDebug
             BuildConfiguration: Debug
             BuildPlatform: ARM64EC
           - Name: ARM64ECRelease
             BuildConfiguration: Release
             BuildPlatform: ARM64EC
-          - Name: X64DebugFabric
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            UseFabric: true
       - BuildEnvironment: SecurePullRequest
         Matrix:
-          - Name: X64DebugFabric
+          - Name: X64Debug
             BuildConfiguration: Debug
             BuildPlatform: x64
-            UseFabric: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Debug
@@ -63,14 +55,6 @@ parameters:
           - Name: ARM64ECRelease
             BuildConfiguration: Release
             BuildPlatform: ARM64EC
-          - Name: X64DebugFabric
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            UseFabric: true
-          - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
-            BuildConfiguration: Release
-            BuildPlatform: x86
-            UseFabric: true
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
@@ -154,9 +138,6 @@ jobs:
                   $newValue = '(FullyQualifiedName!~RNTesterIntegrationTests::)&' + "$(Desktop.IntegrationTests.Filter)"
                   Write-Host "##vso[task.setvariable variable=Desktop.IntegrationTests.Filter]$newValue"
                 displayName: Update Desktop.IntegrationTests.Filter to exclude RNTester integration tests
-
-            - ${{ if eq(matrix.UseFabric, true) }}:
-              - template: ../templates/enable-fabric-experimental-feature.yml
 
             - template: ../templates/msbuild-sln.yml
               parameters:
@@ -323,10 +304,7 @@ jobs:
 
             - template: ../templates/publish-build-artifacts.yml
               parameters:
-                ${{ if eq(matrix.UseFabric, true) }}:
-                  artifactName: DesktopFabric
-                ${{ else }}:
-                  artifactName: Desktop
+                artifactName: Desktop
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 contents: |

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -33,43 +33,21 @@ parameters:
     - Name: X64Debug
       BuildConfiguration: Debug
       BuildPlatform: x64
-      UseFabric: false
     - Name: X64Release
       BuildConfiguration: Release
       BuildPlatform: x64
-      UseFabric: false
     - Name: X86Debug
       BuildConfiguration: Debug
       BuildPlatform: x86
-      UseFabric: false
     - Name: X86Release
       BuildConfiguration: Release
       BuildPlatform: x86
-      UseFabric: false
     - Name: ARM64ECDebug
       BuildConfiguration: Debug
       BuildPlatform: ARM64EC
-      UseFabric: false
     - Name: ARM64ECRelease
       BuildConfiguration: Release
       BuildPlatform: ARM64EC
-      UseFabric: false
-    - Name: X64DebugFabric
-      BuildConfiguration: Debug
-      BuildPlatform: x64
-      UseFabric: true
-    - Name: X64ReleaseFabric
-      BuildConfiguration: Release
-      BuildPlatform: x64
-      UseFabric: true
-    - Name: X86DebugFabric
-      BuildConfiguration: Debug
-      BuildPlatform: x86
-      UseFabric: true
-    - Name: X86ReleaseFabric
-      BuildConfiguration: Release
-      BuildPlatform: x86
-      UseFabric: true
 
 - name: universalBuildMatrix
   type: object
@@ -277,9 +255,6 @@ extends:
 
             - template: .ado/templates/apply-published-version-vars.yml@self
 
-            - ${{ if eq(matrix.UseFabric, true) }}:
-              - template: .ado/templates/enable-fabric-experimental-feature.yml@self
-
             - template: .ado/templates/msbuild-sln.yml@self
               parameters:
                 solutionDir: vnext
@@ -291,10 +266,7 @@ extends:
             - template: .ado/templates/publish-build-artifacts.yml@self
               parameters:
                 oneESMode: true ## Files are only copied to staging, not published
-                ${{ if eq(matrix.UseFabric, true) }}:
-                  artifactName: DesktopFabric
-                ${{ else }}:
-                  artifactName: Desktop
+                artifactName: Desktop
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 contents: |
@@ -320,14 +292,9 @@ extends:
                 targetPath: '$(CrashDumpRootPath)'
                 artifactName: Crash dumps - $(Agent.JobName)-$(System.JobAttempt)
               - output: pipelineArtifact
-                ${{ if eq(matrix.UseFabric, true) }}:
-                  displayName: 'Publish Artifact: DesktopFabric.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}'
-                  artifactName: DesktopFabric.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}
-                  targetPath: $(Build.StagingDirectory)/NuGet/DesktopFabric/${{matrix.buildPlatform}}/${{matrix.buildConfiguration}}
-                ${{ else }}:
-                  displayName: 'Publish Artifact: Desktop.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}'
-                  artifactName: Desktop.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}
-                  targetPath: $(Build.StagingDirectory)/NuGet/Desktop/${{matrix.buildPlatform}}/${{matrix.buildConfiguration}}
+                displayName: 'Publish Artifact: Desktop.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}'
+                artifactName: Desktop.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}
+                targetPath: $(Build.StagingDirectory)/NuGet/Desktop/${{matrix.buildPlatform}}/${{matrix.buildConfiguration}}
 
         - ${{ each matrix in parameters.universalBuildMatrix }}:
           - job: RnwNativeBuildUniversal${{ matrix.Name }}
@@ -485,28 +452,6 @@ extends:
                   configuration: Debug
                 - platform: ARM64EC
                   configuration: Debug
-
-          - template: .ado/templates/prep-and-pack-nuget.yml@self
-            parameters:
-              artifactName: DesktopFabric
-              publishCommitId: $(publishCommitId)
-              npmVersion: $(npmVersion)-Fabric
-              packDesktop: true
-              ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-                signMicrosoft: false # Temporarily disabled for all builds, see issue #14030
-              slices:
-                - platform: x64
-                  configuration: Release
-                - platform: x86
-                  configuration: Release
-                # - platform: ARM64EC
-                #   configuration: Release
-                - platform: x64
-                  configuration: Debug
-                - platform: x86
-                  configuration: Debug
-                # - platform: ARM64EC
-                #   configuration: Debug
 
           templateContext:
             sdl:

--- a/change/react-native-windows-cee7156d-9d30-4922-a594-c591aa4d568b.json
+++ b/change/react-native-windows-cee7156d-9d30-4922-a594-c591aa4d568b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Only build OfficeReact.Win32 with UseFabric enabled",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -111,7 +111,12 @@
         %(AdditionalDependencies);
         Bcrypt.lib;
         Chakrart.lib;
-        Pathcch.lib
+        D2D1.lib;
+        D3D11.lib;
+        DWrite.lib;
+        Pathcch.lib;
+        ShCore.lib;
+        Uiautomationcore.lib
       </AdditionalDependencies>
       <DelayLoadDLLs>Chakra.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
-    <RnwNewArch>false</RnwNewArch>
+    <RnwNewArch>true</RnwNewArch>
+    <UseFabric>true</UseFabric>
+    <UseWinUI3>true</UseWinUI3>
     <UseExperimentalWinUI3>true</UseExperimentalWinUI3>
     <WindowsAppSdkAutoInitialize>false</WindowsAppSdkAutoInitialize>
   </PropertyGroup>

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -15,23 +15,23 @@
   </metadata>
   <files>
 
-    <file src="$nugetroot$\Desktop*\x86\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\x64\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\ARM64EC\Debug\React.Windows.Desktop.DLL\react-native-win32.*"      target="lib\debug\ARM64EC"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\x86\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\x64\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\ARM64EC\Release\React.Windows.Desktop.DLL\react-native-win32.*"    target="lib\ship\ARM64EC"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\x86\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x86"/>
-    <file src="$nugetroot$\Desktop*\x64\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x64"/>
-    <file src="$nugetroot$\Desktop*\ARM64EC\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"   target="lib\debug\ARM64EC"/>
-    <file src="$nugetroot$\Desktop*\x86\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x86"/>
-    <file src="$nugetroot$\Desktop*\x64\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x64"/>
-    <file src="$nugetroot$\Desktop*\ARM64EC\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\ship\ARM64EC"/>
+    <file src="$nugetroot$\Desktop\x86\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x64\Debug\React.Windows.Desktop.DLL\react-native-win32.*"          target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\ARM64EC\Debug\React.Windows.Desktop.DLL\react-native-win32.*"      target="lib\debug\ARM64EC"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x86\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x64\Release\React.Windows.Desktop.DLL\react-native-win32.*"        target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\ARM64EC\Release\React.Windows.Desktop.DLL\react-native-win32.*"    target="lib\ship\ARM64EC"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x86\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x86"/>
+    <file src="$nugetroot$\Desktop\x64\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"       target="lib\debug\x64"/>
+    <file src="$nugetroot$\Desktop\ARM64EC\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd"   target="lib\debug\ARM64EC"/>
+    <file src="$nugetroot$\Desktop\x86\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x86"/>
+    <file src="$nugetroot$\Desktop\x64\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd"     target="lib\ship\x64"/>
+    <file src="$nugetroot$\Desktop\ARM64EC\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\ship\ARM64EC"/>
 
-    <file src="$nugetroot$\Desktop*\x86\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\x64\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\x86\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
-    <file src="$nugetroot$\Desktop*\x64\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x86\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x86"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x64\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"        target="lib\debug\x64"      exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x86\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x86"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\Desktop\x64\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"      target="lib\ship\x64"       exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
 
     <file src="$nugetroot$\inc\callinvoker\ReactCommon\CallInvoker.h" target="inc\ReactCommon"/>
     <file src="$nugetroot$\inc\callinvoker\ReactCommon\SchedulerPriority.h" target="inc\ReactCommon"/>


### PR DESCRIPTION
## Description

This PR changes our build system to only build the version of `OfficeReact.Win32` with Fabric enabled.

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
We are building both versions of Desktop in our CI, but the `-Fabric` version is in fact a strict superset of functionality and the only one that Office uses now.

### What
Changed the default so that Desktop always builds with `RnwNewArch` (and therefore `UseFabric`) enabled. Removed the matrix configurations for DesktopFabric from all CI. Fixed the affected nuspec file. Also fixed Desktop publish to include ARM64EC for Fabric and the an issue caused by #14311.

## Screenshots
N/A.

## Testing
Verified the build works.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14319)