### PR TITLE
Fix react devtools hitting an assert on launch

### DIFF
--- a/change/react-native-windows-fb01ddc4-cef6-477e-b91d-7583eeb458b1.json
+++ b/change/react-native-windows-fb01ddc4-cef6-477e-b91d-7583eeb458b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix react devtools hitting an assert on launch",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
@@ -48,7 +48,12 @@ void DebuggingOverlayViewManager::DispatchCommand(
     // There is little point in attempting to implement these commands until then.
     return;
   }
-  Super::DispatchCommand(viewToUpdate, commandId, std::move(commandArgs));
+
+  // Paper doesn't handle the following commands, so we'll just skip them.
+  if (commandId != "highlightTraceUpdates" && commandId != "highlightElements" &&
+      commandId != "clearElementsHighlights") {
+    Super::DispatchCommand(viewToUpdate, commandId, std::move(commandArgs));
+  }
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
@@ -48,12 +48,6 @@ void DebuggingOverlayViewManager::DispatchCommand(
     // There is little point in attempting to implement these commands until then.
     return;
   }
-
-  // Paper doesn't handle the following commands, so we'll just skip them.
-  if (commandId != "highlightTraceUpdates" && commandId != "highlightElements" &&
-      commandId != "clearElementsHighlights") {
-    Super::DispatchCommand(viewToUpdate, commandId, std::move(commandArgs));
-  }
 }
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description
Removes unnecessary call to Super::DispatchCommand, ViewManagerBase will just assert(false) on dispatch command. https://github.com/microsoft/react-native-windows/blob/main/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp#L358. Seemed better just to remove the call incase Meta adds more methods we aren't supporting on Paper.

But let me know if the call is necessary for some reason I'm missing, we could also add a check to ignore the unsupported methods (see previous commit).

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
react dev-tools will fail because upstream added the methods "highlightTraceUpdates", "highlightElements", and "clearElementsHighlights" and we only added those for Fabric, not Paper. 

Resolves #14298

## Testing
tested that react devtools works again!

## Changelog
yes - Fixes react devtools hitting an assert on launch
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14320)