### PR TITLE
TurboModule spec checking should accept hstring for string arguments

### DIFF
--- a/change/react-native-windows-6d9f3161-2868-4c4d-a3a1-a49b9eee3d5b.json
+++ b/change/react-native-windows-6d9f3161-2868-4c4d-a3a1-a49b9eee3d5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "TurboModule spec checking should accept hstring for string arguments",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -411,6 +411,26 @@ constexpr bool MatchInputArg<std::string, std::wstring>() noexcept {
   return true;
 }
 
+template <>
+constexpr bool MatchInputArg<std::string, winrt::hstring>() noexcept {
+  return true;
+}
+
+template <>
+constexpr bool MatchInputArg<winrt::hstring, std::string>() noexcept {
+  return true;
+}
+
+template <>
+constexpr bool MatchInputArg<std::wstring, winrt::hstring>() noexcept {
+  return true;
+}
+
+template <>
+constexpr bool MatchInputArg<winrt::hstring, std::wstring>() noexcept {
+  return true;
+}
+
 template <class TResult, class TInputArgs, class TOutputCallbacks, class TOutputPromises>
 struct MethodSignature {
   using Result = TResult;

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
@@ -48,7 +48,7 @@ void Clipboard::getString(React::ReactPromise<std::string> result) noexcept {
   );
 }
 
-void Clipboard::setString(std::wstring content) noexcept {
+void Clipboard::setString(winrt::hstring content) noexcept {
   m_reactContext.UIDispatcher().Post([=] {
     DataTransfer::DataPackage data;
     data.SetText(content);

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
@@ -18,7 +18,7 @@ struct Clipboard {
   void getString(winrt::Microsoft::ReactNative::ReactPromise<std::string> result) noexcept;
 
   REACT_METHOD(setString)
-  void setString(std::wstring content) noexcept;
+  void setString(winrt::hstring content) noexcept;
 
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;
 };


### PR DESCRIPTION
## Description
If you have a turbo module spec that defines a method as taking a string parameter, then you should be able to use an `hstring` on the native side.

Currently the module works correctly when using an `hstring`, but if you use the codegen'd spec to validate that the native TurboModule correctly implements the methods from JS, the build will fail because it does not correctly identify `hstring` as being a valid argument type for a JS string.

As an example the built in Clipboard module is currently using `std::wstring`.  Changing it to `hstring` without this change will cause the build to fail.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14322)