### PR TITLE
Fix Number.h not copied from react-native core

### DIFF
--- a/change/react-native-windows-b37f9813-c7a4-49cd-83a8-808a00b86649.json
+++ b/change/react-native-windows-b37f9813-c7a4-49cd-83a8-808a00b86649.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Number.h not copied from react-native core",
+  "packageName": "react-native-windows",
+  "email": "hampus.sjoberg@protonmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
@@ -108,6 +108,7 @@ Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Convert.h -De
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Error.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\EventEmitter.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Function.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
+Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Number.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\LongLivedObject.cpp -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\LongLivedObject.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Object.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

react-native-windows currently maintains its own forked C++ TurboModule bridging files.
For untouched stuff we copy JSI and TurboModule files from core react-native in `Layout-MSRN-Headers.ps1`.
However, this script misses to copy `Number.h`.

This causes compilation error when trying to import `react/bridging/Bridging.h`, which would be the case for example when using codegen to generate C++ TurboModule (JSI) bindings (note: this is for C++ JSI TurboModules, not react-native-windows's TurboModule system).

```
PS C:\Users\CocoT1\Projects\rn77> yarn example windows
[...]
Time Elapsed 00:00:00.61
✔ Restoring NuGet packages
 ✔ Auto-linking...
Success: No auto-linking changes necessary. (69ms)
 ✔ Found Solution: C:\Users\CocoT1\Projects\rn77\example\windows\rn77Example.sln
 ℹ Build configuration: Debug
 ℹ Build platform: x64
 ✖ Building Solution: Generating Code...
 ✖ Build failed with message 4:7>C:\Users\CocoT1\.nuget\packages\microsoft.reactnative.cxx\0.77.0-fabric\tools\Microsoft.ReactNative.Cxx\ReactCommon\react\bridging\Bridging.h(18,10): error C1083: Cannot open include file: 'react/bridging/Number.h': No such file or directory [C:\Users\CocoT1\Projects\rn77\example\windows\rn77Example\rn77Example.vcxproj]. Check your build configuration.
```

### What

I'm changing the `Layout-MSRN-Headers.ps1` script to also copy `Number.h`.
I think this should be enough for the nuget the contain to file, but I'm no expert here.

## Testing

Monkeypatched by copying over Number.h to the microsoft.reactnative.cxx nuget (`C:\Users\CocoT1\.nuget\packages\microsoft.reactnative.cxx\0.77.0-fabric\tools\Microsoft.ReactNative.Cxx\ReactCommon\react\bridging\`).

Works all good.

I don't know how to run the `Layout-MSRN-Headers.ps1` script locally.


Here's a create-react-native-library project:
https://github.com/hsjoberg/rnw-cxx-turbomodule
Note: it will fail to build unless you copy Number.h over to the nuget cache as explained earlier.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14331)