### PR TITLE
[0.78] Fix Number.h not copied from react-native core

### DIFF
--- a/change/react-native-windows-b37f9813-c7a4-49cd-83a8-808a00b86649.json
+++ b/change/react-native-windows-b37f9813-c7a4-49cd-83a8-808a00b86649.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Number.h not copied from react-native core",
+  "packageName": "react-native-windows",
+  "email": "hampus.sjoberg@protonmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
@@ -108,6 +108,7 @@ Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Convert.h -De
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Error.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\EventEmitter.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Function.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
+Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Number.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\LongLivedObject.cpp -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\LongLivedObject.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\Object.h -Destination $MSRNCxxTargetRoot\ReactCommon\react\bridging\


### PR DESCRIPTION
Hi. This PR cherry-picks c0be76e207aa68f2ce0d73fa776fe17026a30248 (#14331) into 0.78.
It would be to nice include this one as otherwise JSI/Codegen is broken.

Cheers
Hampus
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14353)