### PR TITLE
Fix tooltips in high dpi

### DIFF
--- a/change/react-native-windows-53667472-816f-4d36-b9f3-70b761dd1cf3.json
+++ b/change/react-native-windows-53667472-816f-4d36-b9f3-70b761dd1cf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix tooltips in high dpi",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -183,7 +183,7 @@ void ComponentView::updateProps(
     updateShadowProps(oldViewProps, newViewProps);
   }
   if (oldViewProps.tooltip != newViewProps.tooltip) {
-    if (!m_tooltipTracked && newViewProps.tooltip) {
+    if (!m_tooltipTracked && newViewProps.tooltip && !newViewProps.tooltip->empty()) {
       TooltipService::GetCurrent(m_reactContext.Properties())->StartTracking(*this);
       m_tooltipTracked = true;
     } else if (m_tooltipTracked && !newViewProps.tooltip) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TooltipService.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TooltipService.cpp
@@ -10,6 +10,7 @@
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include "TextDrawing.h"
 #include "dwmapi.h"
 
@@ -49,6 +50,8 @@ facebook::react::AttributedStringBox CreateTooltipAttributedString(const std::st
   auto fragment = facebook::react::AttributedString::Fragment{};
   fragment.string = tooltip;
   fragment.textAttributes.fontSize = tooltipFontSize;
+  fragment.textAttributes.fontSizeMultiplier =
+      static_cast<float>(winrt::Windows::UI::ViewManagement::UISettings().TextScaleFactor());
   attributedString.appendFragment(std::move(fragment));
   return facebook::react::AttributedStringBox{attributedString};
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TooltipService.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TooltipService.cpp
@@ -236,7 +236,7 @@ void TooltipTracker::ShowTooltip(const winrt::Microsoft::ReactNative::ComponentV
   if (!m_hwndTip) {
     auto viewCompView = view.as<winrt::Microsoft::ReactNative::Composition::ViewComponentView>();
     auto selfView =
-      winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::ViewComponentView>(viewCompView);
+        winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::ViewComponentView>(viewCompView);
     auto parentHwnd = selfView->GetHwndForParenting();
     auto tooltipData = std::make_unique<TooltipData>(view);
     tooltipData->attributedString = CreateTooltipAttributedString(*selfView->viewProps()->tooltip);
@@ -255,32 +255,31 @@ void TooltipTracker::ShowTooltip(const winrt::Microsoft::ReactNative::ComponentV
     facebook::react::TextLayoutManager::GetTextLayout(
         tooltipData->attributedString, {} /*paragraphAttributes*/, layoutConstraints, tooltipData->textLayout);
 
-    if (tooltipData->textLayout)
-    {
+    if (tooltipData->textLayout) {
       DWRITE_TEXT_METRICS tm;
       winrt::check_hresult(tooltipData->textLayout->GetMetrics(&tm));
 
       tooltipData->width =
-        static_cast<int>((tm.width + tooltipHorizontalPadding + tooltipHorizontalPadding) * scaleFactor);
+          static_cast<int>((tm.width + tooltipHorizontalPadding + tooltipHorizontalPadding) * scaleFactor);
       tooltipData->height = static_cast<int>((tm.height + tooltipTopPadding + tooltipBottomPadding) * scaleFactor);
 
-      POINT pt = { static_cast<LONG>(m_pos.X), static_cast<LONG>(m_pos.Y) };
+      POINT pt = {static_cast<LONG>(m_pos.X), static_cast<LONG>(m_pos.Y)};
       ClientToScreen(parentHwnd, &pt);
 
       RegisterTooltipWndClass();
       HINSTANCE hInstance = GetModuleHandle(NULL);
       m_hwndTip = CreateWindow(
-        c_tooltipWindowClassName,
-        L"Tooltip",
-        WS_POPUP,
-        pt.x - tooltipData->width / 2,
-        static_cast<int>(pt.y - tooltipData->height - (toolTipPlacementMargin * scaleFactor)),
-        tooltipData->width,
-        tooltipData->height,
-        parentHwnd,
-        NULL,
-        hInstance,
-        tooltipData.get());
+          c_tooltipWindowClassName,
+          L"Tooltip",
+          WS_POPUP,
+          pt.x - tooltipData->width / 2,
+          static_cast<int>(pt.y - tooltipData->height - (toolTipPlacementMargin * scaleFactor)),
+          tooltipData->width,
+          tooltipData->height,
+          parentHwnd,
+          NULL,
+          hInstance,
+          tooltipData.get());
 
       DWM_WINDOW_CORNER_PREFERENCE preference = DWMWCP_ROUNDSMALL;
       UINT borderThickness = 0;


### PR DESCRIPTION
## Description
- The margins on tooltips were not getting scaled correctly for the scale factor, resulting in clipped text at high scale factors.
- Fixed a crash when the tooltip is set to an empty string.
- Tooltips were not respecting the system TextScaleFactor

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14397)