### PR TITLE
Property updates switching between PlatformColors would no-op

### DIFF
--- a/change/react-native-windows-ca0880f1-4d40-4ab6-9c95-d843aade3939.json
+++ b/change/react-native-windows-ca0880f1-4d40-4ab6-9c95-d843aade3939.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Property updates switching between PlatformColors would no-op",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
@@ -77,13 +77,12 @@ winrt::Microsoft::ReactNative::Color Color::ReadValue(
   switch (reader.ValueType()) {
     case JSValueType::Int64: {
       auto argb = reader.GetInt64();
-      return winrt::make<Color>(facebook::react::Color{
-          /*color*/
-          {static_cast<uint8_t>((argb >> 24) & 0xFF),
-           static_cast<uint8_t>((argb >> 16) & 0xFF),
-           static_cast<uint8_t>((argb >> 8) & 0xFF),
-           static_cast<uint8_t>(argb & 0xFF)},
-          {}});
+      return winrt::make<Color>(facebook::react::Color{/*color*/
+                                                       {static_cast<uint8_t>((argb >> 24) & 0xFF),
+                                                        static_cast<uint8_t>((argb >> 16) & 0xFF),
+                                                        static_cast<uint8_t>((argb >> 8) & 0xFF),
+                                                        static_cast<uint8_t>(argb & 0xFF)},
+                                                       {}});
     }
     case JSValueType::Object: {
       std::vector<std::string> platformColors;

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
@@ -78,7 +78,6 @@ winrt::Microsoft::ReactNative::Color Color::ReadValue(
     case JSValueType::Int64: {
       auto argb = reader.GetInt64();
       return winrt::make<Color>(facebook::react::Color{
-          /*m_isDefined*/ true,
           /*color*/
           {static_cast<uint8_t>((argb >> 24) & 0xFF),
            static_cast<uint8_t>((argb >> 16) & 0xFF),
@@ -96,10 +95,10 @@ winrt::Microsoft::ReactNative::Color Color::ReadValue(
           SkipValue<JSValue>(reader); // Skip this property
         }
       }
-      return winrt::make<Color>(facebook::react::Color{/*m_isDefined*/ true, /*color*/ {}, std::move(platformColors)});
+      return winrt::make<Color>(facebook::react::Color{/*color*/ {}, std::move(platformColors)});
     }
     default:
-      return winrt::make<Color>(facebook::react::Color{/*m_isDefined*/ false, /*color*/ {0, 0, 0, 0}, {}});
+      return winrt::make<Color>(facebook::react::Color{/*color*/ {0, 0, 0, 0}, {}});
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/HostPlatformColor.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/HostPlatformColor.h
@@ -12,13 +12,10 @@ namespace facebook::react {
 
 struct Color {
   bool operator==(const Color &otherColor) const {
-    return m_isUndefined && otherColor.m_isUndefined ||
-        (m_isUndefined == otherColor.m_isUndefined && m_color == otherColor.m_color &&
-         m_platformColor == otherColor.m_platformColor);
+    return m_color == otherColor.m_color && m_platformColor == otherColor.m_platformColor;
   }
   bool operator!=(const Color &otherColor) const {
-    return m_isUndefined != otherColor.m_isUndefined || m_color != otherColor.m_color ||
-        m_platformColor != otherColor.m_platformColor;
+    return m_color != otherColor.m_color || m_platformColor != otherColor.m_platformColor;
   }
 
   winrt::Windows::UI::Color AsWindowsColor() const {
@@ -36,13 +33,12 @@ struct Color {
     return RGB(m_color.R, m_color.G, m_color.B) | (m_color.A << 24);
   }
 
-  bool m_isUndefined;
   winrt::Windows::UI::Color m_color;
   std::vector<std::string> m_platformColor;
 };
 
 namespace HostPlatformColor {
-static const facebook::react::Color UndefinedColor{true};
+static const facebook::react::Color UndefinedColor{{0, 0, 0, 0} /*Black*/, {} /*Empty PlatformColors*/};
 } // namespace HostPlatformColor
 
 inline Color hostPlatformColorFromComponents(ColorComponents components) {
@@ -53,7 +49,6 @@ inline Color hostPlatformColorFromComponents(ColorComponents components) {
       static_cast<uint8_t>((int)round(components.green * ratio) & 0xff),
       static_cast<uint8_t>((int)round(components.blue * ratio) & 0xff)};
   return {
-      /* .m_isUndefined = */ false,
       /* .m_color = */ color,
       /* .m_platformColor = */ {}};
 }

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/PlatformColorParser.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/PlatformColorParser.h
@@ -19,7 +19,6 @@ parsePlatformColor(const ContextContainer &contextContainer, int32_t surfaceId, 
     auto map = (std::unordered_map<std::string, std::vector<std::string>>)value;
     if (map.find("windowsbrush") != map.end()) {
       facebook::react::Color color = {
-          /* .m_isDefined = */ true,
           /* .m_color = */ {},
           /* .m_platformColor = */ std::move(map["windowsbrush"]),
       };


### PR DESCRIPTION
## Description
In our HostPlatformColor object we had a bool that was representing an undefined color.  There were a couple of places where we were treating this bool as isDefined, instead of isUndefined.  This caused the == operator of Color to return true when comparing any PlatformColors. - Which causes various issues.

With the following component, the text would not change color when pressing the button:
```jsx
const Bootstrap = () => {
  const [isHighlight, setIsHighlight] = React.useState(false);
  const swapColors = () => {
    setIsHighlight(!isHighlight);
  };
  return (
    <View>
      <Button title="Press" onPress={swapColors} />
      <Text
        style={{
          color: isHighlight ? PlatformColor('Highlight') : PlatformColor('WindowText'),
        }}>
        <Text>Text here</Text>
      </Text>
    </View>
  );
};
```


I just removed the whole m_isUndefined property.  It is not needed as SharedColor has a bool operator that just compares the color to the global Undefined color, which doesn't need an additional bool.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14398)