### PR TITLE
Prevent race condition in ConnectSucceeds WS unit test

### DIFF
--- a/change/react-native-windows-77840265-2969-48e7-9ab2-ee5877155246.json
+++ b/change/react-native-windows-77840265-2969-48e7-9ab2-ee5877155246.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent race condition in ConnectSucceeds",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

Fix unstable test Microsoft::React::Test::WinRTWebSocketResourceUnitTest::ConnectSucceeds


### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The addressed test fails intermittently on CI runs.

### What
Drain/synchronize test DispatchQueue used to emulate the calling thread.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14405)