### PR TITLE
[Fabric] Implement selectTextOnFocus prop in TextInput

### DIFF
--- a/change/react-native-windows-bc55b824-3ab8-4b55-9cd6-316450f7f562.json
+++ b/change/react-native-windows-bc55b824-3ab8-4b55-9cd6-316450f7f562.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement selectTextOnFocus for TextInput in Fabric",
+  "packageName": "react-native-windows",
+  "email": "14967941+danielayala94@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -219,7 +219,9 @@ const examples: Array<RNTesterModuleExample> = [
             style={styles.singleLine}
             testID="select-text-on-focus"
           />
-          <Text>Do not select text on focus if clear text on focus is enabled:</Text>
+          <Text>
+            Do not select text on focus if clear text on focus is enabled:
+          </Text>
           <ExampleTextInput
             selectTextOnFocus={true}
             clearTextOnFocus={true}

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -209,6 +209,28 @@ const examples: Array<RNTesterModuleExample> = [
     },
   },
   {
+    title: 'Select text on focus',
+    render: function (): React.Node {
+      return (
+        <View>
+          <Text>Select text on focus:</Text>
+          <ExampleTextInput
+            selectTextOnFocus={true}
+            style={styles.singleLine}
+            testID="select-text-on-focus"
+          />
+          <Text>Do not select text on focus if clear text on focus is enabled:</Text>
+          <ExampleTextInput
+            selectTextOnFocus={true}
+            clearTextOnFocus={true}
+            style={styles.singleLine}
+            testID="select-text-on-focus-while-clear-text-on-focus"
+          />
+        </View>
+      );
+    },
+  },
+  {
     title: 'Colors and text inputs',
     render: function (): React.Node {
       return (

--- a/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
@@ -464,9 +464,7 @@ describe('TextInput Tests', () => {
   });
 
   test('TextInputs can select text on focus', async () => {
-    const component = await app.findElementByTestID(
-      'select-text-on-focus',
-    );
+    const component = await app.findElementByTestID('select-text-on-focus');
     await component.waitForDisplayed({timeout: 5000});
 
     await app.waitUntil(
@@ -484,7 +482,7 @@ describe('TextInput Tests', () => {
     // Check if the text is selected on focus.
     await component.click();
 
-    const dump = await dumpVisualTree(('select-text-on-focus'));
+    const dump = await dumpVisualTree('select-text-on-focus');
     expect(dump).toMatchSnapshot();
   });
 

--- a/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
@@ -462,6 +462,64 @@ describe('TextInput Tests', () => {
     // Verify the textInput contents are cleared after regaining focus
     expect(await componentFocusTrue.getText()).toBe('');
   });
+
+  test('TextInputs can select text on focus', async () => {
+    const component = await app.findElementByTestID(
+      'select-text-on-focus',
+    );
+    await component.waitForDisplayed({timeout: 5000});
+
+    await app.waitUntil(
+      async () => {
+        await component.setValue('Hello World');
+        return (await component.getText()) === 'Hello World';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
+
+    // Check if the text is selected on focus.
+    await component.click();
+
+    const dump = await dumpVisualTree(('select-text-on-focus'));
+    expect(dump).toMatchSnapshot();
+  });
+
+  test('TextInputs can clear text on focus even if selectTextOnFocus == true', async () => {
+    const targetComponent = await app.findElementByTestID(
+      'select-text-on-focus-while-clear-text-on-focus',
+    );
+    await targetComponent.waitForDisplayed({timeout: 5000});
+
+    await app.waitUntil(
+      async () => {
+        await targetComponent.setValue('Hello World');
+        return (await targetComponent.getText()) === 'Hello World';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
+
+    // Click on the previous textInput to move focus away from this TextInput
+    const anotherTextInput = await app.findElementByTestID(
+      'select-text-on-focus',
+    );
+    await anotherTextInput.waitForDisplayed({timeout: 5000});
+    await anotherTextInput.click();
+
+    // Now click on the tested component, make sure the text is cleared.
+    await targetComponent.click();
+
+    // Verify the textInput contents are cleared after regaining focus
+    expect(await targetComponent.getText()).toBe('');
+  });
+
   test('TextInputs can have inline images', async () => {
     const component = await app.findElementByTestID('textinput-inline-images');
     await component.waitForDisplayed({timeout: 5000});

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -126,6 +126,17 @@ export default class Bootstrap extends React.Component<{}, any> {
             clearTextOnFocus={true}
             placeholder={'Clear text on focus'}
           />
+          <TextInput
+            style={styles.input}
+            selectTextOnFocus={true}
+            placeholder={'Select text on focus'}
+          />
+          <TextInput
+            style={styles.input}
+            clearTextOnFocus={true}
+            selectTextOnFocus={true}
+            placeholder={'Clear text on focus, even if selectTextOnFocus is true'}
+          /> 
           <Button
             title={
               this.state.passwordHidden

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -135,8 +135,10 @@ export default class Bootstrap extends React.Component<{}, any> {
             style={styles.input}
             clearTextOnFocus={true}
             selectTextOnFocus={true}
-            placeholder={'Clear text on focus, even if selectTextOnFocus is true'}
-          /> 
+            placeholder={
+              'Clear text on focus, even if selectTextOnFocus is true'
+            }
+          />
           <Button
             title={
               this.state.passwordHidden

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -703,7 +703,8 @@ void WindowsTextInputComponentView::OnPointerReleased(
     auto hr = m_textServices->TxSendMessage(msg, static_cast<WPARAM>(wParam), static_cast<LPARAM>(lParam), &lresult);
     args.Handled(hr != S_FALSE);
 
-    // Can't select text on focus at onGotFocus() as the selection is lost after processing the released pointer message.
+    // We should not select text at onGotFocus() as the selection is cleared after processing the released pointer
+    // message.
     if (msg == WM_LBUTTONUP) {
       handleSelectTextOnFocus();
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -110,6 +110,8 @@ struct WindowsTextInputComponentView
       const std::string &previousCapitalizationType,
       const std::string &newcapitalizationType) noexcept;
 
+  void handleSelectTextOnFocus() noexcept;
+
   winrt::Windows::UI::Composition::CompositionSurfaceBrush m_brush{nullptr};
   winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual m_caretVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_drawingSurface{nullptr};


### PR DESCRIPTION
## Description

### Type of Change
New feature.

### Why
Implement selectTextOnFocus prop in TextInput. It is implemented in Paper; this PR brings the Fabric implementation.

Resolves #13133 

### What
Created a function that:
- Selects the whole text when the TextInput is focused
- Drops the selection when TextInput loses focus

The function is called in two places:
- `OnPointerReleased()`, if the mouse left button was pressed, to select the text.
- `OnLostFocus()`, to clear the selection.

Text selection will not occur if `clearTextOnFocus` prop is set to `true`. This is purely by design, as the RN documentation doesn't specify what the behavior should be. For reference, if both props are set to true, Android doesn't clear the text on focus and performs the selection, but iOS clears the text input.

## Screenshots
https://github.com/user-attachments/assets/779d299e-452e-4ff2-9c7b-05ec75f2d7fb

## Testing
Added e2e tests to TextInputComponentTest and two TextInput fields in playground, in both cases demonstrating the capabilities explained above.

## Changelog
Yes

Implement selectTextOnFocus for TextInput in Fabric