### PR TITLE
Fix bool operator on transparent colors returning false

### DIFF
--- a/change/react-native-windows-984ae1a3-5950-4ab1-bebb-44b11bc5b147.json
+++ b/change/react-native-windows-984ae1a3-5950-4ab1-bebb-44b11bc5b147.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bool operator on transparent colors returning false",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -979,10 +979,12 @@ ReactNativeIsland::GetComponentView() noexcept {
 
   if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
           winrt::Microsoft::ReactNative::ReactPropertyBag(m_context.Properties()))) {
-    auto rootComponentViewDescriptor = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(
-        static_cast<facebook::react::SurfaceId>(m_rootTag));
-    return rootComponentViewDescriptor.view
+    if (auto view = fabricuiManager->GetViewRegistry().findComponentViewWithTag(
+      static_cast<facebook::react::SurfaceId>(m_rootTag)))
+    {
+      return view
         .as<winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView>();
+    }
   }
   return nullptr;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -980,10 +980,8 @@ ReactNativeIsland::GetComponentView() noexcept {
   if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
           winrt::Microsoft::ReactNative::ReactPropertyBag(m_context.Properties()))) {
     if (auto view = fabricuiManager->GetViewRegistry().findComponentViewWithTag(
-      static_cast<facebook::react::SurfaceId>(m_rootTag)))
-    {
-      return view
-        .as<winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView>();
+            static_cast<facebook::react::SurfaceId>(m_rootTag))) {
+      return view.as<winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView>();
     }
   }
   return nullptr;

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/HostPlatformColor.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/HostPlatformColor.h
@@ -38,7 +38,9 @@ struct Color {
 };
 
 namespace HostPlatformColor {
-static const facebook::react::Color UndefinedColor{{0, 0, 0, 0} /*Black*/, {"__undefinedColor"} /*Empty PlatformColors*/};
+static const facebook::react::Color UndefinedColor{
+    {0, 0, 0, 0} /*Black*/,
+    {"__undefinedColor"} /*Empty PlatformColors*/};
 } // namespace HostPlatformColor
 
 inline Color hostPlatformColorFromComponents(ColorComponents components) {

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/HostPlatformColor.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/HostPlatformColor.h
@@ -38,7 +38,7 @@ struct Color {
 };
 
 namespace HostPlatformColor {
-static const facebook::react::Color UndefinedColor{{0, 0, 0, 0} /*Black*/, {} /*Empty PlatformColors*/};
+static const facebook::react::Color UndefinedColor{{0, 0, 0, 0} /*Black*/, {"__undefinedColor"} /*Empty PlatformColors*/};
 } // namespace HostPlatformColor
 
 inline Color hostPlatformColorFromComponents(ColorComponents components) {


### PR DESCRIPTION
## Description
Setting a border color to 'transparent' caused a black border to show up.

### Why
There is code that does `if (!borderColor) borderColor = black`.  The bool operator is supposed to check if the color is undefined.  But was also returning false for #00000000.  

### What
I modified the undefined color to have a special token platform color, that way Color::Undefined != Color::Transparent.


I also fixed up an issue in ReactNativeIsland where calling `GetComponentView` on the island before the surface has loaded, would crash.  Now it just returns null.  This was sometimes causing a crash when showing a logbox.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14413)