### PR TITLE
Allow non-versioned MSBuild local overrides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,18 +22,13 @@ indent_size = 4
 end_of_line = crlf
 
 # Xml project files
-[*.{config,csproj,njsproj,props,targets,vcxitems,vcxproj,vcxproj.filters}]
+[*.{config,csproj,csproj.filters,nuspec,props,ruleset,targets,vcxitems,vcxitems.filters,vcxproj,vcxproj.filters}]
 indent_size = 2
 end_of_line = crlf
 insert_final_newline = false
 
 # Xml files
 [*.{xml,stylecop,resx,ruleset}]
-indent_size = 2
-end_of_line = crlf
-
-# XML config files
-[*.{msbuild,props,targets,ruleset,config,nuspec}]
 indent_size = 2
 end_of_line = crlf
 

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ ipch/
 *.tlog/
 Ankh.NoLoad
 UpgradeLog.htm
+Directory.Build.local.props
+Directory.Build.local.targets
 
 #MonoDevelop
 *.pidb

--- a/.prettierignore
+++ b/.prettierignore
@@ -55,3 +55,13 @@ vnext/src-win/rntypes
 vnext/rntypes
 vnext/target
 vnext/flow-typed
+
+# MSBuild project files
+*.props
+*.targets
+*.config
+*.ruleset
+*.vcxproj
+*.vcxproj.filters
+*.csproj
+*.csproj.filters

--- a/.prettierignore
+++ b/.prettierignore
@@ -55,13 +55,3 @@ vnext/src-win/rntypes
 vnext/rntypes
 vnext/target
 vnext/flow-typed
-
-# MSBuild project files
-*.props
-*.targets
-*.config
-*.ruleset
-*.vcxproj
-*.vcxproj.filters
-*.csproj
-*.csproj.filters

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -150,5 +150,6 @@
     "**/*.{ts,tsx,js,jsx}"
   ],
   "prettier.configPath": ".prettierrc",
-  "prettier.ignorePath": ".prettierignore"
+  "prettier.ignorePath": ".prettierignore",
+  "xml.format.maxLineWidth": 0
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,4 +30,7 @@
     <MSBuildProjectExtensionsPath Condition="'$(ProjectName)' == ''">$(RootIntDir)\ProjectExtensions\$(MSBuildProjectName)\</MSBuildProjectExtensionsPath>
   </PropertyGroup>
 
+  <!-- User overrides -->
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Build.local.props" Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.local.props')" />
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,7 +4,7 @@
   <!-- This target is used to compute the inputs and outputs for running the `yarn install`. -->
   <Target
     Name="ReactNativeYarnInstallInputAndOutputs"
-    >
+  >
     <ItemGroup>
       <_ReactNativeYarnInstallInputFiles Include="$(MSBuildThisFileDirectory)yarn.lock" />
       <_ReactNativeYarnInstallInputFiles Include="$(MSBuildThisFileDirectory)**\package.json" Exclude="$(MSBuildThisFileDirectory)node_modules\**" />
@@ -24,7 +24,7 @@
     Inputs="@(_ReactNativeYarnInstallInputFiles)"
     Outputs="@(_ReactNativeYarnInstallOutputFiles)"
     Condition="'$(DesignTimeBuild)'=='' AND '$(AGENT_NAME)' == ''"
-    >
+  >
 
     <Message Text="Running yarn install to fetch latest packages." Importance="High" />
     <Message Text="yarn install --frozen-lockfile --mutex file:.yarn-mutex" Importance="High" />
@@ -32,8 +32,8 @@
       ContinueOnError="True"
       Command="yarn install --frozen-lockfile --mutex file:.yarn-mutex"
       WorkingDirectory="$(MSBuildThisFileDirectory)"
-      >
-      <Output TaskParameter="ExitCode" ItemName="_ReactNativeYarnExitCode"/>
+    >
+      <Output TaskParameter="ExitCode" ItemName="_ReactNativeYarnExitCode" />
     </Exec>
 
     <Message Text="yarn install: Succeeded" Condition="'%(_ReactNativeYarnExitCode.Identity)' == '0'" Importance="High" />
@@ -195,5 +195,8 @@
     <Message Text="                                            %(ProjectCapability.Identity)" />
 
   </Target>
+
+  <!-- User overrides -->
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Build.local.targets" Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.local.targets')" />
 
 </Project>


### PR DESCRIPTION
## Description

Allows customizing MSBuild behavior locally through the file system.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Customizing MSBuild logic for local development requires verbose command line tweaking or modifying versioned files.


### What
Allows creating Directory.Build.local.{props,targets} transitory (non-versioned) files.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14430)