### PR TITLE
Replace use of `execSync` with `spawnSync` in `@react-native-windows/automation`

### DIFF
--- a/change/@react-native-windows-automation-c0a9ebab-d210-4090-b544-5ac4c6651079.json
+++ b/change/@react-native-windows-automation-c0a9ebab-d210-4090-b544-5ac4c6651079.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace use of `execSync` with `spawnSync` in `@react-native-windows/automation`",
+  "packageName": "@react-native-windows/automation",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
+++ b/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
@@ -6,7 +6,7 @@
  */
 
 import chalk from 'chalk';
-import {execSync, spawn, ChildProcess} from 'child_process';
+import {spawnSync, spawn, ChildProcess} from 'child_process';
 import fs from '@react-native-windows/fs';
 import path from 'path';
 import readlineSync from 'readline-sync';
@@ -199,7 +199,11 @@ export default class AutomationEnvironment extends NodeEnvironment {
 
       if (this.rootLaunchApp) {
         const appPackageName = resolveAppName(appName);
-        execSync(`start shell:AppsFolder\\${appPackageName}`);
+        spawnSync('cmd', [
+          '/c',
+          'start',
+          `shell:AppsFolder\\${appPackageName}`,
+        ]);
       }
 
       // Set up the "Desktop" or Root session
@@ -323,10 +327,10 @@ function resolveAppName(appName: string): string {
   }
 
   try {
-    const packageFamilyName = execSync(
-      `powershell (Get-AppxPackage -Name ${appName}).PackageFamilyName`,
-    )
-      .toString()
+    const packageFamilyName = spawnSync('powershell', [
+      `(Get-AppxPackage -Name ${appName}).PackageFamilyName`,
+    ])
+      .stdout.toString()
       .trim();
 
     if (packageFamilyName.length === 0) {


### PR DESCRIPTION
## Description

This PR updates the use of `execSync` to `spawnSync` in `@react-native-windows/automation` to avoid potential security vulnerabilities.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
There is a CodeQL alert that we're using shell commands unsafely in the automation library to get the name of an appx and then launch it for unit tests.

Closes #14242

### What
Rather than using `execSync`, which is unsafe, we are now using `spawnSync` to execute shell commands in a safer manner.

## Screenshots
N/A

## Testing
I verified that our existing E2E test apps still launch and run as expected with this change.

## Changelog
Should this change be included in the release notes: _yes_

Replace use of `execSync` with `spawnSync` in `@react-native-windows/automation`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14434)