### PR TITLE
[0.77] Button Should Pass onAccessibilityTap Prop to Native Code

### DIFF
--- a/change/react-native-windows-dee3a16c-0e0f-4af4-b524-b216b0a19255.json
+++ b/change/react-native-windows-dee3a16c-0e0f-4af4-b524-b216b0a19255.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Button should pass onAccessibilityTap to native",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-dee3a16c-0e0f-4af4-b524-b216b0a19255.json
+++ b/change/react-native-windows-dee3a16c-0e0f-4af4-b524-b216b0a19255.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Button should pass onAccessibilityTap to native",
   "packageName": "react-native-windows",
   "email": "34109996+chiaramooney@users.noreply.github.com",

--- a/vnext/src-win/Libraries/Components/Button.windows.js
+++ b/vnext/src-win/Libraries/Components/Button.windows.js
@@ -152,6 +152,7 @@ type ButtonProps = $ReadOnly<{|
   accessible?: ?boolean,
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  onAccessibilityTap?: ?() => mixed, // Windows
   accessibilityState?: ?AccessibilityState,
 
   /**
@@ -333,6 +334,7 @@ const Button: component(
     accessibilityHint,
     accessibilityLanguage,
     onAccessibilityAction,
+    onAccessibilityTap, // Windows
     tabIndex,
   } = props;
   const buttonStyles: Array<ViewStyleProp> = [styles.button];
@@ -391,6 +393,7 @@ const Button: component(
         accessibilityLanguage={accessibilityLanguage}
         accessibilityRole="button"
         accessibilityState={_accessibilityState}
+        onAccessibilityTap={onAccessibilityTap} // Windows
         importantForAccessibility={_importantForAccessibility}
         hasTVPreferredFocus={hasTVPreferredFocus}
         nextFocusDown={nextFocusDown}


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Backport #14444 to 0.77.

## Changelog
Should this change be included in the release notes: No