### PR TITLE
Add onHoverIn/Out Test Example

### DIFF
--- a/packages/e2e-test-app-fabric/test/PressableComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/PressableComponentTest.test.ts
@@ -93,7 +93,45 @@ describe('Pressable Tests', () => {
       },
     );
   });
-  test('Pressables can have event handlers', async () => {
+  test('Pressables can have event handlers, hover', async () => {
+    const searchBox = await app.findElementByTestID('example_search');
+    await app.waitUntil(
+      async () => {
+        await searchBox.setValue('fee');
+        return (await searchBox.getText()) === 'fee';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct search text into test searchbox.`,
+      },
+    );
+    const component = await app.findElementByTestID(
+      'pressable_feedback_events_button',
+    );
+    await component.waitForDisplayed({timeout: 20000});
+    const dump = await dumpVisualTree('pressable_feedback_events_button');
+    expect(dump).toMatchSnapshot();
+    await component.moveTo();
+    const console = await app.findElementByTestID(
+      'pressable_feedback_events_console',
+    );
+    await console.moveTo();
+    const dump2 = await dumpVisualTree('pressable_feedback_events_console');
+    expect(dump2).toMatchSnapshot();
+    await app.waitUntil(
+      async () => {
+        await searchBox.setValue(['Backspace', 'Backspace', 'Backspace']);
+        return (await searchBox.getText()) === 'Search...';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct search text into test searchbox.`,
+      },
+    );
+  });
+  test('Pressables can have event handlers, hover and click', async () => {
     const searchBox = await app.findElementByTestID('example_search');
     await app.waitUntil(
       async () => {

--- a/packages/e2e-test-app-fabric/test/__snapshots__/PressableComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/PressableComponentTest.test.ts.snap
@@ -627,7 +627,7 @@ exports[`Pressable Tests Pressables can have delayed event handlers 2`] = `
 }
 `;
 
-exports[`Pressable Tests Pressables can have event handlers 1`] = `
+exports[`Pressable Tests Pressables can have event handlers, hover 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_feedback_events_button",
@@ -682,7 +682,157 @@ exports[`Pressable Tests Pressables can have event handlers 1`] = `
 }
 `;
 
-exports[`Pressable Tests Pressables can have event handlers 2`] = `
+exports[`Pressable Tests Pressables can have event handlers, hover 2`] = `
+{
+  "Automation Tree": {
+    "AutomationId": "pressable_feedback_events_console",
+    "ControlType": 50026,
+    "LocalizedControlType": "group",
+    "__Children": [
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "LocalizedControlType": "text",
+        "Name": "hover in",
+        "TextRangePattern.GetText": "hover in",
+      },
+    ],
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "TestId": "pressable_feedback_events_console",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
+  },
+  "Visual Tree": {
+    "Brush": {
+      "Brush Type": "ColorBrush",
+      "Color": "rgba(249, 249, 249, 255)",
+    },
+    "Comment": "pressable_feedback_events_console",
+    "Offset": "0, 0, 0",
+    "Size": "896, 120",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "11, 11, 0",
+        "Size": "874, 19",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "874, 19",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Pressable Tests Pressables can have event handlers, hover and click 1`] = `
+{
+  "Automation Tree": {
+    "AutomationId": "pressable_feedback_events_button",
+    "ControlType": 50000,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "button",
+    "Name": "pressable feedback events",
+    "ValuePattern.Value": "Press Me",
+    "__Children": [
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "LocalizedControlType": "text",
+        "Name": "Press Me",
+        "TextRangePattern.GetText": "Press Me",
+      },
+    ],
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "pressable feedback events",
+      "TestId": "pressable_feedback_events_button",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
+  },
+  "Visual Tree": {
+    "Comment": "pressable_feedback_events_button",
+    "Offset": "0, 0, 0",
+    "Size": "56, 18",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "56, 20",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "56, 20",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`Pressable Tests Pressables can have event handlers, hover and click 2`] = `
 {
   "Automation Tree": {
     "AutomationId": "pressable_feedback_events_console",


### PR DESCRIPTION
## Description

### Type of Change
- Testing

### Why
Add onHoverIn/Out for Pressable test to expand test coverage for props. 

### What
Add onHoverIn/Out for Pressable test.

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14457)