### PR TITLE
[0.78] Fix use of ExperimentalWinUI3 in CI / Secure PR

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -196,11 +196,13 @@ parameters:
             platform: x64
             additionalRunArguments: --no-autolink
             useNuGet: true
+            useExperimentalWinUI3: true
           - Name: PaperX64ReleaseCpp
             template: old/uwp-cpp-app
             configuration: Release
             platform: x64
             runWack: true
+            useExperimentalWinUI3: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: FabricX64Debug
@@ -420,3 +422,4 @@ jobs:
                   buildEnvironment: ${{ parameters.buildEnvironment }}
                   useChakra: ${{ coalesce(matrix.useChakra, false) }}
                   useNuGet: ${{ coalesce(matrix.useNuGet, false) }}
+                  useExperimentalWinUI3: ${{ coalesce(matrix.useExperimentalWinUI3, false) }}

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -47,6 +47,7 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x64
             UseFabric: true
+            UseExperimentalWinUI3: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Debug
@@ -189,6 +190,11 @@ jobs:
 
             - ${{ if eq(matrix.UseFabric, true) }}:
               - template: ../templates/enable-fabric-experimental-feature.yml
+              
+            - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
+              - template:  ../templates/enable-experimental-winui3.yml
+                parameters:
+                  workingDir: vnext
 
             - template: ../templates/msbuild-sln.yml
               parameters:

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -76,7 +76,7 @@ jobs:
 
             - template: ../templates/set-experimental-feature.yml
               parameters:
-                package: packages/e2e-test-app
+                workingDir: packages/e2e-test-app/windows
                 feature: UseHermes
                 ${{ if eq(matrix.UseChakra, true) }}:
                   value: false

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -110,7 +110,7 @@ jobs:
 
             - template: ../templates/set-experimental-feature.yml
               parameters:
-                package: packages/integration-test-app
+                workingDir: packages/integration-test-app/windows
                 feature: UseHermes
                 ${{ if eq(matrix.UseChakra, true) }}:
                   value: false

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -141,22 +141,9 @@ jobs:
                   certificatePassword: ${{ parameters.certificatePassword }}
         
             - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
-              - template:  ../templates/set-experimental-feature.yml
+              - template:  ../templates/enable-experimental-winui3.yml
                 parameters:
-                  package: packages\playground
-                  feature: UseExperimentalWinUI3
-                  value: true
-
-              - task: PowerShell@2
-                displayName: Enable the internal WinAppSDK Feed
-                inputs:
-                  targetType: filePath # filePath | inline
-                  filePath: $(Build.SourcesDirectory)\vnext\Scripts\EnableInternalWinAppSDKFeed.ps1
-
-              - task: NuGetAuthenticate@1
-                displayName: 'NuGet Authenticate Internal WinAppSDK Feed'
-                inputs:
-                  nuGetServiceConnections: 'WinAppSDK Experimental NuGet for RNW'
+                  workingDir: packages\playground\windows
 
             # NuGet ignores packages.config if it detects <PackageReference>.
             # Use restore packages.config directly to keep compabitility with ReactNativePicker.

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -48,10 +48,12 @@
               BuildConfiguration: Release
               BuildPlatform: x64
               UseFabric: true
+              UseExperimentalWinUI3: true
             - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
               BuildConfiguration: Release
               BuildPlatform: x86
               UseFabric: true
+              UseExperimentalWinUI3: true
         - BuildEnvironment: Continuous
           Matrix:
             - Name: X64Debug
@@ -135,6 +137,11 @@
 
                 - ${{ if eq(matrix.UseFabric, true) }}:
                   - template: ../templates/enable-fabric-experimental-feature.yml
+                  
+                - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
+                  - template:  ../templates/enable-experimental-winui3.yml
+                    parameters:
+                      workingDir: vnext
 
                 - template: ../templates/msbuild-sln.yml
                   parameters:

--- a/.ado/templates/enable-experimental-winui3.yml
+++ b/.ado/templates/enable-experimental-winui3.yml
@@ -1,0 +1,25 @@
+parameters:
+- name: workingDir
+  type: string
+- name: enableInternalFeed
+  type: boolean
+  default: false # If WinUI3ExperimentalVersion in WinUI.props is only available on the ProjectReuinion feed, set to true, else if is on nuget.org, set to false
+
+steps:
+  - template:  ../templates/set-experimental-feature.yml
+    parameters:
+      workingDir: ${{ parameters.workingDir }}
+      feature: UseExperimentalWinUI3
+      value: true
+
+  - ${{ if eq(parameters.enableInternalFeed, true) }}:
+    - task: PowerShell@2
+      displayName: Enable the internal WinAppSDK Feed
+      inputs:
+        targetType: filePath # filePath | inline
+        filePath: $(Build.SourcesDirectory)\vnext\Scripts\EnableInternalWinAppSDKFeed.ps1
+
+    - task: NuGetAuthenticate@1
+      displayName: 'NuGet Authenticate Internal WinAppSDK Feed'
+      inputs:
+        nuGetServiceConnections: 'WinAppSDK Experimental NuGet for RNW'

--- a/.ado/templates/enable-fabric-experimental-feature.yml
+++ b/.ado/templates/enable-fabric-experimental-feature.yml
@@ -1,13 +1,16 @@
 steps:
-  - powershell: |
-      [xml] $experimentalFeatures = Get-Content vnext\ExperimentalFeatures.props
-      $nsm = New-Object Xml.XmlNamespaceManager($experimentalFeatures.NameTable)
-      $nsm.AddNamespace('ns', $experimentalFeatures.DocumentElement.NamespaceURI)
-
-      $xmlNode = $experimentalFeatures.CreateElement("PropertyGroup");
-      $xmlNode.InnerXml = "<RnwNewArch>true</RnwNewArch><UseFabric>true</UseFabric><UseWinUI3>true</UseWinUI3>"
-
-      $experimentalFeatures.DocumentElement.AppendChild($xmlNode);
-
-      $experimentalFeatures.Save("vnext\ExperimentalFeatures.props")
-    displayName: Enable UseFabric experimental feature
+  - template:  ../templates/set-experimental-feature.yml
+    parameters:
+      workingDir: vnext
+      feature: RnwNewArch
+      value: true
+  - template:  ../templates/set-experimental-feature.yml
+    parameters:
+      workingDir: vnext
+      feature: UseFabric
+      value: true
+  - template:  ../templates/set-experimental-feature.yml
+    parameters:
+      workingDir: vnext
+      feature: UseWinUI3
+      value: true

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -25,6 +25,9 @@ parameters:
   - name: useNuGet
     type: boolean
     default: false
+  - name: useExperimentalWinUI3
+    type: boolean
+    default: false
   - name: runWack
     type: boolean
     default: false
@@ -133,9 +136,17 @@ steps:
   - ${{ if eq(parameters.UseChakra, true) }}:
     - template:  set-experimental-feature.yml
       parameters:
-        package: ..\testcli
+        workingDir: ..\testcli\windows
         feature: UseHermes
         value: false
+
+  - ${{ if eq(parameters.useExperimentalWinUI3, true) }}:
+    - template:  ../templates/enable-experimental-winui3.yml
+      parameters:
+        ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
+          workingDir: $(Agent.BuildDirectory)\testcli\example\windows
+        ${{ else }}:
+          workingDir: $(Agent.BuildDirectory)\testcli\windows
 
   - ${{ if or(endsWith(parameters.template, '-app'), and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old')))) }}:
     - powershell: |

--- a/.ado/templates/set-experimental-feature.yml
+++ b/.ado/templates/set-experimental-feature.yml
@@ -1,5 +1,5 @@
 parameters:
-- name: package
+- name: workingDir
   type: string
 - name: feature
   type: string
@@ -8,13 +8,12 @@ parameters:
 
 steps:
   - powershell: |
-      [xml] $experimentalFeatures = Get-Content .\ExperimentalFeatures.props
-      $nsm = New-Object Xml.XmlNamespaceManager($experimentalFeatures.NameTable)
-      $nsm.AddNamespace('ns', $experimentalFeatures.DocumentElement.NamespaceURI)
-
-      $xmlNode = $experimentalFeatures.SelectSingleNode('//ns:PropertyGroup/ns:${{ parameters.feature }}', $nsm);
-      $xmlNode.InnerText = '${{ parameters.value }}'
-
-      $experimentalFeatures.Save("$pwd\ExperimentalFeatures.props")
+      [xml] $xmlDoc = Get-Content .\ExperimentalFeatures.props
+      # Add to new property group at the end of the file to ensure it overrides any other setting
+      $propertyGroup = $xmlDoc.CreateElement("PropertyGroup", $xmlDoc.DocumentElement.NamespaceURI);
+      $newProp = $propertyGroup.AppendChild($xmlDoc.CreateElement("${{ parameters.feature }}", $xmlDoc.DocumentElement.NamespaceURI)); 
+      $newProp.AppendChild($xmlDoc.CreateTextNode("${{ parameters.value }}"));
+      $xmlDoc.DocumentElement.AppendChild($propertyGroup);
+      $xmlDoc.Save("$pwd\ExperimentalFeatures.props")
     displayName: Set "${{ parameters.feature }}" to "${{ parameters.value }}"
-    workingDirectory: ${{ parameters.package }}/windows
+    workingDirectory: ${{ parameters.workingDir }}

--- a/change/react-native-windows-8c3b9cef-da7b-4f02-9a80-4b1a912d7231.json
+++ b/change/react-native-windows-8c3b9cef-da7b-4f02-9a80-4b1a912d7231.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.78] Fix use of ExperimentalWinUI3 in CI / Secure PR",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -2,7 +2,6 @@
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <RnwNewArch>false</RnwNewArch>
     <UseExperimentalWinUI3>true</UseExperimentalWinUI3>
-    <WindowsAppSdkAutoInitialize>false</WindowsAppSdkAutoInitialize>
   </PropertyGroup>
   <PropertyGroup>
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>

--- a/vnext/PropertySheets/WebView2.props
+++ b/vnext/PropertySheets/WebView2.props
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="WebView2 versioning">
       <!-- WinAppSDK 1.6+ has a dependency on Microsoft.Web.WebView2, there are a few places we need to pull in this package explicitly. -->
-      <WebView2PackageVersion>1.0.2792.45</WebView2PackageVersion>
+      <!-- This minimum fallback version should be greater than or equal to what's needed by both the default and experimental versions of WinAppSDK in WinUI.props. -->
+      <WebView2PackageVersion Condition="'$(WebView2PackageVersion)'=='' Or $([MSBuild]::VersionLessThan('$(WebView2PackageVersion)', '1.0.2792.45'))">1.0.2792.45</WebView2PackageVersion>
   </PropertyGroup>
 </Project>

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -3,13 +3,16 @@
   <PropertyGroup Label="WinUI3 versioning">
 
     <!-- 
-      Internal versions are located at: https://microsoft.visualstudio.com/DefaultCollection/ProjectReunion/_artifacts/feed/Project.Reunion.nuget.internal/NuGet/Microsoft.WindowsAppSDK/versions
-      For local testing of internal versions, modify WinUI3ExperimentalVersion, and comment out the addition nuget source in NuGet.Config
+      Internal versions are typically only located at: https://microsoft.visualstudio.com/DefaultCollection/ProjectReunion/_artifacts/feed/Project.Reunion.nuget.internal/NuGet/Microsoft.WindowsAppSDK/versions
+      For local testing of internal versions, modify WinUI3ExperimentalVersion, and comment out the additional nuget source in NuGet.Config
+      When this version is updated, be sure to update the default for the enableInternalFeed parameter of /.ado/templates/enable-experimental-winui3.yml and the minimum version of WebView in WebView2.props
     -->
     <WinUI3ExperimentalVersion Condition="'$(WinUI3ExperimentalVersion)'==''">1.7.250109001-experimental2</WinUI3ExperimentalVersion>
     <!-- This value is also used by the CLI, see /packages/@react-native-windows/cli/.../autolinkWindows.ts -->
     <WinUI3Version Condition="'$(WinUI3Version)'=='' AND '$(UseExperimentalWinUI3)'=='true'">$(WinUI3ExperimentalVersion)</WinUI3Version>
     <WinUI3Version Condition="'$(WinUI3Version)'==''">1.6.240923002</WinUI3Version>
+    <!-- This is needed to prevent build errors with WinAppSDK >= 1.7 trying to double build WindowsAppRuntimeAutoInitializer.cpp -->
+    <WindowsAppSdkAutoInitialize Condition="'$(WindowsAppSdkAutoInitialize)'=='' And $([MSBuild]::VersionGreaterThan('$(WinUI3Version)', '1.7.0'))">false</WindowsAppSdkAutoInitialize>
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI2x versioning">


### PR DESCRIPTION
This PR backports #14441 to RNW 0.78.

## Description

This PR aims to fix our usage of the Secure PR and/or CI where `UseExperimentalWinUI3` is enabled. This PR standardizes how we enable building with `UseExperimentalWinUI3`.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We are not always building the correct matrix when running Secure PR. Furthermore, we are unnecessarily failing when trying to access internal feeds when we don't need them. The current experimental WinUI3 we're using is in fact publicly available on NuGet.org.

### What
* Created a new ADO pipeline template for enabling UseExperimentalWinUI3 and optionally registering and authenticating to the ProjectReunion feed
* Updated all SecurePR builds to use the new template
* Updated the ADO pipeline for enabling experimental features to be more robust
* Ensure `WindowsAppSdkAutoInitialize` is set to false for all builds using WinAppSDK >= 1.7

## Screenshots
N/A

## Testing
Verified running Secure PR worked for this PR.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14477)