### PR TITLE
[0.75] Bump folly to v2024.01.01.00 

### DIFF
--- a/change/react-native-windows-21dbc793-f697-4cf7-b953-f9482a6481f2.json
+++ b/change/react-native-windows-21dbc793-f697-4cf7-b953-f9482a6481f2.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Bump folly to v2024.01.01.00",
-  "packageName": "react-native-windows",
-  "email": "jthysell@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-21dbc793-f697-4cf7-b953-f9482a6481f2.json
+++ b/change/react-native-windows-21dbc793-f697-4cf7-b953-f9482a6481f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump folly to v2024.01.01.00",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-f2fa63e6-4162-4d25-95e4-f0811a00225a.json
+++ b/change/react-native-windows-f2fa63e6-4162-4d25-95e4-f0811a00225a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump folly to v2024.01.01.00 (#14452)",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -16,8 +16,8 @@
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
     <!-- When bumping the Folly version, be sure to bump the git hash of that version's commit and build Folly.vcxproj (to update its cgmanifest.json) too. -->
-    <FollyVersion>2023.11.06.00</FollyVersion>
-    <FollyCommitHash>d62707bf4dc8c58bcc317260611b8cbe25c7f444</FollyCommitHash>
+    <FollyVersion>2024.01.01.00</FollyVersion>
+    <FollyCommitHash>234d39a36a43106747d10cc19efada72fd810dd3</FollyCommitHash>
     <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->
     <FmtVersion>10.1.0</FmtVersion>
     <FmtCommitHash>ca2e3685b160617d3d95fcd9e789c4e06ca88</FmtCommitHash>

--- a/vnext/Folly/TEMP_UntilFollyUpdate/json.cpp
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/json.cpp
@@ -849,6 +849,10 @@ void escapeStringImpl(
       }
       auto prefix = firstEscapableInWord<EnableExtraAsciiEscapes>(word, opts);
       DCHECK_LE(prefix, avail);
+      // [Windows Sometimes prefix is completely wrong (corrupt?), only in Release, causing a later AV (see issue #14394).
+      // Prefix should always be <= avail, capping it here as a workaround, hoping the assert above eventually catches this in Debug.
+      prefix = std::min(prefix, (size_t)avail);
+      // Windows]
       firstEsc += prefix;
       if (prefix < 8) {
         break;

--- a/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.cpp
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ struct to_ascii_array {
     return data.data[index];
   }
 };
-
 template <uint64_t Base, typename Alphabet>
 alignas(kIsMobile ? sizeof(size_t) : hardware_constructive_interference_size)
     typename to_ascii_array<Base, Alphabet>::data_type_ const
@@ -94,13 +93,13 @@ extern template to_ascii_table<10, to_ascii_alphabet_upper>::data_type_ const
 extern template to_ascii_table<16, to_ascii_alphabet_upper>::data_type_ const
     to_ascii_table<16, to_ascii_alphabet_upper>::data;
 
-template <uint64_t Base, typename I>
+template <uint64_t Base, typename Int>
 struct to_ascii_powers {
-  static constexpr size_t size_(I v) {
+  static constexpr size_t size_(Int v) {
     return 1 + (v < Base ? 0 : size_(v / Base));
   }
-  static constexpr size_t const size = size_(~I(0));
-  using data_type_ = c_array<I, size>;
+  static constexpr size_t const size = size_(~Int(0));
+  using data_type_ = c_array<Int, size>;
   static constexpr data_type_ data_() {
     data_type_ result{};
     for (size_t i = 0; i < size; ++i) {
@@ -111,12 +110,14 @@ struct to_ascii_powers {
   // @lint-ignore CLANGTIDY
   static data_type_ const data;
 };
-template <uint64_t Base, typename I>
-constexpr size_t const to_ascii_powers<Base, I>::size;
-template <uint64_t Base, typename I>
+#if FOLLY_CPLUSPLUS < 201703L
+template <uint64_t Base, typename Int>
+constexpr size_t const to_ascii_powers<Base, Int>::size;
+#endif
+template <uint64_t Base, typename Int>
 alignas(hardware_constructive_interference_size)
-    typename to_ascii_powers<Base, I>::data_type_ const
-    to_ascii_powers<Base, I>::data = to_ascii_powers<Base, I>::data_();
+    typename to_ascii_powers<Base, Int>::data_type_ const
+    to_ascii_powers<Base, Int>::data = to_ascii_powers<Base, Int>::data_();
 
 extern template to_ascii_powers<8, uint64_t>::data_type_ const
     to_ascii_powers<8, uint64_t>::data;
@@ -151,7 +152,7 @@ template <uint64_t Base>
 FOLLY_ALWAYS_INLINE size_t to_ascii_size_array(uint64_t v) {
   using powers = to_ascii_powers<Base, uint64_t>;
   for (size_t i = 0u; i < powers::size; ++i) {
-    if (FOLLY_LIKELY(v < powers::data.data[i])) {
+    if (FOLLY_UNLIKELY(v < powers::data.data[i])) {
       return i + size_t(i == 0);
     }
   }
@@ -272,6 +273,15 @@ FOLLY_ALWAYS_INLINE size_t to_ascii_with_table(char* out, uint64_t v) {
   return size;
 }
 
+// Assumes that size >= number of digits in v. If >, the result is left-padded
+// with 0s.
+template <uint64_t Base, typename Alphabet>
+FOLLY_ALWAYS_INLINE void to_ascii_with_route(
+    char* outb, size_t size, uint64_t v) {
+  kIsMobile //
+      ? to_ascii_with_array<Base, Alphabet>(outb, size, v)
+      : to_ascii_with_table<Base, Alphabet>(outb, size, v);
+}
 template <uint64_t Base, typename Alphabet>
 FOLLY_ALWAYS_INLINE size_t
 to_ascii_with_route(char* outb, char const* oute, uint64_t v) {
@@ -279,9 +289,7 @@ to_ascii_with_route(char* outb, char const* oute, uint64_t v) {
   if (FOLLY_UNLIKELY(oute < outb || size_t(oute - outb) < size)) {
     return 0;
   }
-  kIsMobile //
-      ? to_ascii_with_array<Base, Alphabet>(outb, size, v)
-      : to_ascii_with_table<Base, Alphabet>(outb, size, v);
+  to_ascii_with_route<Base, Alphabet>(outb, size, v);
   return size;
 }
 template <uint64_t Base, typename Alphabet, size_t N>

--- a/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,14 +61,14 @@ using to_ascii_alphabet_upper = to_ascii_alphabet<true>;
 //  In base 10, u64 requires at most 20 bytes, u32 at most 10, u16 at most 5,
 //  and u8 at most 3.
 /*
-template <uint64_t Base, typename I>
+template <uint64_t Base, typename Int>
 FOLLY_INLINE_VARIABLE constexpr size_t to_ascii_size_max =
-  detail::to_ascii_powers<Base, I>::size;
+    detail::to_ascii_powers<Base, Int>::size;
 */
 //  to_ascii_size_max_decimal
 //
 //  An alias to to_ascii_size_max<10>.
-template <typename I>
+template <typename Int>
 FOLLY_INLINE_VARIABLE constexpr size_t to_ascii_size_max_decimal;
 
 template <>
@@ -170,7 +170,7 @@ size_t to_ascii_upper(char (&out)[N], uint64_t v) {
 //
 //  An alias to to_ascii<10, false>.
 //
-//  async-signals-afe
+//  async-signal-safe
 inline size_t to_ascii_decimal(char* outb, char const* oute, uint64_t v) {
   return to_ascii_lower<10>(outb, oute, v);
 }

--- a/vnext/Folly/cgmanifest.json
+++ b/vnext/Folly/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Type": "git",
                 "Git": {
                   "RepositoryUrl": "https://github.com/facebook/folly",
-                  "CommitHash": "d62707bf4dc8c58bcc317260611b8cbe25c7f444"
+                  "CommitHash": "234d39a36a43106747d10cc19efada72fd810dd3"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
## Description

This PR bumps Folly to v2024.01.01.00.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Catching up with what upstream is using.

### What
This PR bumps Folly to v2024.01.01.00. It also fixes an issue in Folly and how nugets are published in PR.

Closes #14394

## Screenshots
N/A

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14483)