### PR TITLE
Update creaternw scripts to use RNW devDependencies

### DIFF
--- a/change/react-native-windows-a6d5e620-66e7-4d2a-8c90-de8920f57845.json
+++ b/change/react-native-windows-a6d5e620-66e7-4d2a-8c90-de8920f57845.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update creaternw scripts to use RNW devDependencies",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/creaternwapp.cmd
+++ b/vnext/Scripts/creaternwapp.cmd
@@ -61,8 +61,8 @@ if not "%part%"=="" (
 
 if %LINK_RNW% equ 1 (
   @echo creaternwapp.cmd Determining versions from local RNW repo at %RNW_ROOT%
-  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" peerDependencies.react') do @set R_VERSION=%%a
-  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" peerDependencies.react-native') do @set RN_VERSION=%%a
+  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" devDependencies.react') do @set R_VERSION=%%a
+  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" devDependencies.react-native') do @set RN_VERSION=%%a
   for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" version') do @set RNW_VERSION=%%a
   for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" dependencies.@react-native-community/cli') do @set RNCLI_VERSION=%%a
 )
@@ -74,7 +74,7 @@ if "%RNW_VERSION%"=="" (
 
 if "%RN_VERSION%"=="" (
   @echo creaternwapp.cmd Determining react-native version from react-native-windows dependency
-  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% peerDependencies.react-native') do @set RN_VERSION=%%a
+  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% devDependencies.react-native') do @set RN_VERSION=%%a
 )
 
 if "%RNCLI_VERSION%"=="" (
@@ -84,7 +84,7 @@ if "%RNCLI_VERSION%"=="" (
 
 if "%R_VERSION%"=="" (
   @echo creaternwapp.cmd Determining react version from react-native-windows dependency
-  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% peerDependencies.react') do @set R_VERSION=%%a
+  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% devDependencies.react') do @set R_VERSION=%%a
 )
 
 @echo creaternwapp.cmd Determining concrete versions for react@%R_VERSION%, react-native@%RN_VERSION%, @react-native-community/cli@%RNCLI_VERSION%, and react-native-windows@%RNW_VERSION% 

--- a/vnext/Scripts/creaternwlib.cmd
+++ b/vnext/Scripts/creaternwlib.cmd
@@ -63,8 +63,8 @@ if not "%part%"=="" (
 
 if %LINK_RNW% equ 1 (
   @echo creaternwlib.cmd Determining versions from local RNW repo at %RNW_ROOT%
-  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" peerDependencies.react') do @set R_VERSION=%%a
-  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" peerDependencies.react-native') do @set RN_VERSION=%%a
+  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" devDependencies.react') do @set R_VERSION=%%a
+  for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" devDependencies.react-native') do @set RN_VERSION=%%a
   for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" version') do @set RNW_VERSION=%%a
   for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" dependencies.@react-native-community/cli') do @set RNCLI_VERSION=%%a
 )
@@ -76,7 +76,7 @@ if "%RNW_VERSION%"=="" (
 
 if "%RN_VERSION%"=="" (
   @echo creaternwlib.cmd Determining react-native version from react-native-windows dependency
-  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% peerDependencies.react-native') do @set RN_VERSION=%%a
+  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% devDependencies.react-native') do @set RN_VERSION=%%a
 )
 
 if "%RNCLI_VERSION%"=="" (
@@ -86,7 +86,7 @@ if "%RNCLI_VERSION%"=="" (
 
 if "%R_VERSION%"=="" (
   @echo creaternwlib.cmd Determining react version from react-native-windows dependency
-  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% peerDependencies.react') do @set R_VERSION=%%a
+  for /f "delims=" %%a in ('npm show react-native-windows@%RNW_VERSION% devDependencies.react') do @set R_VERSION=%%a
 )
 
 @echo creaternwlib.cmd Determining concrete versions for react@%R_VERSION%, react-native@%RN_VERSION%, and react-native-windows@%RNW_VERSION% 


### PR DESCRIPTION
## Description

The new `creaternwapp.cmd` and creaternwlib.cmd scripts have an issue where new RN projects won't use the range qualifier in peerDependencies (so you ask for `react-native@^0.74.0` and you get `react-native@0.74.0` even though `react-native@0.74.5` exists).

This PR fixes the script to, when determining which `react` and `react-native` version to use, to look at `react-native-windows`'s devDependency, which is more reliable than the peerDependency.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Unexpectedly having the wrong RN project version causes all sorts of build issues and confusion, and is easy to miss.

### What
See above.

## Screenshots
N/A

## Testing
Verfied it works for new  projects.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14491)