### PR TITLE
Use creaternwapp.cmd and creaternwlib.cmd scripts to create new projects in CI

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -71,14 +71,6 @@ steps:
           artifactName: CliInitNuGet.${{parameters.platform}}.${{parameters.configuration}}
           targetPath: $(System.DefaultWorkingDirectory)/NugetRootFinal
 
-  - script: |
-      call yarn config set npmRegistryServer http://localhost:4873
-      call yarn config set unsafeHttpWhitelist --json "[\"localhost\"]"
-    displayName: yarn config verdaccio
-    workingDirectory: $(Agent.BuildDirectory)
-    env:
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
   - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
         $(Build.SourcesDirectory)\vnext\Scripts\creaternwapp.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /lt ${{ parameters.template }} testcli

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -71,67 +71,37 @@ steps:
           artifactName: CliInitNuGet.${{parameters.platform}}.${{parameters.configuration}}
           targetPath: $(System.DefaultWorkingDirectory)/NugetRootFinal
 
-  - ${{ if endsWith(parameters.template, '-app') }}:
-    - script: |
-        npx --yes @react-native-community/cli@latest init testcli --version $(reactNativeDevDependency) --verbose --skip-install --install-pods false --skip-git-init true
-      displayName: Init new app project with @react-native-community/cli init
-      workingDirectory: $(Agent.BuildDirectory)
-
-  - ${{ if endsWith(parameters.template, '-lib') }}:
-    - script: |
-        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type turbo-module --react-native-version $(reactNativeDevDependency) --example vanilla testcli
-      displayName: Init new lib project with create-react-native-library
-      workingDirectory: $(Agent.BuildDirectory)
-
-  - script: |
-      call yarn install
-    displayName: pre-windows yarn install
-    workingDirectory: $(Agent.BuildDirectory)\testcli
-    env:
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
   - script: |
       call yarn config set npmRegistryServer http://localhost:4873
       call yarn config set unsafeHttpWhitelist --json "[\"localhost\"]"
     displayName: yarn config verdaccio
-    workingDirectory: $(Agent.BuildDirectory)\testcli
+    workingDirectory: $(Agent.BuildDirectory)
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
   - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
-        call yarn add react-native-windows@$(npmVersion)
-      displayName: yarn add react-native-windows
-      workingDirectory: $(Agent.BuildDirectory)\testcli
+        $(Build.SourcesDirectory)\vnext\Scripts\creaternwapp.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /lt ${{ parameters.template }} testcli
+      displayName: Init new app project with creaternwapp.cmd
+      workingDirectory: $(Agent.BuildDirectory)
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
   - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
-        call yarn add react-native-windows@$(npmVersion) --dev
-      displayName: yarn add react-native-windows dev/peer
-      workingDirectory: $(Agent.BuildDirectory)\testcli
+        $(Build.SourcesDirectory)\vnext\Scripts\creaternwlib.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) testcli
+      displayName: Init new lib project with creaternwlib.cmd
+      workingDirectory: $(Agent.BuildDirectory)
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-  - script: |
-      call npx @react-native-community/cli init-windows --template ${{ parameters.template }} --overwrite --logging ${{ parameters.additionalInitArguments }}
-    displayName: Call @react-native-community/cli init-windows
-    workingDirectory: $(Agent.BuildDirectory)\testcli
-    env:
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
-  
-  - script: |
-      call yarn install
-    displayName: post-windows yarn install
-    workingDirectory: $(Agent.BuildDirectory)\testcli
-    env:
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
   - ${{ if eq(parameters.UseChakra, true) }}:
     - template:  set-experimental-feature.yml
       parameters:
-        workingDir: ..\testcli\windows
+        ${{ if endsWith(parameters.template, '-lib') }}:
+          workingDir: $(Agent.BuildDirectory)\testcli\example\windows
+        ${{ else }}:
+          workingDir: $(Agent.BuildDirectory)\testcli\windows
         feature: UseHermes
         value: false
 

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -73,7 +73,7 @@ steps:
 
   - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
-        $(Build.SourcesDirectory)\vnext\Scripts\creaternwapp.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /lt ${{ parameters.template }} testcli
+        $(Build.SourcesDirectory)\vnext\Scripts\creaternwapp.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /lt ${{ parameters.template }} /verdaccio testcli
       displayName: Init new app project with creaternwapp.cmd
       workingDirectory: $(Agent.BuildDirectory)
       env:
@@ -81,7 +81,7 @@ steps:
 
   - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
-        $(Build.SourcesDirectory)\vnext\Scripts\creaternwlib.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) testcli
+        $(Build.SourcesDirectory)\vnext\Scripts\creaternwlib.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /verdaccio testcli
       displayName: Init new lib project with creaternwlib.cmd
       workingDirectory: $(Agent.BuildDirectory)
       env:

--- a/.ado/templates/verdaccio-start.yml
+++ b/.ado/templates/verdaccio-start.yml
@@ -20,5 +20,11 @@ steps:
     - script: npx beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --verbose --access public --changehint "Run `yarn change` from root of repo to generate a change file."
       displayName: Publish packages to verdaccio
     
-  - script: yarn config set registry http://localhost:4873
-    displayName: Modify yarn config to point to local verdaccio server
+  - script: | 
+      call npm config set registry http://localhost:4873
+      call yarn config set registry http://localhost:4873
+      call yarn config set npmRegistryServer http://localhost:4873
+      call yarn config set unsafeHttpWhitelist --json "[\"localhost\"]"
+    displayName: Modify npm/yarn config to point to local verdaccio server
+    env:
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/.ado/templates/verdaccio-stop.yml
+++ b/.ado/templates/verdaccio-stop.yml
@@ -19,3 +19,12 @@ steps:
         targetPath: 'verdaccio.log'
         artifact: '$(Agent.JobName).Verdaccio.log-$(System.JobAttempt)'
       condition: failed()
+
+  - script: | 
+      call npm config delete registry
+      call yarn config delete registry
+      call yarn config delete npmRegistryServer
+      call yarn config delete unsafeHttpWhitelist
+    displayName: Reset npm/yarn config to stop poiting at local verdaccio server
+    env:
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/change/react-native-windows-75d0a98d-9db5-4a73-a321-0d0a42767855.json
+++ b/change/react-native-windows-75d0a98d-9db5-4a73-a321-0d0a42767855.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use creaternwapp.cmd and creaternwlib.cmd scripts to create new projects in CI",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/creaternwapp.cmd
+++ b/vnext/Scripts/creaternwapp.cmd
@@ -64,6 +64,11 @@ if not "%part%"=="" (
 )
 :loopend
 
+if %USE_VERDACCIO% equ 1 (
+  @echo creaternwapp.cmd: Setting npm to use verdaccio at http://localhost:4873
+  call npm config set registry http://localhost:4873
+)
+
 if %LINK_RNW% equ 1 (
   @echo creaternwapp.cmd Determining versions from local RNW repo at %RNW_ROOT%
   for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" peerDependencies.react') do @set R_VERSION=%%a
@@ -127,7 +132,7 @@ call git add .
 call git commit -m "npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% --verbose --skip-install --install-pods false --skip-git-init true"
 
 if %USE_VERDACCIO% equ 1 (
-  @echo creaternwapp.cmd: Setting npm registry to verdaccio at http://localhost:4873
+  @echo creaternwapp.cmd: Setting yarn to use verdaccio at http://localhost:4873
   call yarn config set registry http://localhost:4873
   call yarn config set npmRegistryServer http://localhost:4873
   call yarn config set unsafeHttpWhitelist --json "[\"localhost\"]"

--- a/vnext/Scripts/creaternwapp.cmd
+++ b/vnext/Scripts/creaternwapp.cmd
@@ -10,6 +10,7 @@ REM /rn [version]   Use react-native@version (default: latest)
 REM /rnw [version]  Use react-native-windows@version (default: latest)
 REM /lt [template]  Use template (default: cpp-app)
 REM /linkrnw        Use your local RNW repo at RNW_ROOT
+REM /verdaccio      Configure new project to use verdaccio (used in CI)
 REM
 REM Requirements:
 REM - You've set the RNW_ROOT environment variable with the path to your clone
@@ -28,7 +29,9 @@ set R_VERSION=
 set RN_VERSION=
 set RNW_VERSION=
 set RNCLI_VERSION=
+
 set LINK_RNW=0
+set USE_VERDACCIO=0
 
 :loop
 set part=%1
@@ -36,6 +39,8 @@ set param=%2
 if not "%part%"=="" (
   if "%part%"=="/linkrnw" (
       set LINK_RNW=1
+  ) else if "%part%"=="/verdaccio" (
+      set USE_VERDACCIO=1
   ) else if "%part%"=="/r" (
       set R_VERSION=%param%
       shift
@@ -113,12 +118,20 @@ if not "x%RN_VERSION:nightly=%"=="x%RN_VERSION%" (
   pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli-platform-ios"": "".*""', '""@react-native-community/cli-platform-ios"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
 )
 
+@echo creaternwapp.cmd: Calling yarn install
 call yarn install
 
 @echo creaternwapp.cmd: Creating commit to save current state
 if not exist ".git\" call git init .
 call git add .
 call git commit -m "npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% --verbose --skip-install --install-pods false --skip-git-init true"
+
+if %USE_VERDACCIO% equ 1 (
+  @echo creaternwapp.cmd: Setting npm registry to verdaccio at http://localhost:4873
+  call yarn config set registry http://localhost:4873
+  call yarn config set npmRegistryServer http://localhost:4873
+  call yarn config set unsafeHttpWhitelist --json "[\"localhost\"]"
+)
 
 @echo creaternwapp.cmd: Adding RNW dependency to app
 call yarn add react-native-windows@%RNW_VERSION%
@@ -135,6 +148,7 @@ if %LINK_RNW% equ 1 (
   )
 )
 
+@echo creaternwapp.cmd: Calling yarn install
 call yarn install
 
 @echo creaternwapp.cmd: Creating commit to save current state

--- a/vnext/Scripts/creaternwlib.cmd
+++ b/vnext/Scripts/creaternwlib.cmd
@@ -65,6 +65,11 @@ if not "%part%"=="" (
 )
 :loopend
 
+if %USE_VERDACCIO% equ 1 (
+  @echo creaternwlib.cmd: Setting npm to use verdaccio at http://localhost:4873
+  call npm config set registry http://localhost:4873
+)
+
 if %LINK_RNW% equ 1 (
   @echo creaternwlib.cmd Determining versions from local RNW repo at %RNW_ROOT%
   for /f "delims=" %%a in ('npm show "%RNW_ROOT%\vnext" peerDependencies.react') do @set R_VERSION=%%a
@@ -129,7 +134,7 @@ if not "x%RN_VERSION:nightly=%"=="x%RN_VERSION%" (
 call yarn install
 
 if %USE_VERDACCIO% equ 1 (
-  @echo creaternwapp.cmd: Setting npm registry to verdaccio at http://localhost:4873
+  @echo creaternwlib.cmd: Setting yarn to use verdaccio at http://localhost:4873
   call yarn config set registry http://localhost:4873
   call yarn config set npmRegistryServer http://localhost:4873
   call yarn config set unsafeHttpWhitelist --json "[\"localhost\"]"

--- a/vnext/Scripts/creaternwlib.cmd
+++ b/vnext/Scripts/creaternwlib.cmd
@@ -10,6 +10,7 @@ REM /rn [version]   Use react-native@version (default: latest)
 REM /rnw [version]  Use react-native-windows@version (default: latest)
 REM /lt [template]  Use create-react-native-library template (default: turbo-module)
 REM /linkrnw        Use your local RNW repo at RNW_ROOT
+REM /verdaccio      Configure new project to use verdaccio (used in CI)
 REM
 REM Requirements:
 REM - You've set the RNW_ROOT environment variable with the path to your clone
@@ -31,6 +32,7 @@ set RNCLI_VERSION=
 set RNW_VERSION=
 
 set LINK_RNW=0
+set USE_VERDACCIO=0
 
 :loop
 set part=%1
@@ -38,6 +40,8 @@ set param=%2
 if not "%part%"=="" (
   if "%part%"=="/linkrnw" (
       set LINK_RNW=1
+  ) else if "%part%"=="/verdaccio" (
+      set USE_VERDACCIO=1
   ) else if "%part%"=="/r" (
       set R_VERSION=%param%
       shift
@@ -121,7 +125,15 @@ if not "x%RN_VERSION:nightly=%"=="x%RN_VERSION%" (
   popd
 )
 
+@echo creaternwlib.cmd: Calling yarn install
 call yarn install
+
+if %USE_VERDACCIO% equ 1 (
+  @echo creaternwapp.cmd: Setting npm registry to verdaccio at http://localhost:4873
+  call yarn config set registry http://localhost:4873
+  call yarn config set npmRegistryServer http://localhost:4873
+  call yarn config set unsafeHttpWhitelist --json "[\"localhost\"]"
+)
 
 @echo creaternwlib.cmd Adding RNW dependency to library
 call yarn add react-native-windows@%RNW_VERSION% --dev
@@ -132,6 +144,7 @@ if %LINK_RNW% equ 1 (
   call yarn link %RNW_ROOT%\vnext
 )
 
+@echo creaternwlib.cmd: Calling yarn install
 call yarn install
 
 @echo creaternwlib.cmd Creating commit to save current state


### PR DESCRIPTION
## Description

This PR updates the new project steps in `react-native-init-windows.yml` to use the `creaternwapp.cmd` and `creaternwlib.cmd` scripts instead of calling the steps manually.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
The scripts were created to help us tackle the increasingly difficult process of creating new projects (esp. in main) for testing. This PR makes sure that all innovations and fixes in those scripts are also used by our CLI testing.

### What
Removed the new projects tasks and logic from `react-native-init-windows.yml` and instead just call the `creaternwapp.cmd` and `creaternwlib.cmd` scripts. Added a flag to enable using verdaccio (must sometimes be set after project is created) and also moved the configuration for consuming verdaccio into the verdaccio start/stop templates.

## Screenshots
N/A

## Testing
Verified tests worked.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14492)