### PR TITLE
[Fabric] Implement onProgress for Image

### DIFF
--- a/change/react-native-windows-eed51fa4-43c0-4164-8892-4c3fa0571940.json
+++ b/change/react-native-windows-eed51fa4-43c0-4164-8892-4c3fa0571940.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement onProgress for Image",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -20,7 +20,9 @@ const loadingImageUri =
 const largeImageUri =
   'https://cdn.freebiesupply.com/logos/large/2x/react-logo-png-transparent.png';
 
-const smallImageUri =
+const smallImageUri = 'https://reactnative.dev/img/tiny_logo.png';
+
+const flowerImageUri =
   'https://cdn.pixabay.com/photo/2021/08/02/00/10/flowers-6515538_1280.jpg';
 
 const reactLogoUri = 'https://reactjs.org/logo-og.png';
@@ -74,6 +76,8 @@ export default class Bootstrap extends React.Component<
     let imageUri = '';
     if (value === 'small') {
       imageUri = smallImageUri;
+    } else if (value === 'flower') {
+      imageUri = flowerImageUri;
     } else if (value === 'large') {
       imageUri = largeImageUri;
     } else if (value === 'data-svg') {
@@ -138,6 +142,10 @@ export default class Bootstrap extends React.Component<
     this.setSelection(value);
   };
 
+  handleOnProgress = (event: any) => {
+    const {progress, loaded, total} = event.nativeEvent;
+    console.log(`Progress: ${progress}, Loaded = ${loaded} , Total = ${total}`);
+  };
   render() {
     const resizeModes = [
       {label: 'center', value: 'center'},
@@ -149,6 +157,7 @@ export default class Bootstrap extends React.Component<
 
     const imageSources = [
       {label: 'small', value: 'small'},
+      {label: 'flower', value: 'flower'},
       {label: 'large', value: 'large'},
       {label: 'data', value: 'data'},
       {label: 'data-svg', value: 'data-svg'},
@@ -258,6 +267,7 @@ export default class Bootstrap extends React.Component<
               onLoad={() => console.log('onLoad')}
               onLoadStart={() => console.log('onLoadStart')}
               onLoadEnd={() => console.log('onLoadEnd')}
+              onProgress={this.handleOnProgress}
             />
           )}
         </View>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -31,32 +31,29 @@ extern "C" HRESULT WINAPI WICCreateImagingFactory_Proxy(UINT SDKVersion, IWICIma
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 ImageComponentView::WindowsImageResponseObserver::WindowsImageResponseObserver(
+    winrt::Microsoft::ReactNative::ReactContext const &reactContext,
     winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::implementation::ImageComponentView> wkImage)
-    : m_wkImage(std::move(wkImage)) {}
+    : m_reactContext(reactContext), m_wkImage(std::move(wkImage)) {}
 
 void ImageComponentView::WindowsImageResponseObserver::didReceiveProgress(float progress, int64_t loaded, int64_t total)
     const {
-  if (auto imgComponentView = m_wkImage.get()) {
-    int loadedInt = static_cast<int>(loaded);
-    int totalInt = static_cast<int>(total);
-    imgComponentView->m_reactContext.UIDispatcher().Post([progress, wkImage = m_wkImage, loadedInt, totalInt]() {
-      if (auto image = wkImage.get()) {
-        image->didReceiveProgress(progress, loadedInt, totalInt);
-      }
-    });
-  }
+  int loadedInt = static_cast<int>(loaded);
+  int totalInt = static_cast<int>(total);
+  m_reactContext.UIDispatcher().Post([progress, wkImage = m_wkImage, loadedInt, totalInt]() {
+    if (auto image = wkImage.get()) {
+      image->didReceiveProgress(progress, loadedInt, totalInt);
+    }
+  });
 }
 
 void ImageComponentView::WindowsImageResponseObserver::didReceiveImage(
     facebook::react::ImageResponse const &imageResponse) const {
-  if (auto imgComponentView{m_wkImage.get()}) {
-    auto imageResponseImage = std::static_pointer_cast<ImageResponseImage>(imageResponse.getImage());
-    imgComponentView->m_reactContext.UIDispatcher().Post([imageResponseImage, wkImage = m_wkImage]() {
-      if (auto image{wkImage.get()}) {
-        image->didReceiveImage(imageResponseImage);
-      }
-    });
-  }
+  auto imageResponseImage = std::static_pointer_cast<ImageResponseImage>(imageResponse.getImage());
+  m_reactContext.UIDispatcher().Post([imageResponseImage, wkImage = m_wkImage]() {
+    if (auto image{wkImage.get()}) {
+      image->didReceiveImage(imageResponseImage);
+    }
+  });
 }
 
 void ImageComponentView::WindowsImageResponseObserver::didReceiveFailure(
@@ -175,7 +172,7 @@ void ImageComponentView::updateState(
   auto newImageState = std::static_pointer_cast<facebook::react::ImageShadowNode::ConcreteState const>(state);
 
   if (!m_imageResponseObserver) {
-    m_imageResponseObserver = std::make_shared<WindowsImageResponseObserver>(get_weak());
+    m_imageResponseObserver = std::make_shared<WindowsImageResponseObserver>(this->m_reactContext, get_weak());
   }
 
   setStateAndResubscribeImageResponseObserver(newImageState);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -85,6 +85,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ViewComponen
 
   void ImageLoadStart() noexcept;
   void ImageLoaded() noexcept;
+  void didReceiveProgress(float progress, int loaded, int total) noexcept;
   void didReceiveImage(const std::shared_ptr<ImageResponseImage> &wicbmp) noexcept;
   void didReceiveFailureFromObserver(const facebook::react::ImageLoadError &error) noexcept;
   void setStateAndResubscribeImageResponseObserver(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -71,6 +71,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ViewComponen
   struct WindowsImageResponseObserver : facebook::react::ImageResponseObserver {
    public:
     WindowsImageResponseObserver(
+        winrt::Microsoft::ReactNative::ReactContext const &reactContext,
         winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::implementation::ImageComponentView> wkImage);
     void didReceiveProgress(float progress, int64_t loaded, int64_t total) const override;
     void didReceiveImage(const facebook::react::ImageResponse &imageResponse) const override;
@@ -78,6 +79,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ViewComponen
 
    private:
     winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::implementation::ImageComponentView> m_wkImage;
+    winrt::Microsoft::ReactNative::ReactContext m_reactContext;
   };
 
   void ensureDrawingSurface() noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
@@ -78,7 +78,9 @@ wicBitmapSourceFromStream(const winrt::Windows::Storage::Streams::IRandomAccessS
 }
 
 winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::ImageResponse>
-WindowsImageManager::GetImageRandomAccessStreamAsync(ReactImageSource source) const {
+WindowsImageManager::GetImageRandomAccessStreamAsync(
+    ReactImageSource source,
+    std::function<void(uint64_t progress, uint64_t total)> progressCallback) const {
   co_await winrt::resume_background();
 
   winrt::Windows::Foundation::Uri uri(winrt::to_hstring(source.uri));
@@ -130,8 +132,28 @@ WindowsImageManager::GetImageRandomAccessStreamAsync(ReactImageSource source) co
         response.ReasonPhrase(), response.StatusCode(), response.Headers());
   }
 
+  auto inputStream = co_await response.Content().ReadAsInputStreamAsync();
+  uint64_t total = response.Content().Headers().ContentLength().GetUInt64();
+  uint64_t progress = 0;
+
   winrt::Windows::Storage::Streams::InMemoryRandomAccessStream memoryStream;
-  co_await response.Content().WriteToStreamAsync(memoryStream);
+  winrt::Windows::Storage::Streams::DataReader reader(inputStream);
+  constexpr uint32_t bufferSize = 16 * 1024;
+
+  while (true) {
+    uint32_t loaded = co_await reader.LoadAsync(bufferSize);
+    if (loaded == 0)
+      break;
+
+    auto buffer = reader.ReadBuffer(loaded);
+    co_await memoryStream.WriteAsync(buffer);
+    progress += loaded;
+
+    if (progressCallback) {
+      progressCallback(progress, total);
+    }
+  }
+
   memoryStream.Seek(0);
 
   co_return winrt::Microsoft::ReactNative::Composition::StreamImageResponse(memoryStream.CloneStream());
@@ -160,7 +182,13 @@ facebook::react::ImageRequest WindowsImageManager::requestImage(
     source.width = imageSource.size.width;
     source.sourceType = ImageSourceType::Download;
 
-    imageResponseTask = GetImageRandomAccessStreamAsync(source);
+    auto progressCallback = [weakObserverCoordinator](int64_t progress, int64_t total) {
+      if (auto observerCoordinator = weakObserverCoordinator.lock()) {
+        float normalizedProgress = total > 0 ? static_cast<float>(progress) / static_cast<float>(total) : 1.0f;
+        observerCoordinator->nativeImageResponseProgress(normalizedProgress, progress, total);
+      }
+    };
+    imageResponseTask = GetImageRandomAccessStreamAsync(source, progressCallback);
   }
 
   imageResponseTask.Completed([weakObserverCoordinator](auto asyncOp, auto status) {
@@ -193,11 +221,6 @@ facebook::react::ImageRequest WindowsImageManager::requestImage(
         auto errorInfo = std::make_shared<facebook::react::ImageErrorInfo>();
         errorInfo->error = FormatHResultError(winrt::hresult_error(asyncOp.ErrorCode()));
         observerCoordinator->nativeImageResponseFailed(facebook::react::ImageLoadError(errorInfo));
-        break;
-      }
-      case winrt::Windows::Foundation::AsyncStatus::Started: {
-        // TODO progress? - Can we register for progress off the download task?
-        // observerCoordinator->nativeImageResponseProgress(0.0/*progress*/, 0/*completed*/, 0/*total*/);
         break;
       }
     }

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
@@ -24,7 +24,7 @@ struct WindowsImageManager {
   winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::ImageResponse>
   GetImageRandomAccessStreamAsync(
       ReactImageSource source,
-      std::function<void(uint64_t progress, uint64_t total)> progressCallback) const;
+      std::function<void(uint64_t loaded, uint64_t total)> progressCallback) const;
 
   winrt::Windows::Web::Http::HttpClient m_httpClient;
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
@@ -22,7 +22,9 @@ struct WindowsImageManager {
 
  private:
   winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::ImageResponse>
-  GetImageRandomAccessStreamAsync(ReactImageSource source) const;
+  GetImageRandomAccessStreamAsync(
+      ReactImageSource source,
+      std::function<void(uint64_t progress, uint64_t total)> progressCallback) const;
 
   winrt::Windows::Web::Http::HttpClient m_httpClient;
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Implement the onProgress property for the fabric implementation of Image.

Note: At one point there was a TODO for this in our new fabric code.

This property was not available in RNW Paper but could be implemented for Fabric.

See https://reactnative.dev/docs/image#onprogress for details.

Resolves https://github.com/microsoft/react-native-windows/issues/13118 and https://github.com/microsoft/react-native-windows/issues/13752

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

Added a progress Callback during request start for image downloading that keeps track of progress and invokes `observerCoordinator->nativeImageResponseProgress`

Refer: 
https://learn.microsoft.com/en-us/uwp/api/windows.web.http.httpstringcontent.writetostreamasync?view=winrt-26100
https://learn.microsoft.com/en-us/uwp/api/windows.web.http.httpstringcontent.readasinputstreamasync?view=winrt-26100

**Key Differences between ReadAsInputStreamAsync and WriteToStreamAsync:**

Aspect | ReadAsInputStreamAsync + Manual Loop | WriteToStreamAsync
-- | -- | --
Control | ✅ Full control over buffer size, read/write logic, progress reporting, cancellation | ❌ Black-box – you don’t control how reading/writing is done internally
Progress Reporting | ✅ You can track progressCallback(progress, total) manually | ❌ No built-in way to hook into progress during transfer
Customization | ✅ Can add error handling, retries, filters, stalls, compression, etc. | ❌ Not customizable, does an internal streaming copy
Code Simplicity | ❌ More verbose | ✅ One-liner – cleaner if you don’t need control
Performance | Slightly more overhead due to manual buffering | Likely optimized under the hood, but not significantly different

## Screenshots
Add any relevant screen captures here from before or after your changes. 

![image](https://github.com/user-attachments/assets/de81657d-65ed-4a69-965e-2b4fa745d385)
![image](https://github.com/user-attachments/assets/a2b133fa-ef43-4f31-9d57-5fd15e022d55)
<img width="620" alt="image" src="https://github.com/user-attachments/assets/36228d42-9c62-40b5-bd5e-7554f39a5d55" />

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

1. Tested in playground composition adding the onProgress event call with large and small size image.
2. Tested in RNWTester e2e fabric test app, testID: **image-network-callback** and **image-network**. _'An Image component can have a network callback'_ and _'A network Image example'_
 
_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_
Yes

Add a brief summary of the change to use in the release notes for the next release.
Implemented onProgress event for Image in Fabric new architecture.
Invoked on download progress.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14493)
