### PR TITLE
[Fabric] Add Custom Font Family in Text Input

### DIFF
--- a/change/react-native-windows-54a72170-7490-4502-8483-62b58bbe76fd.json
+++ b/change/react-native-windows-54a72170-7490-4502-8483-62b58bbe76fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": " Add Custom Font Family support in TextInput",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -311,6 +311,36 @@ const examples: Array<RNTesterModuleExample> = [
     },
   },
   {
+    title: 'Font Family',
+    render: function (): React.Node {
+      return (
+        <View testID="style-fontFamily">
+          <ExampleTextInput
+            defaultValue="Font Family (default)"
+            style={[styles.singleLine]}
+            testID="textinput-family-default"
+          />
+          {[
+            'normal',
+            'Times New Roman',
+            'Courier New',
+            'Arial',
+            'Comic Sans MS',
+            'Georgia',
+            'Verdana',
+          ].map(fontFamily => (
+            <ExampleTextInput
+              defaultValue={`Font Family (${fontFamily})`}
+              key={fontFamily}
+              style={[styles.singleLine, {fontFamily}]}
+              testID={'textinput-family-' + fontFamily}
+            />
+          ))}
+        </View>
+      );
+    },
+  },
+  {
     title: 'Text input, themes and heights',
     render: function (): React.Node {
       return (

--- a/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
@@ -236,7 +236,6 @@ describe('TextInput Tests', () => {
     await component.waitForDisplayed({timeout: 5000});
     const dump = await dumpVisualTree('style-fontFamily');
     expect(dump).toMatchSnapshot();
-    // Behavior not implemented yet
   });
   test('TextInputs can have a font size', async () => {
     const component = await app.findElementByTestID('style-fontSize');

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -561,7 +561,7 @@ exports[`TextInput Tests TextInputs can autocomplete, address country 1`] = `
   "Visual Tree": {
     "Comment": "textinput-autocomplete-address-country",
     "Offset": "0, 0, 0",
-    "Size": "916, 29",
+    "Size": "916, 28",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -639,7 +639,7 @@ exports[`TextInput Tests TextInputs can autocomplete, country 1`] = `
   "Visual Tree": {
     "Comment": "textinput-autocomplete-country",
     "Offset": "0, 0, 0",
-    "Size": "916, 28",
+    "Size": "916, 29",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -872,7 +872,7 @@ exports[`TextInput Tests TextInputs can autogrow 1`] = `
   "Visual Tree": {
     "Comment": "textinput-autogrow",
     "Offset": "0, 0, 0",
-    "Size": "300, 131",
+    "Size": "300, 130",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -1066,12 +1066,12 @@ exports[`TextInput Tests TextInputs can be defined as a set using accessibilityP
       },
       {
         "Offset": "0, 31, 0",
-        "Size": "916, 32",
+        "Size": "916, 33",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "916, 32",
+            "Size": "916, 33",
             "Visual Type": "SpriteVisual",
             "__Children": [
               {
@@ -1217,7 +1217,7 @@ exports[`TextInput Tests TextInputs can be editable 1`] = `
   "Visual Tree": {
     "Comment": "textinput-editable",
     "Offset": "0, 0, 0",
-    "Size": "916, 29",
+    "Size": "916, 28",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -1527,7 +1527,7 @@ exports[`TextInput Tests TextInputs can be set to not editable 1`] = `
   "Visual Tree": {
     "Comment": "textinput-not-editable",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -2679,7 +2679,7 @@ exports[`TextInput Tests TextInputs can have custom return key label, Compile 1`
   "Visual Tree": {
     "Comment": "textinput-return-Compile",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -2835,7 +2835,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, done 1`] = 
   "Visual Tree": {
     "Comment": "textinput-return-done",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -2991,7 +2991,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, next 1`] = 
   "Visual Tree": {
     "Comment": "textinput-return-next",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3069,7 +3069,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, none 1`] = 
   "Visual Tree": {
     "Comment": "textinput-return-none",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3225,7 +3225,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, search 1`] 
   "Visual Tree": {
     "Comment": "textinput-return-search",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3537,7 +3537,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=2 
   "Visual Tree": {
     "Comment": "textinput-letterspacing-2",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3615,7 +3615,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=9 
   "Visual Tree": {
     "Comment": "textinput-letterspacing-9",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4021,7 +4021,7 @@ exports[`TextInput Tests TextInputs can have inline images, drawable props not s
   "Visual Tree": {
     "Comment": "textinput-inline-images-3",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4099,7 +4099,7 @@ exports[`TextInput Tests TextInputs can have inline images, drawableLeft and dra
   "Visual Tree": {
     "Comment": "textinput-inline-images-2",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4177,7 +4177,7 @@ exports[`TextInput Tests TextInputs can have shadows 1`] = `
   "Visual Tree": {
     "Comment": "textinput-shadow",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4790,7 +4790,7 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to false 1`] = `
   "Visual Tree": {
     "Comment": "textinput-readonly-false",
     "Offset": "0, 0, 0",
-    "Size": "916, 28",
+    "Size": "916, 29",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4868,7 +4868,7 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to true 1`] = `
   "Visual Tree": {
     "Comment": "textinput-readyonly",
     "Offset": "0, 0, 0",
-    "Size": "916, 29",
+    "Size": "916, 28",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5718,7 +5718,7 @@ exports[`TextInput Tests TextInputs support secure entry, with placeholder text 
   "Visual Tree": {
     "Comment": "textinput-password-placeholder",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5808,17 +5808,17 @@ exports[`TextInput Tests TextInputs which have a searchbox role should also supp
   "Visual Tree": {
     "Comment": "textinput-searchbox",
     "Offset": "0, 0, 0",
-    "Size": "916, 31",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
         "Offset": "0, 0, 0",
-        "Size": "916, 33",
+        "Size": "916, 32",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "916, 33",
+            "Size": "916, 32",
             "Visual Type": "SpriteVisual",
             "__Children": [
               {

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -78429,6 +78429,234 @@ exports[`snapshotAllPages TextInput 24`] = `
 `;
 
 exports[`snapshotAllPages TextInput 25`] = `
+<View
+  testID="style-fontFamily"
+>
+  <TextInput
+    defaultValue="Font Family (default)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-default"
+  />
+  <TextInput
+    defaultValue="Font Family (normal)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+          {
+            "fontFamily": "normal",
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-normal"
+  />
+  <TextInput
+    defaultValue="Font Family (Times New Roman)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+          {
+            "fontFamily": "Times New Roman",
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-Times New Roman"
+  />
+  <TextInput
+    defaultValue="Font Family (Courier New)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+          {
+            "fontFamily": "Courier New",
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-Courier New"
+  />
+  <TextInput
+    defaultValue="Font Family (Arial)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+          {
+            "fontFamily": "Arial",
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-Arial"
+  />
+  <TextInput
+    defaultValue="Font Family (Comic Sans MS)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+          {
+            "fontFamily": "Comic Sans MS",
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-Comic Sans MS"
+  />
+  <TextInput
+    defaultValue="Font Family (Georgia)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+          {
+            "fontFamily": "Georgia",
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-Georgia"
+  />
+  <TextInput
+    defaultValue="Font Family (Verdana)"
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        [
+          {
+            "fontSize": 16,
+          },
+          {
+            "fontFamily": "Verdana",
+          },
+        ],
+      ]
+    }
+    testID="textinput-family-Verdana"
+  />
+</View>
+`;
+
+exports[`snapshotAllPages TextInput 26`] = `
 <TextInput
   placeholder="If you set height, beware of padding set from themes"
   style={
@@ -78456,7 +78684,7 @@ exports[`snapshotAllPages TextInput 25`] = `
 />
 `;
 
-exports[`snapshotAllPages TextInput 26`] = `
+exports[`snapshotAllPages TextInput 27`] = `
 <View>
   <TextInput
     placeholder="letterSpacing = 0"
@@ -78573,7 +78801,7 @@ exports[`snapshotAllPages TextInput 26`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 27`] = `
+exports[`snapshotAllPages TextInput 28`] = `
 <View>
   <TextInput
     defaultValue="iloveturtles"
@@ -78632,7 +78860,7 @@ exports[`snapshotAllPages TextInput 27`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 28`] = `
+exports[`snapshotAllPages TextInput 29`] = `
 <TextInput
   defaultValue="Can't touch this! (>'-')> ^(' - ')^ <('-'<) (>'-')> ^(' - ')^"
   editable={false}
@@ -78659,7 +78887,7 @@ exports[`snapshotAllPages TextInput 28`] = `
 />
 `;
 
-exports[`snapshotAllPages TextInput 29`] = `
+exports[`snapshotAllPages TextInput 30`] = `
 <View>
   <TextInput
     autoCorrect={true}
@@ -78775,7 +79003,7 @@ exports[`snapshotAllPages TextInput 29`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 30`] = `
+exports[`snapshotAllPages TextInput 31`] = `
 <View>
   <TextInput
     editable={true}
@@ -78868,7 +79096,7 @@ exports[`snapshotAllPages TextInput 30`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 31`] = `
+exports[`snapshotAllPages TextInput 32`] = `
 <View
   style={
     {
@@ -78967,7 +79195,7 @@ exports[`snapshotAllPages TextInput 31`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 32`] = `
+exports[`snapshotAllPages TextInput 33`] = `
 <View
   style={
     {
@@ -79085,7 +79313,7 @@ exports[`snapshotAllPages TextInput 32`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 33`] = `
+exports[`snapshotAllPages TextInput 34`] = `
 <View>
   <TextInput
     autoComplete="country"
@@ -79199,7 +79427,7 @@ exports[`snapshotAllPages TextInput 33`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 34`] = `
+exports[`snapshotAllPages TextInput 35`] = `
 <View>
   <TextInput
     placeholder="returnKeyType: none"
@@ -79420,7 +79648,7 @@ exports[`snapshotAllPages TextInput 34`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 35`] = `
+exports[`snapshotAllPages TextInput 36`] = `
 <View>
   <TextInput
     inlineImageLeft="ic_menu_black_24dp"
@@ -79497,7 +79725,7 @@ exports[`snapshotAllPages TextInput 35`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 36`] = `
+exports[`snapshotAllPages TextInput 37`] = `
 <View>
   <TextInput
     style={
@@ -79527,7 +79755,7 @@ exports[`snapshotAllPages TextInput 36`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 37`] = `
+exports[`snapshotAllPages TextInput 38`] = `
 <View>
   <Text>
     PressIn/PressOut message
@@ -79562,7 +79790,7 @@ exports[`snapshotAllPages TextInput 37`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 38`] = `
+exports[`snapshotAllPages TextInput 39`] = `
 <View>
   <Text>
     Default submit key (Enter):
@@ -79698,7 +79926,7 @@ exports[`snapshotAllPages TextInput 38`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 39`] = `
+exports[`snapshotAllPages TextInput 40`] = `
 [
   <View
     focusable={true}
@@ -79764,7 +79992,7 @@ exports[`snapshotAllPages TextInput 39`] = `
 ]
 `;
 
-exports[`snapshotAllPages TextInput 40`] = `
+exports[`snapshotAllPages TextInput 41`] = `
 [
   <Text>
     Spell Check Enabled:
@@ -79813,7 +80041,7 @@ exports[`snapshotAllPages TextInput 40`] = `
 ]
 `;
 
-exports[`snapshotAllPages TextInput 41`] = `
+exports[`snapshotAllPages TextInput 42`] = `
 <View>
   <Text>
     CaretHidden
@@ -79845,7 +80073,7 @@ exports[`snapshotAllPages TextInput 41`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 42`] = `
+exports[`snapshotAllPages TextInput 43`] = `
 <View>
   <Text>
     Cursorcolor
@@ -79877,7 +80105,7 @@ exports[`snapshotAllPages TextInput 42`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 43`] = `
+exports[`snapshotAllPages TextInput 44`] = `
 <View>
   <Text>
     Shadow
@@ -79915,7 +80143,7 @@ exports[`snapshotAllPages TextInput 43`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 44`] = `
+exports[`snapshotAllPages TextInput 45`] = `
 <View
   accessible={true}
   testID="textinput-set"
@@ -79998,7 +80226,7 @@ exports[`snapshotAllPages TextInput 44`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 45`] = `
+exports[`snapshotAllPages TextInput 46`] = `
 <View
   accessible={true}
   testID="textinput-searchbox"

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -148,6 +148,10 @@ export default class Bootstrap extends React.Component<{}, any> {
             style={[styles.input, {letterSpacing: 5.1}]}
             placeholder={'Letter Spacing'}
           />
+          <TextInput
+            style={[styles.input, {fontFamily: 'Times New Roman'}]}
+            placeholder={'Font Family Time New Roman'}
+          />
           <Button
             title={
               this.state.passwordHidden

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -988,7 +988,8 @@ void WindowsTextInputComponentView::updateProps(
       (oldTextInputProps.textAttributes.allowFontScaling != newTextInputProps.textAttributes.allowFontScaling) ||
       oldTextInputProps.textAttributes.fontWeight != newTextInputProps.textAttributes.fontWeight ||
       !facebook::react::floatEquality(
-          oldTextInputProps.textAttributes.letterSpacing, newTextInputProps.textAttributes.letterSpacing)) {
+          oldTextInputProps.textAttributes.letterSpacing, newTextInputProps.textAttributes.letterSpacing) ||
+      oldTextInputProps.textAttributes.fontFamily != newTextInputProps.textAttributes.fontFamily) {
     m_propBitsMask |= TXTBIT_CHARFORMATCHANGE;
     m_propBits |= TXTBIT_CHARFORMATCHANGE;
   }
@@ -1298,6 +1299,14 @@ void WindowsTextInputComponentView::UpdateCharFormat() noexcept {
   // if (dFontStyle & FS_Underline) {
   //    cfNew.dwEffects |= CFE_UNDERLINE;
   //  }
+
+  // set font family
+  if (!props.textAttributes.fontFamily.empty()) {
+    cfNew.dwMask |= CFM_FACE;
+    std::wstring fontFamily =
+        std::wstring(props.textAttributes.fontFamily.begin(), props.textAttributes.fontFamily.end());
+    wcsncpy_s(cfNew.szFaceName, fontFamily.c_str(), LF_FACESIZE);
+  }
 
   // set char offset
   cfNew.dwMask |= CFM_OFFSET;


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves https://github.com/microsoft/react-native-windows/issues/13662 and some part of https://github.com/microsoft/react-native-windows/issues/14380

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

Support fontFamily in TextInput

## Screenshots
Add any relevant screen captures here from before or after your changes. 

https://github.com/user-attachments/assets/5834d969-50a2-414a-b535-64e7b12897d0


![image](https://github.com/user-attachments/assets/261379b1-7504-4a02-ba3f-669f456a7add)

https://github.com/user-attachments/assets/13572b60-d530-4d8e-8cf8-e6db7139ce83


## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

1. Tested and added new case in playground composite 
2. Tested and added new case in RNTester
![image](https://github.com/user-attachments/assets/6cb9bf70-dc23-4473-8021-15b7374284a3)

## Changelog
Should this change be included in the release notes: _indicate yes or no_
yes

Add a brief summary of the change to use in the release notes for the next release.
Support fontFamily in TextInput


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14495)