### PR TITLE
Make ExperimentalFeatures overridable through props files

### DIFF
--- a/change/react-native-windows-2d88d8d6-ef31-45db-a6e4-f51aa3ed5ab0.json
+++ b/change/react-native-windows-2d88d8d6-ef31-45db-a6e4-f51aa3ed5ab0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make ExperimentalFeatures overridable through props files",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,19 +1,19 @@
 <Project>
   <PropertyGroup>
-    <RnwNewArch>false</RnwNewArch>
-    <UseFabric>false</UseFabric>
-    <UseWinUI3>false</UseWinUI3>
-    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
+    <RnwNewArch Condition="'$(RnwNewArch)' == ''">false</RnwNewArch>
+    <UseFabric Condition="'$(UseFabric)' == ''">false</UseFabric>
+    <UseWinUI3 Condition="'$(UseWinUI3)' == ''">false</UseWinUI3>
+    <ReactExperimentalFeaturesSet Condition="'$(ReactExperimentalFeaturesSet)' == ''">true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
-    <RnwNewArch>true</RnwNewArch>
-    <UseFabric>true</UseFabric>
-    <UseWinUI3>true</UseWinUI3>
-    <UseExperimentalWinUI3>true</UseExperimentalWinUI3>
+    <RnwNewArch Condition="'$(RnwNewArch)' == ''">true</RnwNewArch>
+    <UseFabric Condition="'$(UseFabric)' == ''">true</UseFabric>
+    <UseWinUI3 Condition="'$(UseWinUI3)' == ''">true</UseWinUI3>
+    <UseExperimentalWinUI3 Condition="'$(UseExperimentalWinUI3)' == ''">true</UseExperimentalWinUI3>
   </PropertyGroup>
   <PropertyGroup Condition="'$(SolutionName)'=='Microsoft.ReactNative.NewArch'">
-    <RnwNewArch>true</RnwNewArch>
-    <UseFabric>true</UseFabric>
-    <UseWinUI3>true</UseWinUI3>
+    <RnwNewArch Condition="'$(RnwNewArch)' == ''">true</RnwNewArch>
+    <UseFabric Condition="'$(UseFabric)' == ''">true</UseFabric>
+    <UseWinUI3 Condition="'$(UseWinUI3)' == ''">true</UseWinUI3>
   </PropertyGroup>
 </Project>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,10 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <RnwNewArch Condition="'$(RnwNewArch)' == ''">false</RnwNewArch>
-    <UseFabric Condition="'$(UseFabric)' == ''">false</UseFabric>
-    <UseWinUI3 Condition="'$(UseWinUI3)' == ''">false</UseWinUI3>
-    <ReactExperimentalFeaturesSet Condition="'$(ReactExperimentalFeaturesSet)' == ''">true</ReactExperimentalFeaturesSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <RnwNewArch Condition="'$(RnwNewArch)' == ''">true</RnwNewArch>
     <UseFabric Condition="'$(UseFabric)' == ''">true</UseFabric>
@@ -15,5 +9,12 @@
     <RnwNewArch Condition="'$(RnwNewArch)' == ''">true</RnwNewArch>
     <UseFabric Condition="'$(UseFabric)' == ''">true</UseFabric>
     <UseWinUI3 Condition="'$(UseWinUI3)' == ''">true</UseWinUI3>
+  </PropertyGroup>
+  <!-- Declare the unconditional group last so it does not supersede solution-specific assignments -->
+  <PropertyGroup>
+    <RnwNewArch Condition="'$(RnwNewArch)' == ''">false</RnwNewArch>
+    <UseFabric Condition="'$(UseFabric)' == ''">false</UseFabric>
+    <UseWinUI3 Condition="'$(UseWinUI3)' == ''">false</UseWinUI3>
+    <ReactExperimentalFeaturesSet Condition="'$(ReactExperimentalFeaturesSet)' == ''">true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 </Project>

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
@@ -2,20 +2,21 @@
   "version": 1,
   "dependencies": {
     "net6.0-windows10.0.22621": {
-      "Microsoft.UI.Xaml": {
-        "type": "Direct",
-        "requested": "[2.8.0, )",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "Microsoft.Windows.CsWinRT": {
         "type": "Direct",
         "requested": "[2.2.0, )",
         "resolved": "2.2.0",
         "contentHash": "R8MDVawukHrKgYCFgYaoLfbAna/FrImEFRxDK9k8ITbrXv3KLE5uN6tRqrNV83H4MFdqJ/uiA/hg1cSsXkl0vw=="
+      },
+      "Microsoft.WindowsAppSDK": {
+        "type": "Direct",
+        "requested": "[1.6.240923002, )",
+        "resolved": "1.6.240923002",
+        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
+        }
       },
       "boost": {
         "type": "Transitive",
@@ -48,8 +49,13 @@
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+        "resolved": "1.0.2651.64",
+        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22621.756",
+        "contentHash": "7ZL2sFSioYm1Ry067Kw1hg0SCcW5kuVezC2SwjGbcPE61Nn+gTbH86T73G3LcEOVj0S3IZzNuE/29gZvOLS7VA=="
       },
       "common": {
         "type": "Project",
@@ -74,7 +80,7 @@
           "Folly": "[1.0.0, )",
           "Microsoft.JavaScript.Hermes": "[0.1.23, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
-          "Microsoft.UI.Xaml": "[2.8.0, )",
+          "Microsoft.WindowsAppSDK": "[1.6.240923002, )",
           "ReactCommon": "[1.0.0, )",
           "boost": "[1.83.0, )"
         }

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
@@ -2,21 +2,20 @@
   "version": 1,
   "dependencies": {
     "net6.0-windows10.0.22621": {
+      "Microsoft.UI.Xaml": {
+        "type": "Direct",
+        "requested": "[2.8.0, )",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
       "Microsoft.Windows.CsWinRT": {
         "type": "Direct",
         "requested": "[2.2.0, )",
         "resolved": "2.2.0",
         "contentHash": "R8MDVawukHrKgYCFgYaoLfbAna/FrImEFRxDK9k8ITbrXv3KLE5uN6tRqrNV83H4MFdqJ/uiA/hg1cSsXkl0vw=="
-      },
-      "Microsoft.WindowsAppSDK": {
-        "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
-          "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
-        }
       },
       "boost": {
         "type": "Transitive",
@@ -49,13 +48,8 @@
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
-      },
-      "Microsoft.Windows.SDK.BuildTools": {
-        "type": "Transitive",
-        "resolved": "10.0.22621.756",
-        "contentHash": "7ZL2sFSioYm1Ry067Kw1hg0SCcW5kuVezC2SwjGbcPE61Nn+gTbH86T73G3LcEOVj0S3IZzNuE/29gZvOLS7VA=="
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "common": {
         "type": "Project",
@@ -80,7 +74,7 @@
           "Folly": "[1.0.0, )",
           "Microsoft.JavaScript.Hermes": "[0.1.23, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
-          "Microsoft.WindowsAppSDK": "[1.6.240923002, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )",
           "ReactCommon": "[1.0.0, )",
           "boost": "[1.83.0, )"
         }


### PR DESCRIPTION
## Description

Allow overriding ExperimentalFeatures properties without modifying versioned files.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why

Properties in ExperimentalFeatures.props are set unconditionally.
This prevents them from being overriden ahead of time by previoulsy imported property files (i.e. Directory.Build.local.props).

Note, properties set in the MSBuild command line always take precedence and are not affected by this issue.

### What

Set all properties in ExperimentalFeatures conditionally (only if a given property hasn't been already set in another properties file).


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14501)