### PR TITLE
[0.77] [Fabric] Fix Bug in Narrator Navigation

### DIFF
--- a/change/react-native-windows-62631742-8186-482d-8779-3bdc35d1a131.json
+++ b/change/react-native-windows-62631742-8186-482d-8779-3bdc35d1a131.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Narrator Bug",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-62631742-8186-482d-8779-3bdc35d1a131.json
+++ b/change/react-native-windows-62631742-8186-482d-8779-3bdc35d1a131.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Fix Narrator Bug",
   "packageName": "react-native-windows",
   "email": "34109996+chiaramooney@users.noreply.github.com",

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -15,6 +15,7 @@
 #include <Utils/KeyboardUtils.h>
 #include <Utils/ValueUtils.h>
 #include <Views/FrameworkElementTransferProperties.h>
+#include <atlcomcli.h>
 #include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.UI.Composition.h>
@@ -350,9 +351,9 @@ void ComponentView::onLostFocus(
 
       m_componentHostingFocusVisual->hostFocusVisual(false, get_strong());
     }
-    if (m_uiaProvider) {
+    if (UiaClientsAreListening()) {
       winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-          m_uiaProvider, UIA_HasKeyboardFocusPropertyId, true, false);
+          EnsureUiaProvider(), UIA_HasKeyboardFocusPropertyId, true, false);
     }
   }
   base_type::onLostFocus(args);
@@ -400,8 +401,8 @@ void ComponentView::onGotFocus(
       focusRect.size.height += (FOCUS_VISUAL_WIDTH * 2);
       focusVisualRoot(focusRect)->hostFocusVisual(true, get_strong());
     }
-    if (m_uiaProvider) {
-      auto spProviderSimple = m_uiaProvider.try_as<IRawElementProviderSimple>();
+    if (UiaClientsAreListening()) {
+      auto spProviderSimple = EnsureUiaProvider().try_as<IRawElementProviderSimple>();
       if (spProviderSimple != nullptr) {
         winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
             m_uiaProvider, UIA_HasKeyboardFocusPropertyId, false, true);
@@ -705,59 +706,62 @@ void ComponentView::updateTransformProps(
 void ComponentView::updateAccessibilityProps(
     const facebook::react::ViewProps &oldViewProps,
     const facebook::react::ViewProps &newViewProps) noexcept {
-  if (!m_uiaProvider)
+  if (!UiaClientsAreListening())
     return;
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider, UIA_IsKeyboardFocusablePropertyId, oldViewProps.focusable, newViewProps.focusable);
+      EnsureUiaProvider(), UIA_IsKeyboardFocusablePropertyId, oldViewProps.focusable, newViewProps.focusable);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider,
+      EnsureUiaProvider(),
       UIA_NamePropertyId,
       oldViewProps.accessibilityLabel,
       newViewProps.accessibilityLabel.empty() ? DefaultAccessibleName() : newViewProps.accessibilityLabel);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider,
+      EnsureUiaProvider(),
       UIA_IsContentElementPropertyId,
       (oldViewProps.accessible && oldViewProps.accessibilityRole != "none"),
       (newViewProps.accessible && newViewProps.accessibilityRole != "none"));
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider,
+      EnsureUiaProvider(),
       UIA_IsControlElementPropertyId,
       (oldViewProps.accessible && oldViewProps.accessibilityRole != "none"),
       (newViewProps.accessible && newViewProps.accessibilityRole != "none"));
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider,
+      EnsureUiaProvider(),
       UIA_IsEnabledPropertyId,
       !(oldViewProps.accessibilityState && oldViewProps.accessibilityState->disabled),
       !(newViewProps.accessibilityState && newViewProps.accessibilityState->disabled));
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider,
+      EnsureUiaProvider(),
       UIA_IsEnabledPropertyId,
       !(oldViewProps.accessibilityState && oldViewProps.accessibilityState->busy),
       !(newViewProps.accessibilityState && newViewProps.accessibilityState->busy));
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider, UIA_ControlTypePropertyId, oldViewProps.accessibilityRole, newViewProps.accessibilityRole);
+      EnsureUiaProvider(), UIA_ControlTypePropertyId, oldViewProps.accessibilityRole, newViewProps.accessibilityRole);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider, UIA_HelpTextPropertyId, oldViewProps.accessibilityHint, newViewProps.accessibilityHint);
+      EnsureUiaProvider(), UIA_HelpTextPropertyId, oldViewProps.accessibilityHint, newViewProps.accessibilityHint);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider,
+      EnsureUiaProvider(),
       UIA_PositionInSetPropertyId,
       oldViewProps.accessibilityPosInSet,
       newViewProps.accessibilityPosInSet);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider, UIA_SizeOfSetPropertyId, oldViewProps.accessibilitySetSize, newViewProps.accessibilitySetSize);
+      EnsureUiaProvider(),
+      UIA_SizeOfSetPropertyId,
+      oldViewProps.accessibilitySetSize,
+      newViewProps.accessibilitySetSize);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      m_uiaProvider,
+      EnsureUiaProvider(),
       UIA_LiveSettingPropertyId,
       oldViewProps.accessibilityLiveRegion,
       newViewProps.accessibilityLiveRegion);
@@ -765,7 +769,8 @@ void ComponentView::updateAccessibilityProps(
   if ((oldViewProps.accessibilityState.has_value() && oldViewProps.accessibilityState->selected.has_value()) !=
       ((newViewProps.accessibilityState.has_value() && newViewProps.accessibilityState->selected.has_value()))) {
     auto compProvider =
-        m_uiaProvider.try_as<winrt::Microsoft::ReactNative::implementation::CompositionDynamicAutomationProvider>();
+        EnsureUiaProvider()
+            .try_as<winrt::Microsoft::ReactNative::implementation::CompositionDynamicAutomationProvider>();
     if (compProvider) {
       if ((newViewProps.accessibilityState.has_value() && newViewProps.accessibilityState->selected.has_value())) {
         winrt::Microsoft::ReactNative::implementation::AddSelectionItemsToContainer(compProvider.get());

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -76,14 +76,8 @@ void RootComponentView::updateLayoutMetrics(
 winrt::Microsoft::ReactNative::ComponentView RootComponentView::GetFocusedComponent() noexcept {
   return m_focusedComponent;
 }
-<<<<<<< HEAD
-void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &value) noexcept {
-=======
 
-void RootComponentView::SetFocusedComponent(
-    const winrt::Microsoft::ReactNative::ComponentView &value,
-    winrt::Microsoft::ReactNative::FocusNavigationDirection direction) noexcept {
->>>>>>> e3b41f85e2 ([Fabric] Fix Bug in Narrator Navigation (#14498))
+void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &value) noexcept {
   if (m_focusedComponent == value)
     return;
 
@@ -97,12 +91,8 @@ void RootComponentView::SetFocusedComponent(
     if (auto rootView = m_wkRootView.get()) {
       winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(rootView)->TrySetFocus();
     }
-<<<<<<< HEAD
-    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value);
-=======
     m_focusedComponent = value;
-    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value, direction);
->>>>>>> e3b41f85e2 ([Fabric] Fix Bug in Narrator Navigation (#14498))
+    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value);
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(value)->onGotFocus(args);
   }
 }
@@ -169,9 +159,10 @@ bool RootComponentView::TrySetFocusedComponent(
 
 bool RootComponentView::TryMoveFocus(bool next) noexcept {
   if (!m_focusedComponent) {
-    return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
-        next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-             : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+    return NavigateFocus(
+        winrt::Microsoft::ReactNative::FocusNavigationRequest(
+            next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+                 : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
   }
 
   Mso::Functor<bool(const winrt::Microsoft::ReactNative::ComponentView &)> fn =
@@ -209,9 +200,10 @@ bool RootComponentView::TryMoveFocus(bool next) noexcept {
   }
 
   // Wrap focus around if nothing outside the island takes focus
-  return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
-      next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-           : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+  return NavigateFocus(
+      winrt::Microsoft::ReactNative::FocusNavigationRequest(
+          next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+               : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
 }
 
 HRESULT RootComponentView::GetFragmentRoot(IRawElementProviderFragmentRoot **pRetVal) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -76,7 +76,14 @@ void RootComponentView::updateLayoutMetrics(
 winrt::Microsoft::ReactNative::ComponentView RootComponentView::GetFocusedComponent() noexcept {
   return m_focusedComponent;
 }
+<<<<<<< HEAD
 void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative::ComponentView &value) noexcept {
+=======
+
+void RootComponentView::SetFocusedComponent(
+    const winrt::Microsoft::ReactNative::ComponentView &value,
+    winrt::Microsoft::ReactNative::FocusNavigationDirection direction) noexcept {
+>>>>>>> e3b41f85e2 ([Fabric] Fix Bug in Narrator Navigation (#14498))
   if (m_focusedComponent == value)
     return;
 
@@ -90,11 +97,14 @@ void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative:
     if (auto rootView = m_wkRootView.get()) {
       winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeIsland>(rootView)->TrySetFocus();
     }
+<<<<<<< HEAD
     auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value);
+=======
+    m_focusedComponent = value;
+    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>(value, direction);
+>>>>>>> e3b41f85e2 ([Fabric] Fix Bug in Narrator Navigation (#14498))
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(value)->onGotFocus(args);
   }
-
-  m_focusedComponent = value;
 }
 
 bool RootComponentView::NavigateFocus(const winrt::Microsoft::ReactNative::FocusNavigationRequest &request) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -159,10 +159,9 @@ bool RootComponentView::TrySetFocusedComponent(
 
 bool RootComponentView::TryMoveFocus(bool next) noexcept {
   if (!m_focusedComponent) {
-    return NavigateFocus(
-        winrt::Microsoft::ReactNative::FocusNavigationRequest(
-            next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-                 : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+    return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
+        next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+             : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
   }
 
   Mso::Functor<bool(const winrt::Microsoft::ReactNative::ComponentView &)> fn =
@@ -200,10 +199,9 @@ bool RootComponentView::TryMoveFocus(bool next) noexcept {
   }
 
   // Wrap focus around if nothing outside the island takes focus
-  return NavigateFocus(
-      winrt::Microsoft::ReactNative::FocusNavigationRequest(
-          next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-               : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+  return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
+      next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+           : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
 }
 
 HRESULT RootComponentView::GetFragmentRoot(IRawElementProviderFragmentRoot **pRetVal) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1147,10 +1147,10 @@ void WindowsTextInputComponentView::OnTextUpdated() noexcept {
     emitter->onChange(onChangeArgs);
   }
 
-  if (m_uiaProvider) {
+  if (UiaClientsAreListening()) {
     auto text = GetTextFromRichEdit();
     winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-        m_uiaProvider, UIA_ValueValuePropertyId, text, text);
+        EnsureUiaProvider(), UIA_ValueValuePropertyId, text, text);
   }
 }
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Fix bug in Narrator navigation. Narrator only announced currently focused component, but when user tried to navigated to any other control, Narrator blue box did not move and did not announce. 

Backport #14498 to 0.77.

### What
- Fixed break in UIA behavior. Usage of m_uiaProvider instead of UIAClientsAreListening to gate UIA calls caused UIA code to not execute when AT tools like Narrator were launched.
- HasKeyboardFocus must be updated before UIA Focus Changed event is fired, otherwise Narrator will dismiss the focus event.

NOTE: 
- TextInput controls are still unable to receive keyboard focus. From initial debugging with the Narrator team, it appears the element is becoming null during focus processing. Issue filed to track this bug: #14499 

## Testing
Manual accessibility testing.

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14498)