### PR TITLE
[Fabric] Implement SpellCheck and AutoCorrect for TextInput

### DIFF
--- a/change/react-native-windows-99f88013-45df-4134-99df-b0fb86dc5e88.json
+++ b/change/react-native-windows-99f88013-45df-4134-99df-b0fb86dc5e88.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement SpellCheck and AutoCorrect for TextInput",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextInputTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextInputTestPage.tsx
@@ -62,6 +62,8 @@ export class TextInputTestPage extends React.Component<
           style={{height: 80}}
           placeholder="MultiLine"
           multiline={true}
+          spellCheck={false}
+          autoCorrect={false}
         />
         <TextInput
           testID="auto-caps-textinput-field"

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -29370,8 +29370,10 @@ exports[`snapshotAllPages LegacyTextInputTest 1`] = `
     testID="textinput-field"
   />
   <TextInput
+    autoCorrect={false}
     multiline={true}
     placeholder="MultiLine"
+    spellCheck={false}
     style={
       {
         "height": 80,

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -100,6 +100,12 @@ export default class Bootstrap extends React.Component<{}, any> {
             />
             <TextInput
               style={styles.input}
+              placeholder={'SpellChecking Disabled Autocorrect Enabled'}
+              spellCheck={false}
+              autoCorrect={true}
+            />
+            <TextInput
+              style={styles.input}
               placeholder={
                 'SpellChecking default (true) Autocorrect default (true)'
               }

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -82,8 +82,27 @@ export default class Bootstrap extends React.Component<{}, any> {
             />
             <TextInput
               style={styles.input}
-              placeholder={'SpellChecking Disabled'}
+              placeholder={'SpellChecking Enabled Autocorrect Disabled'}
+              spellCheck={true}
+              autoCorrect={false}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={'SpellChecking Enabled Autocorrect Enabled'}
+              spellCheck={true}
+              autoCorrect={true}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={'SpellChecking Disabled Autocorrect Disabled'}
               spellCheck={false}
+              autoCorrect={false}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={
+                'SpellChecking default (true) Autocorrect default (true)'
+              }
             />
             <TextInput
               style={styles.input}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -463,6 +463,13 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
   WindowsTextInputComponentView *m_outer;
 };
 
+int WINAPI
+AutoCorrectCallback(LANGID langid, const WCHAR *pszBefore, WCHAR *pszAfter, LONG cchAfter, LONG *pcchReplaced) {
+  wcsncpy_s(pszAfter, cchAfter, pszBefore, _TRUNCATE);
+  *pcchReplaced = static_cast<LONG>(wcslen(pszAfter));
+  return ATP_REPLACEALLTEXT;
+}
+
 facebook::react::AttributedString WindowsTextInputComponentView::getAttributedString() const {
   // Use BaseTextShadowNode to get attributed string from children
 
@@ -1067,6 +1074,14 @@ void WindowsTextInputComponentView::updateProps(
     m_propBits |= TXTBIT_PARAFORMATCHANGE;
   }
 
+  if (oldTextInputProps.autoCorrect != newTextInputProps.autoCorrect || !oldProps) {
+    updateAutoCorrect(newTextInputProps.autoCorrect);
+  }
+
+  if (oldTextInputProps.spellCheck != newTextInputProps.spellCheck || !oldProps) {
+    updateSpellCheck(newTextInputProps.spellCheck);
+  }
+
   UpdatePropertyBits();
 }
 
@@ -1591,4 +1606,23 @@ void WindowsTextInputComponentView::updateLetterSpacing(float letterSpacing) noe
       m_textServices->TxSendMessage(EM_SETCHARFORMAT, SCF_SELECTION, reinterpret_cast<LPARAM>(&cf), &res));
 }
 
+void WindowsTextInputComponentView::updateAutoCorrect(bool enable) noexcept {
+  LRESULT lresult;
+  winrt::check_hresult(m_textServices->TxSendMessage(
+      EM_SETAUTOCORRECTPROC, !enable ? reinterpret_cast<WPARAM>(AutoCorrectCallback) : 0, 0, &lresult));
+}
+
+void WindowsTextInputComponentView::updateSpellCheck(bool enable) noexcept {
+  LRESULT currentLangOptions;
+  winrt::check_hresult(m_textServices->TxSendMessage(EM_GETLANGOPTIONS, 0, 0, &currentLangOptions));
+
+  DWORD newLangOptions = static_cast<DWORD>(currentLangOptions);
+  if (enable) {
+    newLangOptions |= IMF_SPELLCHECKING;
+  }
+
+  LRESULT lresult;
+  winrt::check_hresult(
+      m_textServices->TxSendMessage(EM_SETLANGOPTIONS, IMF_SPELLCHECKING, enable ? newLangOptions : 0, &lresult));
+}
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1075,18 +1075,16 @@ void WindowsTextInputComponentView::updateProps(
   }
 
   // Please note: spellcheck performs both red lines and autocorrect as per windows behaviour
-  if (oldTextInputProps.spellCheck != newTextInputProps.spellCheck || !oldProps) {
-    updateSpellCheck(newTextInputProps.spellCheck);
+  bool shouldUpdateSpellCheck =
+      (!oldProps || (oldTextInputProps.spellCheck != newTextInputProps.spellCheck) ||
+       (oldTextInputProps.autoCorrect != newTextInputProps.autoCorrect));
+
+  if (shouldUpdateSpellCheck) {
+    bool effectiveSpellCheck = newTextInputProps.spellCheck || newTextInputProps.autoCorrect;
+    updateSpellCheck(effectiveSpellCheck);
   }
 
-  if (oldTextInputProps.autoCorrect != newTextInputProps.autoCorrect || !oldProps) {
-    if (newTextInputProps.autoCorrect) {
-      updateSpellCheck(
-          newTextInputProps
-              .autoCorrect); // if spellcheck = false, autocorrect = true.. then spellcheck will be referred as true
-    }
-    // in case spellcheck is true and autocorrect is false then we can use this method that invokes a callback to toggle
-    // off autocorrect
+  if (!oldProps || oldTextInputProps.autoCorrect != newTextInputProps.autoCorrect) {
     updateAutoCorrect(newTextInputProps.autoCorrect);
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -111,6 +111,8 @@ struct WindowsTextInputComponentView
       const std::string &newcapitalizationType) noexcept;
 
   void updateLetterSpacing(float letterSpacing) noexcept;
+  void updateAutoCorrect(bool value) noexcept;
+  void updateSpellCheck(bool value) noexcept;
 
   winrt::Windows::UI::Composition::CompositionSurfaceBrush m_brush{nullptr};
   winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual m_caretVisual{nullptr};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputProps.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputProps.cpp
@@ -24,6 +24,7 @@ WindowsTextInputProps::WindowsTextInputProps(
           */
 
       allowFontScaling(convertRawProp(context, rawProps, "allowFontScaling", sourceProps.allowFontScaling, {true})),
+      autoCorrect(convertRawProp(context, rawProps, "autoCorrect", sourceProps.autoCorrect, {true})),
       clearTextOnFocus(convertRawProp(context, rawProps, "clearTextOnFocus", sourceProps.clearTextOnFocus, {false})),
       editable(convertRawProp(context, rawProps, "editable", sourceProps.editable, {true})),
       maxLength(convertRawProp(context, rawProps, "maxLength", sourceProps.maxLength, {0})),
@@ -36,7 +37,7 @@ WindowsTextInputProps::WindowsTextInputProps(
       selection(convertRawProp(context, rawProps, "selection", sourceProps.selection, {})),
       selectionColor(convertRawProp(context, rawProps, "selectionColor", sourceProps.selectionColor, {})),
       selectTextOnFocus(convertRawProp(context, rawProps, "selectTextOnFocus", sourceProps.selectTextOnFocus, {false})),
-      spellCheck(convertRawProp(context, rawProps, "spellCheck", sourceProps.spellCheck, {false})),
+      spellCheck(convertRawProp(context, rawProps, "spellCheck", sourceProps.spellCheck, {true})),
       text(convertRawProp(context, rawProps, "text", sourceProps.text, {})),
       mostRecentEventCount(
           convertRawProp(context, rawProps, "mostRecentEventCount", sourceProps.mostRecentEventCount, {0})),

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputProps.h
@@ -97,6 +97,7 @@ class WindowsTextInputProps final : public ViewProps, public BaseTextProps {
   setProp(const PropsParserContext &context, RawPropsPropNameHash hash, const char *propName, RawValue const &value);
 
   bool allowFontScaling{true};
+  bool autoCorrect{true};
   bool clearTextOnFocus{false};
   bool editable{true};
   int maxLength{0};
@@ -108,7 +109,7 @@ class WindowsTextInputProps final : public ViewProps, public BaseTextProps {
   CompWindowsTextInputSelectionStruct selection{};
   SharedColor selectionColor{};
   bool selectTextOnFocus{false};
-  bool spellCheck{false};
+  bool spellCheck{true};
   std::string text{};
   int mostRecentEventCount{0};
   bool secureTextEntry{false};


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.
Implement the spellCheck property for the fabric implementation of TextInput.

This property was available in RNW Paper via TextInputViewManager.

See https://reactnative.dev/docs/textinput#spellcheck-ios for details.

Implement the autoCorrect property for TextInput in RNW Fabric.

For reference, check the public API documentation: https://reactnative.dev/docs/textinput#autocorrect

Resolves https://github.com/microsoft/react-native-windows/issues/13843 and https://github.com/microsoft/react-native-windows/issues/13134

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
Implemented changes in textinputcomponent for fabric

Default for both these should be true as per the docs.

Please Note: Spellcheck in windows automatically enables autocorrects. The autocorrect callback API seems to invert the logic.

https://learn.microsoft.com/en-us/windows/win32/api/richedit/nc-richedit-autocorrectproc
https://learn.microsoft.com/en-us/windows/win32/controls/em-getlangoptions

## Screenshots

https://github.com/user-attachments/assets/f78d1a43-4cbb-40fe-a667-6ee9ffc6bff4


## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.
1. Tested and added cases in playground
2. E2ETestAppFabric already has test cases for these

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_ YES

Add a brief summary of the change to use in the release notes for the next release.
Implemented SpellCheck and AutoCorrect for TextInput 