### PR TITLE
fix(cli): codegen jsSrcsDir subpath

### DIFF
--- a/change/@react-native-windows-cli-7fd60dda-c73f-4b27-83e9-e2fec2b6c1de.json
+++ b/change/@react-native-windows-cli-7fd60dda-c73f-4b27-83e9-e2fec2b6c1de.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(cli): codegenWindows file glob for subpaths",
+  "packageName": "@react-native-windows/cli",
+  "email": "fcalise@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/codegenWindows/codegenWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/codegenWindows/codegenWindows.ts
@@ -143,7 +143,10 @@ export class CodeGenWindows {
       'modulesWindows',
     ];
 
-    const jsRootPathRelative = path.relative(process.cwd(), jsRootDir);
+    const jsRootPathRelative = path
+      .relative(process.cwd(), jsRootDir)
+      .split(path.sep)
+      .join('/');
     const options: RnwCodeGenOptions = {
       files: [
         `${jsRootPathRelative}${


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves #14387 

### What
Makes a fix to the codegen cli to allow for subpaths in the `jsSrcsDir` option of the codegen config.

## Screenshots
| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/aae66b5d-6e15-420e-b598-a974f2f53882) | ![image](https://github.com/user-attachments/assets/0c32b0e9-331f-4e0f-80fc-aefcd231955e) |


## Testing
Locally ran codegen after making the modification inside of `node_modules` of an example project. Would be happy to add a test for this if some guidance were to be provided, as I didn't see any colocated codegen tests nearby.

## Changelog
Should this change be included in the release notes: yes

Codegen `jsSrcsDir` can now be at a subpath directory of the package instead of top-level only
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14530)