### PR TITLE
Implement onPartialLoad property for Image in Fabric

### DIFF
--- a/change/react-native-windows-301249bf-2295-45e4-9582-d1b1a88614ca.json
+++ b/change/react-native-windows-301249bf-2295-45e4-9582-d1b1a88614ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement onPartialLoad property for Image in Fabric",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -268,6 +268,8 @@ export default class Bootstrap extends React.Component<
               onLoadStart={() => console.log('onLoadStart')}
               onLoadEnd={() => console.log('onLoadEnd')}
               onProgress={this.handleOnProgress}
+              alt={'This is an image for testing'}
+              onPartialLoad={() => console.log('onPartialLoad')}
             />
           )}
         </View>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -111,6 +111,9 @@ void ImageComponentView::didReceiveProgress(float progress, int loaded, int tota
   auto imageEventEmitter = std::static_pointer_cast<facebook::react::ImageEventEmitter const>(m_eventEmitter);
   if (imageEventEmitter) {
     imageEventEmitter->onProgress(progress, loaded, total);
+    if (progress > 0.0f && progress < 1.0f) {
+      imageEventEmitter->onPartialLoad();
+    }
   }
   ensureDrawingSurface();
 }


### PR DESCRIPTION
## Description

### Type of Change

- New feature (non-breaking change which adds functionality)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves https://github.com/microsoft/react-native-windows/issues/13751

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
Implement the onPartialLoad property for Image in RNW Fabric.

For reference, check the public API documentation: https://reactnative.dev/docs/image#onpartialload-ios


## Screenshots
Add any relevant screen captures here from before or after your changes. 
Implement the onPartialLoad property for Image in RNW Fabric.

For reference, check the public API documentation: https://reactnative.dev/docs/image#onpartialload-ios


## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.
Playground tested

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_
Yes

Add a brief summary of the change to use in the release notes for the next release.
Implement onPartialLoad property for Image in Fabric
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14539)