### PR TITLE
[0.78] Update packages for component governance

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11367,9 +11367,9 @@ table-layout@^1.0.2:
     wordwrapjs "^4.0.0"
 
 tar-fs@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.2.tgz#425f154f3404cb16cb8ff6e671d45ab2ed9596c5"
+  integrity sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"


### PR DESCRIPTION
Updated the following packages:
* 'tar-fs@2.1.2' : CVE-2024-12905

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To resolve Component Governance alerts.

### What
See above

## Screenshots
N/A 

## Testing
Local build

## Changelog
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14565)