### PR TITLE
[0.74] Update WindowsAppSDK version to 1.7.250401001

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -55,17 +55,17 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x86
             SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
+            UseExperimentalWinUI3: false
           - Name: X64DebugCompositionExperimentalWinUI3
             BuildConfiguration: Debug
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
+            UseExperimentalWinUI3: false
           - Name: X64ReleaseCompositionExperimentalWinUI3
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
+            UseExperimentalWinUI3: false
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X86DebugUniversal
@@ -93,16 +93,16 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-          - Name: X86DebugCompositionExperimentalWinUI3
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X64ReleaseCompositionExperimentalWinUI3
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
+          # - Name: X86DebugCompositionExperimentalWinUI3
+          #   BuildConfiguration: Debug
+          #   BuildPlatform: x86
+          #   SolutionFile: Playground-Composition.sln
+          #   UseExperimentalWinUI3: true
+          # - Name: X64ReleaseCompositionExperimentalWinUI3
+          #   BuildConfiguration: Release
+          #   BuildPlatform: x64
+          #   SolutionFile: Playground-Composition.sln
+          #   UseExperimentalWinUI3: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86

--- a/change/react-native-windows-efa98e2b-7308-434d-a16f-77efced3562c.json
+++ b/change/react-native-windows-efa98e2b-7308-434d-a16f-77efced3562c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update WinAppSDK to 1.7.1",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/CustomComponent.cpp
+++ b/packages/playground/windows/playground-composition/CustomComponent.cpp
@@ -83,11 +83,9 @@ struct CustomComponentUserData : winrt::implements<CustomComponentUserData, winr
       bool nativeLayout) {
     nativeLayout;
     islandView;
-#ifdef USE_EXPERIMENTAL_WINUI3
     m_xamlIsland = winrt::Microsoft::UI::Xaml::XamlIsland{};
     m_xamlIsland.Content(CreateXamlButtonContent(nativeLayout));
     islandView.Connect(m_xamlIsland.ContentIsland());
-#endif
   }
 
   void PropsChanged(
@@ -95,9 +93,7 @@ struct CustomComponentUserData : winrt::implements<CustomComponentUserData, winr
       const winrt::Microsoft::ReactNative::IComponentProps &newProps,
       const winrt::Microsoft::ReactNative::IComponentProps & /*oldProps*/) {
     auto myProps = newProps.as<CustomXamlComponentProps>();
-#ifdef USE_EXPERIMENTAL_WINUI3
     m_buttonLabelTextBlock.Text(myProps->label);
-#endif
   }
 
   void FinalizeUpdates() noexcept {
@@ -168,13 +164,11 @@ struct CustomComponentUserData : winrt::implements<CustomComponentUserData, winr
           userData->Initialize(islandView, nativeLayout);
           islandView.UserData(*userData);
 
-#ifdef USE_EXPERIMENTAL_WINUI3
           islandView.Destroying([](const winrt::IInspectable &sender, const winrt::IInspectable & /*args*/) {
             auto senderIslandView = sender.as<winrt::Microsoft::ReactNative::Composition::ContentIslandComponentView>();
             auto userData = senderIslandView.UserData().as<CustomComponentUserData>();
             userData->m_xamlIsland.Close();
           });
-#endif
         });
 
     builder.SetUpdateEventEmitterHandler([](const winrt::Microsoft::ReactNative::ComponentView &source,
@@ -232,9 +226,7 @@ struct CustomComponentUserData : winrt::implements<CustomComponentUserData, winr
   winrt::Microsoft::UI::Xaml::Controls::TextBlock m_buttonLabelTextBlock{nullptr};
   winrt::Microsoft::ReactNative::IComponentState m_state;
   std::unique_ptr<CustomXamlComponentEventEmitter> m_eventEmitter{nullptr};
-#ifdef USE_EXPERIMENTAL_WINUI3
   winrt::Microsoft::UI::Xaml::XamlIsland m_xamlIsland{nullptr};
-#endif
 };
 
 static void RegisterViewComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) {

--- a/packages/playground/windows/playground-composition/DrawingIsland.cpp
+++ b/packages/playground/windows/playground-composition/DrawingIsland.cpp
@@ -875,7 +875,7 @@ void DrawingIsland::Window_Initialize() {
       });
 
 #ifdef USE_EXPERIMENTAL_WINUI3
-      (void)window.ThemeChanged(
+  (void)window.ThemeChanged(
       [this](winrt::ContentIslandEnvironment const &, winrt::IInspectable const &) { return Window_OnThemeChanged(); });
 #endif
 

--- a/packages/playground/windows/playground-composition/DrawingIsland.h
+++ b/packages/playground/windows/playground-composition/DrawingIsland.h
@@ -223,9 +223,7 @@ void Accessibility_OnAutomationProviderRequested(
   // Popups
   // https://task.ms/32440118: Add ContentIsland.SiteBridge to avoid this workaround
   winrt::IContentSiteBridge m_siteBridge{nullptr};
-#ifdef USE_EXPERIMENTAL_WINUI3
-  winrt::PopupWindowSiteBridge m_popupSiteBridge{nullptr};
-#endif
+  winrt::Microsoft::UI::Content::DesktopPopupSiteBridge m_popupSiteBridge{nullptr};
 
   // SystemBackdrops for Popups
   winrt::ISystemBackdropControllerWithTargets m_backdropController{nullptr};

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -705,11 +705,9 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   g_liftedCompositor = winrt::Microsoft::UI::Composition::Compositor();
 
 // We only want to init XAML if we are using XAML islands
-#ifdef USE_EXPERIMENTAL_WINUI3
   // Island-support: Create our custom Xaml App object. This is needed to properly use the controls and metadata
   // in Microsoft.ui.xaml.controls.dll.
   // auto playgroundApp{winrt::make<winrt::Playground::implementation::App>()};
-#endif
 
   return RunPlayground(showCmd, false);
 }

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -704,7 +704,7 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
       winrt::Microsoft::UI::Dispatching::DispatcherQueueController::CreateOnCurrentThread();
   g_liftedCompositor = winrt::Microsoft::UI::Composition::Compositor();
 
-// We only want to init XAML if we are using XAML islands
+  // We only want to init XAML if we are using XAML islands
   // Island-support: Create our custom Xaml App object. This is needed to properly use the controls and metadata
   // in Microsoft.ui.xaml.controls.dll.
   // auto playgroundApp{winrt::make<winrt::Playground::implementation::App>()};

--- a/packages/playground/windows/playground-composition/packages.lock.json
+++ b/packages/playground/windows/playground-composition/packages.lock.json
@@ -28,11 +28,11 @@
       },
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
@@ -57,8 +57,8 @@
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       },
       "Microsoft.Windows.SDK.BuildTools": {
         "type": "Transitive",
@@ -88,7 +88,7 @@
           "Folly": "[1.0.0, )",
           "Microsoft.JavaScript.Hermes": "[0.1.23, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
-          "Microsoft.WindowsAppSDK": "[1.6.240923002, )",
+          "Microsoft.WindowsAppSDK": "[1.7.250401001, )",
           "ReactCommon": "[1.0.0, )",
           "boost": "[1.83.0, )"
         }

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -2,10 +2,10 @@
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
     <UseExperimentalWinUI3>false</UseExperimentalWinUI3>
-    <WindowsAppSdkAutoInitialize>false</WindowsAppSdkAutoInitialize>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <WindowsAppSdkAutoInitialize>false</WindowsAppSdkAutoInitialize>
     <EnableSourceLink>true</EnableSourceLink>
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
-    <UseExperimentalWinUI3>true</UseExperimentalWinUI3>
+    <UseExperimentalWinUI3>false</UseExperimentalWinUI3>
     <WindowsAppSdkAutoInitialize>false</WindowsAppSdkAutoInitialize>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
@@ -149,9 +149,6 @@
     <ClInclude Include="$(TurboModule_SourcePath)\ReactCommon\TurboModule.h">
       <Filter>TurboModule</Filter>
     </ClInclude>
-    <ClInclude Include="$(TurboModule_SourcePath)\ReactCommon\LongLivedObject.h">
-      <Filter>TurboModule</Filter>
-    </ClInclude>
     <ClInclude Include="$(TurboModule_SourcePath)\ReactCommon\TurboModuleUtils.h">
       <Filter>TurboModule</Filter>
     </ClInclude>
@@ -171,6 +168,7 @@
     <ClInclude Include="$(NodeApiDir)js_native_api.h" />
     <ClInclude Include="$(NodeApiDir)js_native_api_types.h" />
     <ClInclude Include="$(NodeApiDir)js_runtime_api.h" />
+    <ClInclude Include="$(Bridging_SourcePath)\LongLivedObject.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="JSI">

--- a/vnext/Microsoft.ReactNative/CompositionComponentView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionComponentView.idl
@@ -89,11 +89,6 @@ namespace Microsoft.ReactNative.Composition
     Microsoft.ReactNative.ViewProps ViewProps { get; };
   };
 
-  // Some other interfaces we could consider implementing/exposing
-  // Use ifdef USE_EXPERIMENTAL_WINUI3 to add these
-  // Microsoft.UI.Content.IContentLink // Use ifdef USE_EXPERIMENTAL_WINUI3
-  // Microsoft.UI.Content.IContentSiteBridge 
-  // Microsoft.UI.Content.IContentSiteBridge2 // Use ifdef USE_EXPERIMENTAL_WINUI3
   [experimental]
   [webhosthidden]
   runtimeclass ContentIslandComponentView : ViewComponentView { 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -28,12 +28,10 @@ CompositionDynamicAutomationProvider::CompositionDynamicAutomationProvider(
   }
 }
 
-#ifdef USE_EXPERIMENTAL_WINUI3
 CompositionDynamicAutomationProvider::CompositionDynamicAutomationProvider(
     const winrt::Microsoft::ReactNative::Composition::ComponentView &componentView,
     const winrt::Microsoft::UI::Content::ChildSiteLink &childSiteLink) noexcept
     : m_view{componentView}, m_childSiteLink{childSiteLink} {}
-#endif // USE_EXPERIMENTAL_WINUI3
 
 HRESULT __stdcall CompositionDynamicAutomationProvider::Navigate(
     NavigateDirection direction,
@@ -41,7 +39,6 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::Navigate(
   if (pRetVal == nullptr)
     return E_POINTER;
 
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_childSiteLink) {
     if (direction == NavigateDirection_FirstChild || direction == NavigateDirection_LastChild) {
       auto fragment = m_childSiteLink.AutomationProvider().try_as<IRawElementProviderFragment>();
@@ -49,7 +46,6 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::Navigate(
       return S_OK;
     }
   }
-#endif // USE_EXPERIMENTAL_WINUI3
 
   return UiaNavigateHelper(m_view.view(), direction, *pRetVal);
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
@@ -25,11 +25,9 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
   CompositionDynamicAutomationProvider(
       const winrt::Microsoft::ReactNative::Composition::ComponentView &componentView) noexcept;
 
-#ifdef USE_EXPERIMENTAL_WINUI3
   CompositionDynamicAutomationProvider(
       const winrt::Microsoft::ReactNative::Composition::ComponentView &componentView,
       const winrt::Microsoft::UI::Content::ChildSiteLink &childContentLink) noexcept;
-#endif // USE_EXPERIMENTAL_WINUI3
 
   // inherited via IRawElementProviderFragment
   virtual HRESULT __stdcall Navigate(NavigateDirection direction, IRawElementProviderFragment **pRetVal) override;
@@ -92,10 +90,8 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
  private:
   ::Microsoft::ReactNative::ReactTaggedView m_view;
   std::vector<winrt::com_ptr<IRawElementProviderSimple>> m_selectionItems;
-#ifdef USE_EXPERIMENTAL_WINUI3
   // Non-null when this UIA node is the peer of a ContentIslandComponentView.
   winrt::Microsoft::UI::Content::ChildSiteLink m_childSiteLink{nullptr};
-#endif
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
@@ -174,7 +174,6 @@ HRESULT __stdcall CompositionRootAutomationProvider::get_FragmentRoot(IRawElemen
 
   *pRetVal = nullptr;
 
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_island) {
     auto parentRoot = m_island.FragmentRootAutomationProvider();
     auto spFragment = parentRoot.try_as<IRawElementProviderFragmentRoot>();
@@ -183,7 +182,6 @@ HRESULT __stdcall CompositionRootAutomationProvider::get_FragmentRoot(IRawElemen
       return S_OK;
     }
   }
-#endif
 
   return S_OK;
 }
@@ -290,7 +288,6 @@ HRESULT __stdcall CompositionRootAutomationProvider::Navigate(
       }
     }
   } else if (direction == NavigateDirection_Parent) {
-#ifdef USE_EXPERIMENTAL_WINUI3
     if (m_island) {
       auto parent = m_island.ParentAutomationProvider();
       auto spFragment = parent.try_as<IRawElementProviderFragment>();
@@ -299,7 +296,6 @@ HRESULT __stdcall CompositionRootAutomationProvider::Navigate(
         return S_OK;
       }
     }
-#endif
   }
 
   *pRetVal = nullptr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
@@ -44,7 +44,6 @@ ContentIslandComponentView::ContentIslandComponentView(
 }
 
 void ContentIslandComponentView::OnMounted() noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   m_childSiteLink = winrt::Microsoft::UI::Content::ChildSiteLink::Create(
       rootComponentView()->parentContentIsland(),
       winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(Visual())
@@ -84,21 +83,17 @@ void ContentIslandComponentView::OnMounted() noexcept {
         }));
     view = view.Parent();
   }
-#endif
 }
 
 void ContentIslandComponentView::OnUnmounted() noexcept {
   m_layoutMetricChangedRevokers.clear();
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_navigationHostDepartFocusRequestedToken && m_navigationHost) {
     m_navigationHost.DepartFocusRequested(m_navigationHostDepartFocusRequestedToken);
     m_navigationHostDepartFocusRequestedToken = {};
   }
-#endif
 }
 
 void ContentIslandComponentView::ParentLayoutChanged() noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_layoutChangePosted)
     return;
 
@@ -114,30 +109,21 @@ void ContentIslandComponentView::ParentLayoutChanged() noexcept {
       strongThis->m_layoutChangePosted = false;
     }
   });
-#endif
 }
 
 winrt::IInspectable ContentIslandComponentView::EnsureUiaProvider() noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_uiaProvider == nullptr) {
     m_uiaProvider = winrt::make<winrt::Microsoft::ReactNative::implementation::CompositionDynamicAutomationProvider>(
         *get_strong(), m_childSiteLink);
   }
   return m_uiaProvider;
-#else
-  return Super::EnsureUiaProvider();
-#endif
 }
 
 bool ContentIslandComponentView::focusable() const noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   // We don't have a way to check to see if the ContentIsland has focusable content,
   // so we'll always return true.  We'll have to handle the case where the content doesn't have
   // focusable content in the OnGotFocus handler.
   return true;
-#else
-  return Super::focusable();
-#endif
 }
 
 // Helper to convert a FocusNavigationDirection to a FocusNavigationReason.
@@ -156,17 +142,12 @@ winrt::Microsoft::UI::Input::FocusNavigationReason GetFocusNavigationReason(
 
 void ContentIslandComponentView::onGotFocus(
     const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   auto gotFocusEventArgs = args.as<winrt::Microsoft::ReactNative::implementation::GotFocusEventArgs>();
   const auto navigationReason = GetFocusNavigationReason(gotFocusEventArgs->Direction());
   m_navigationHost.NavigateFocus(winrt::Microsoft::UI::Input::FocusNavigationRequest::Create(navigationReason));
-#else
-  return Super::onGotFocus(args);
-#endif // USE_EXPERIMENTAL_WINUI3
 }
 
 ContentIslandComponentView::~ContentIslandComponentView() noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_navigationHostDepartFocusRequestedToken && m_navigationHost) {
     m_navigationHost.DepartFocusRequested(m_navigationHostDepartFocusRequestedToken);
     m_navigationHostDepartFocusRequestedToken = {};
@@ -189,7 +170,6 @@ ContentIslandComponentView::~ContentIslandComponentView() noexcept {
       m_previousSiblingAutomationProviderRequestedToken = {};
     }
   }
-#endif // USE_EXPERIMENTAL_WINUI3
   if (m_islandToConnect) {
     m_islandToConnect.Close();
   }
@@ -212,31 +192,26 @@ void ContentIslandComponentView::UnmountChildComponentView(
 void ContentIslandComponentView::updateLayoutMetrics(
     facebook::react::LayoutMetrics const &layoutMetrics,
     facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_childSiteLink) {
     m_childSiteLink.ActualSize({layoutMetrics.frame.size.width, layoutMetrics.frame.size.height});
     ParentLayoutChanged();
   }
-#endif
   base_type::updateLayoutMetrics(layoutMetrics, oldLayoutMetrics);
 }
 
 void ContentIslandComponentView::Connect(const winrt::Microsoft::UI::Content::ContentIsland &contentIsland) noexcept {
-#ifdef USE_EXPERIMENTAL_WINUI3
   if (m_childSiteLink) {
     m_islandToConnect = nullptr;
     m_childSiteLink.Connect(contentIsland);
   } else {
     m_islandToConnect = contentIsland;
   }
-#endif // USE_EXPERIMENTAL_WINUI3
 }
 
 void ContentIslandComponentView::prepareForRecycle() noexcept {
   Super::prepareForRecycle();
 }
 
-#ifdef USE_EXPERIMENTAL_WINUI3
 void ContentIslandComponentView::ConfigureChildSiteLinkAutomation() noexcept {
   // This automation mode must be set before connecting the child ContentIsland.
   // It puts the child content into a mode where it won't own its own framework root.  Instead, the child island's
@@ -288,6 +263,5 @@ void ContentIslandComponentView::ConfigureChildSiteLinkAutomation() noexcept {
         args.Handled(true);
       });
 }
-#endif // USE_EXPERIMENTAL_WINUI3
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
@@ -61,7 +61,6 @@ struct ContentIslandComponentView : ContentIslandComponentViewT<ContentIslandCom
   winrt::event_token m_mountedToken;
   winrt::event_token m_unmountedToken;
   std::vector<winrt::Microsoft::ReactNative::ComponentView::LayoutMetricsChanged_revoker> m_layoutMetricChangedRevokers;
-#ifdef USE_EXPERIMENTAL_WINUI3
   winrt::Microsoft::UI::Content::ChildSiteLink m_childSiteLink{nullptr};
   winrt::Microsoft::UI::Input::InputFocusNavigationHost m_navigationHost{nullptr};
   winrt::event_token m_navigationHostDepartFocusRequestedToken{};
@@ -72,7 +71,6 @@ struct ContentIslandComponentView : ContentIslandComponentViewT<ContentIslandCom
   winrt::event_token m_parentAutomationProviderRequestedToken{};
   winrt::event_token m_nextSiblingAutomationProviderRequestedToken{};
   winrt::event_token m_previousSiblingAutomationProviderRequestedToken{};
-#endif
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -896,7 +896,7 @@ winrt::Microsoft::UI::Content::ContentIsland ReactNativeIsland::Island() {
           }
         });
 #ifdef USE_EXPERIMENTAL_WINUI3
-        if (!m_isFragment) {
+    if (!m_isFragment) {
       m_islandConnectedToken = m_island.Connected(
           [weakThis = get_weak()](
               winrt::IInspectable const &, winrt::Microsoft::UI::Content::ContentIsland const &island) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -893,20 +893,10 @@ winrt::Microsoft::UI::Content::ContentIsland ReactNativeIsland::Island() {
             if (args.DidLayoutDirectionChange()) {
               pThis->Arrange(pThis->m_layoutConstraints, pThis->m_viewportOffset);
             }
-#ifndef USE_EXPERIMENTAL_WINUI3 // Use this in place of Connected/Disconnected events for now. -- Its not quite what we
-                                // want, but it will do for now.
-            if (args.DidSiteVisibleChange()) {
-              if (island.IsSiteVisible()) {
-                pThis->OnMounted();
-              } else {
-                pThis->OnUnmounted();
-              }
-            }
-#endif
           }
         });
 #ifdef USE_EXPERIMENTAL_WINUI3
-    if (!m_isFragment) {
+        if (!m_isFragment) {
       m_islandConnectedToken = m_island.Connected(
           [weakThis = get_weak()](
               winrt::IInspectable const &, winrt::Microsoft::UI::Content::ContentIsland const &island) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.h
@@ -154,7 +154,7 @@ struct ReactNativeIsland
   bool m_isJSViewAttached{false};
   bool m_hasRenderedVisual{false};
   bool m_showingLoadingUI{false};
-  bool m_mounted{false};
+  bool m_mounted{true};
   winrt::weak_ref<winrt::Microsoft::ReactNative::Composition::PortalComponentView> m_portal{nullptr};
   IReactDispatcher m_uiDispatcher{nullptr};
   winrt::IInspectable m_uiaProvider{nullptr};

--- a/vnext/Microsoft.ReactNative/packages.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.lock.json
@@ -32,11 +32,11 @@
       },
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
@@ -52,8 +52,8 @@
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       },
       "Microsoft.Windows.SDK.BuildTools": {
         "type": "Transitive",
@@ -87,120 +87,120 @@
     "native,Version=v0.0/win10-arm": {
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       }
     },
     "native,Version=v0.0/win10-arm-aot": {
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       }
     },
     "native,Version=v0.0/win10-arm64-aot": {
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       }
     },
     "native,Version=v0.0/win10-x64": {
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       }
     },
     "native,Version=v0.0/win10-x64-aot": {
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       }
     },
     "native,Version=v0.0/win10-x86": {
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       }
     },
     "native,Version=v0.0/win10-x86-aot": {
       "Microsoft.WindowsAppSDK": {
         "type": "Direct",
-        "requested": "[1.6.240923002, )",
-        "resolved": "1.6.240923002",
-        "contentHash": "7PfOz2scXU+AAM/GYge+f6s7k3DVI+R1P8MNPZQr56GOPCGw+csvcg3S5KZg47z/o04kNvWH3GKtWT1ML9tpZw==",
+        "requested": "[1.7.250401001, )",
+        "resolved": "1.7.250401001",
+        "contentHash": "kPsJ2LZoo3Xs/6FtIWMZRGnQ2ZMx9zDa0ZpqRGz1qwZr0gwwlXZJTmngaA1Ym2AHmIa05NtX2jEE2He8CzfhTg==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.2651.64",
+          "Microsoft.Web.WebView2": "1.0.2903.40",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.2651.64",
-        "contentHash": "f5sc/vcAoTCTEW7Nqzp4galAuTRguZViw8ksn+Nx2uskEBPm0/ubzy6gVjvXS/P96jLS89C8T9I0hPc417xpNg=="
+        "resolved": "1.0.2903.40",
+        "contentHash": "THrzYAnJgE3+cNH+9Epr44XjoZoRELdVpXlWGPs6K9C9G6TqyDfVCeVAR/Er8ljLitIUX5gaSkPsy9wRhD1sgQ=="
       }
     }
   }

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -9,7 +9,7 @@
     <WinUI3ExperimentalVersion Condition="'$(WinUI3ExperimentalVersion)'==''">1.7.250127003-experimental3</WinUI3ExperimentalVersion>
     <!-- This value is also used by the CLI, see /packages/@react-native-windows/cli/.../autolinkWindows.ts -->
     <WinUI3Version Condition="'$(WinUI3Version)'=='' AND '$(UseExperimentalWinUI3)'=='true'">$(WinUI3ExperimentalVersion)</WinUI3Version>
-    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.6.240923002</WinUI3Version>
+    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.7.250401001</WinUI3Version>
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI2x versioning">


### PR DESCRIPTION
## Description
Updating the WASDK version from 1.7 experimental to a released version.
Mostly this is just removing usages of USE_EXPERIMENTAL_WINUI3.  There are a couple of places where we were using APIs that are still marked as experimental, and so were not part of the final 1.7 release.  In particular ContentIsland.Connected/ContentIsland.Disconnected.

Looking at the usage of these APIs in most normal cases we should be OK without these events. In the edge cases where the wrong thing happens here, there are OnMounted/OnUnmounted APIs exposed on Microsoft.ReactNative.Composition.Experimental.IInternalCompositionRootView which can be called to manually call the code that Connected/Disconnected calls.

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Allows consumers to move to a non-experimental version of WASDK.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14574)