### PR TITLE
[Fabric] Implement snapToStart, snapToEnd, snapToInterval and snapToOffsets in ScrollView

### DIFF
--- a/change/react-native-windows-67c23522-cd6e-44c7-a9f1-5848217a698e.json
+++ b/change/react-native-windows-67c23522-cd6e-44c7-a9f1-5848217a698e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric ] Implement snapToStart, snapToEnd, snapToInterval and snapToOffsets in Scrollview",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/scrollViewSnapSample.tsx
+++ b/packages/playground/Samples/scrollViewSnapSample.tsx
@@ -290,6 +290,7 @@ export default class Bootstrap extends React.Component<{}, any> {
             zoomScale={this.state.zoomValue ? 2.0 : 1.0}
             snapToStart={this.state.snapToStartValue}
             snapToEnd={this.state.snapToEndValue}
+            snapToInterval={150}
             snapToAlignment={this.state.alignToStartValue ? 'start' : 'end'}
             horizontal={this.state.horizontalValue}
             showsHorizontalScrollIndicator={

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -128,9 +128,10 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   bool scrollLeft(float delta, bool aniamte) noexcept;
   bool scrollRight(float delta, bool animate) noexcept;
   void updateBackgroundColor(const facebook::react::SharedColor &color) noexcept;
-  void updateStateWithContentOffset() noexcept;
+  void updateStateWithContentOffset(bool applySnapping) noexcept;
   void updateShowsHorizontalScrollIndicator(bool value) noexcept;
   void updateShowsVerticalScrollIndicator(bool value) noexcept;
+  float calculateSnapPosition(float currentOffset, bool isHorizontal) noexcept;
 
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual m_scrollVisual{nullptr};
@@ -147,6 +148,10 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   bool m_isHorizontal = false;
   bool m_changeViewAfterLoaded = false;
   bool m_dismissKeyboardOnDrag = false;
+  bool m_snapToEnd{true};
+  float m_snapToInterval{0.0f};
+  std::vector<float> m_snapToOffsets{};
+  bool m_snapToStart{true};
   std::shared_ptr<facebook::react::ScrollViewShadowNode::ConcreteState const> m_state;
 };
 


### PR DESCRIPTION
## Description
[Fabric] Implement snapToStart, snapToEnd, snapToInterval and snapToOffsets in ScrollView

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.
[Fabric] Implement snapToStart, snapToEnd, snapToInterval and snapToOffsets in ScrollView

Resolves 
- https://github.com/microsoft/react-native-windows/issues/13152
- https://github.com/microsoft/react-native-windows/issues/13151
- https://github.com/microsoft/react-native-windows/issues/13150
- https://github.com/microsoft/react-native-windows/issues/13149

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
[Fabric] Implement snapToStart, snapToEnd, snapToInterval and snapToOffsets in ScrollView

Refer https://github.com/facebook/react-native/blob/618279508159191f2b11c0b20446f91e82a27abf/packages/react-native/React/Views/ScrollView/RCTScrollView.m#L786

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.
- playground tested

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_
YES

Add a brief summary of the change to use in the release notes for the next release.
[Fabric] Implement snapToStart, snapToEnd, snapToInterval and snapToOffsets in ScrollView

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14592)