### PR TITLE
Fix: Text component pressRetentionOffset issue on Windows

### DIFF
--- a/change/react-native-windows-39944bb5-d21b-45da-b750-d01f32e77200.json
+++ b/change/react-native-windows-39944bb5-d21b-45da-b750-d01f32e77200.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix: Text component pressRetentionOffset issue on Windows",
+  "packageName": "react-native-windows",
+  "email": "abhijeetjha@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1059,21 +1059,36 @@ void CompositionEventHandler::onPointerMoved(
 
     facebook::react::PointerEvent pointerEvent = CreatePointerEventFromIncompleteHoverData(ptScaled, ptLocal);
 
+    //check if this pointer corresponds to active touch that has a responder
+    auto activeTouch = m_activeTouches.find(pointerId);
+    bool isActiveTouch = activeTouch != m_activeTouches.end() && activeTouch->second.eventEmitter != nullptr;
+
+
     auto handler = [&targetView,
-                    &pointerEvent](std::vector<winrt::Microsoft::ReactNative::ComponentView> &eventPathViews) {
+                    &pointerEvent, isActiveTouch](std::vector<winrt::Microsoft::ReactNative::ComponentView> &eventPathViews) {
       const auto eventEmitter = targetView
           ? winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetView)
                 ->eventEmitterAtPoint(pointerEvent.offsetPoint)
           : nullptr;
       bool hasMoveEventListeners =
+          isActiveTouch ||
           IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMove) ||
           IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMoveCapture);
+
+
       if (eventEmitter != nullptr && hasMoveEventListeners) {
+        // Add logging before dispatching the event
         eventEmitter->onPointerMove(pointerEvent);
       }
     };
 
     HandleIncomingPointerEvent(pointerEvent, targetView, pointerPoint, keyModifiers, handler);
+
+    if (isActiveTouch) {
+      // For active touches with responders, also dispatch through touch event system
+      UpdateActiveTouch(activeTouch->second, ptScaled, ptLocal);
+      DispatchTouchEvent(TouchEventType::Move, pointerId, pointerPoint, keyModifiers);
+    }
   }
 }
 
@@ -1387,12 +1402,7 @@ void CompositionEventHandler::DispatchTouchEvent(
           activeTouch.eventEmitter->onPointerDown(pointerEvent);
           break;
         case TouchEventType::Move: {
-          bool hasMoveEventListeners =
-              IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMove) ||
-              IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMoveCapture);
-          if (hasMoveEventListeners) {
-            activeTouch.eventEmitter->onPointerMove(pointerEvent);
-          }
+          activeTouch.eventEmitter->onPointerMove(pointerEvent);
           break;
         }
         case TouchEventType::End:

--- a/vnext/src-win/Libraries/Text/Text.d.ts
+++ b/vnext/src-win/Libraries/Text/Text.d.ts
@@ -224,6 +224,12 @@ export interface TextProps
    * Controls how touch events are handled. Similar to `View`'s `pointerEvents`.
    */
   pointerEvents?: ViewStyle['pointerEvents'] | undefined;
+
+  /**
+   * Insets for press retention.
+   * Example: { top: 20, left: 20, bottom: 20, right: 20 }
+   */
+  pressRetentionOffset?: { top: number, left: number, bottom: number, right: number } | undefined;
 }
 
 /**


### PR DESCRIPTION
## Description
Text component pressRetentionOffset on Windows wasnt working as expected behaviour as it is on native components

PressRetentionOffset implementation is working correctly, allowing touches to remain active within the expanded area while canceling them when moving beyond it.

Problem :
1> when press is moved away from retention offset , it wasnt cancelling then .
2> JS side was handling in pressability and this was hooked to test using usePressability but the issue was that the
PressRetentionOffset  was called with onResponderMove which was never triggered from native side .





### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_

Add a brief summary of the change to use in the release notes for the next release.