### PR TITLE
Fix creaternwapp.cmd and creaternwlib.cmd

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -73,7 +73,7 @@ steps:
 
   - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
-        $(Build.SourcesDirectory)\vnext\Scripts\creaternwapp.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /lt ${{ parameters.template }} /verdaccio testcli
+        $(Build.SourcesDirectory)\vnext\Scripts\creaternwapp.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /t ${{ parameters.template }} /verdaccio testcli
       displayName: Init new app project with creaternwapp.cmd
       workingDirectory: $(Agent.BuildDirectory)
       env:
@@ -81,7 +81,7 @@ steps:
 
   - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
-        $(Build.SourcesDirectory)\vnext\Scripts\creaternwlib.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /verdaccio testcli
+        $(Build.SourcesDirectory)\vnext\Scripts\creaternwlib.cmd /rn $(reactNativeDevDependency) /rnw $(npmVersion) /t ${{ parameters.template }} /verdaccio testcli
       displayName: Init new lib project with creaternwlib.cmd
       workingDirectory: $(Agent.BuildDirectory)
       env:

--- a/change/react-native-windows-ffd49029-f408-419d-85e1-6bdd4b29b3b2.json
+++ b/change/react-native-windows-ffd49029-f408-419d-85e1-6bdd4b29b3b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add git repo check to creaternwapp.cmd and creaternwlib.cmd",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/creaternwapp.cmd
+++ b/vnext/Scripts/creaternwapp.cmd
@@ -123,10 +123,9 @@ pushd "%APP_NAME%"
 
 if not "x%RN_VERSION:nightly=%"=="x%RN_VERSION%" (
   @echo creaternwapp.cmd Fixing react-native nightly issues
-  pwsh.exe -Command "(gc package.json) -replace '""nightly""', '""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli"": "".*""', '""@react-native-community/cli"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli-platform-android"": "".*""', '""@react-native-community/cli-platform-android"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli-platform-ios"": "".*""', '""@react-native-community/cli-platform-ios"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""react-native"": ""[^\*]*""', '""react-native"": ""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""@react-native/(.+-(config|preset))"": "".*""', '""@react-native/$1"": ""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli((-platform-)?(ios|android))?"": "".*""', '""@react-native-community/cli$1"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
 )
 
 @echo creaternwapp.cmd: Calling yarn install

--- a/vnext/Scripts/creaternwapp.cmd
+++ b/vnext/Scripts/creaternwapp.cmd
@@ -8,7 +8,7 @@ REM name            The name of the app to create (default: testapp)
 REM /r [version]    Use react@version (default: latest)
 REM /rn [version]   Use react-native@version (default: latest)
 REM /rnw [version]  Use react-native-windows@version (default: latest)
-REM /lt [template]  Use template (default: cpp-app)
+REM /t [template]   Use template (default: cpp-app)
 REM /linkrnw        Use your local RNW repo at RNW_ROOT
 REM /verdaccio      Configure new project to use verdaccio (used in CI)
 REM
@@ -16,6 +16,12 @@ REM Requirements:
 REM - You've set the RNW_ROOT environment variable with the path to your clone
 
 setlocal enableextensions enabledelayedexpansion
+
+call git rev-parse --is-inside-work-tree > NUL 2>&1
+if %ERRORLEVEL% equ 0 (
+  @echo creaternwapp.cmd: Unable to create a new project in an existing git repo
+  exit /b -1
+)
 
 if "%RNW_ROOT%"=="" (
   @echo creaternwapp.cmd: RNW_ROOT environment variable set to %~dp0..\..
@@ -50,7 +56,7 @@ if not "%part%"=="" (
   ) else if "%part%"=="/rnw" (
       set RNW_VERSION=%param%
       shift
-  ) else if "%part%"=="/lt" (
+  ) else if "%part%"=="/t" (
       set RNW_TEMPLATE_TYPE=%param%
       shift
   ) else if "%part:~0,1%"=="/" (

--- a/vnext/Scripts/creaternwlib.cmd
+++ b/vnext/Scripts/creaternwlib.cmd
@@ -116,8 +116,8 @@ for /f "delims=" %%a in ('npm show react@%R_VERSION% version') do @set R_VERSION
 
 @echo creaternwlib.cmd Creating RNW lib "%LIB_NAME%" with react@%R_VERSION%, react-native@%RN_VERSION%, and react-native-windows@%RNW_VERSION%
 
-@echo creaternwlib.cmd Creating base RN library project with: npx --yes create-react-native-library@latest --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --local false --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
-call npx --yes create-react-native-library@latest --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --local false --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
+@echo creaternwlib.cmd Creating base RN library project with: npx --yes create-react-native-library@0.48.9 --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --local false --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
+call npx --yes create-react-native-library@0.48.9 --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --local false --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
 
 if %ERRORLEVEL% neq 0 (
   @echo creaternwlib.cmd: Unable to create base RN library project

--- a/vnext/Scripts/creaternwlib.cmd
+++ b/vnext/Scripts/creaternwlib.cmd
@@ -4,11 +4,12 @@ REM Creates a RNW lib using the new arch template
 REM
 REM Options:
 REM
-REM name            The name of the app to create (default: testlib)
+REM name            The name of the lib to create (default: testlib)
 REM /r [version]    Use react@version (default: latest)
 REM /rn [version]   Use react-native@version (default: latest)
 REM /rnw [version]  Use react-native-windows@version (default: latest)
-REM /lt [template]  Use create-react-native-library template (default: turbo-module)
+REM /t [template]   Use template (default: cpp-lib)
+REM /bt [template]  Use base create-react-native-library template (default: turbo-module)
 REM /linkrnw        Use your local RNW repo at RNW_ROOT
 REM /verdaccio      Configure new project to use verdaccio (used in CI)
 REM
@@ -16,6 +17,12 @@ REM Requirements:
 REM - You've set the RNW_ROOT environment variable with the path to your clone
 
 setlocal enableextensions enabledelayedexpansion
+
+call git rev-parse --is-inside-work-tree > NUL 2>&1
+if %ERRORLEVEL% equ 0 (
+  @echo creaternwlib.cmd: Unable to create a new project in an existing git repo
+  exit /b -1
+)
 
 if "%RNW_ROOT%"=="" (
   @echo creaternwlib.cmd: RNW_ROOT environment variable set to %~dp0..\..
@@ -51,7 +58,10 @@ if not "%part%"=="" (
   ) else if "%part%"=="/rnw" (
       set RNW_VERSION=%param%
       shift
-  ) else if "%part%"=="/lt" (
+  ) else if "%part%"=="/t" (
+      set RNW_TEMPLATE_TYPE=%param%
+      shift
+  ) else if "%part%"=="/bt" (
       set RN_TEMPLATE_TYPE=%param%
       shift
   ) else if "%part:~0,1%"=="/" (

--- a/vnext/Scripts/creaternwlib.cmd
+++ b/vnext/Scripts/creaternwlib.cmd
@@ -116,8 +116,8 @@ for /f "delims=" %%a in ('npm show react@%R_VERSION% version') do @set R_VERSION
 
 @echo creaternwlib.cmd Creating RNW lib "%LIB_NAME%" with react@%R_VERSION%, react-native@%RN_VERSION%, and react-native-windows@%RNW_VERSION%
 
-@echo creaternwlib.cmd Creating base RN library project with: npx --yes create-react-native-library@latest --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
-call npx --yes create-react-native-library@latest --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
+@echo creaternwlib.cmd Creating base RN library project with: npx --yes create-react-native-library@latest --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --local false --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
+call npx --yes create-react-native-library@latest --slug %LIB_NAME% --description %LIB_NAME% --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --local false --type %RN_TEMPLATE_TYPE% --react-native-version %RN_VERSION% --example vanilla %LIB_NAME%
 
 if %ERRORLEVEL% neq 0 (
   @echo creaternwlib.cmd: Unable to create base RN library project
@@ -128,15 +128,13 @@ pushd "%LIB_NAME%"
 
 if not "x%RN_VERSION:nightly=%"=="x%RN_VERSION%" (
   @echo creaternwlib.cmd Fixing react-native nightly issue
-  pwsh.exe -Command "(gc package.json) -replace '""nightly""', '""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli"": "".*""', '""@react-native-community/cli"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli-platform-android"": "".*""', '""@react-native-community/cli-platform-android"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli-platform-ios"": "".*""', '""@react-native-community/cli-platform-ios"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""react-native"": ""[^\*]*""', '""react-native"": ""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""@react-native/(.+-(config|preset))"": "".*""', '""@react-native/$1"": ""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli((-platform-)?(ios|android))?"": "".*""', '""@react-native-community/cli$1"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
   pushd example
-  pwsh.exe -Command "(gc package.json) -replace '""nightly""', '""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli"": "".*""', '""@react-native-community/cli"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli-platform-android"": "".*""', '""@react-native-community/cli-platform-android"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
-  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli-platform-ios"": "".*""', '""@react-native-community/cli-platform-ios"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""react-native"": ""[^\*]*""', '""react-native"": ""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""@react-native/(.+-(config|preset))"": "".*""', '""@react-native/$1"": ""%RN_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
+  pwsh.exe -Command "(gc package.json) -replace '""@react-native-community/cli((-platform-)?(ios|android))?"": "".*""', '""@react-native-community/cli$1"": ""%RNCLI_VERSION%""' | Out-File -encoding utf8NoBOM package.json"
   popd
 )
 


### PR DESCRIPTION
## Description

This PR fixes the `creaternwapp.cmd` and `creaternwlib.cmd` scripts in CI due to new upstream bugs, but also adds a check to make sure the command isn't run within an existing git repo. The commands for new RN projects are opinionated about how they set up new projects, and can override the settings in existing git repos.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To make sure no one runs these scripts an accidentally messes up their git repo with foreign git hooks, especially *this* repo.

Resolves #14632 
Resolves #14633 

### What
See above.

## Screenshots
N/A

## Testing
Verified the scripts no longer work for creating new projects within this repo.

## Changelog
Should this change be included in the release notes: _no_