### PR TITLE
[Fabric] Implement selectTextOnFocus prop in TextInput

### DIFF
--- a/change/react-native-windows-01615f82-6942-4a39-8608-3e010f4b9009.json
+++ b/change/react-native-windows-01615f82-6942-4a39-8608-3e010f4b9009.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Implement selectTextOnFocus in Text Input",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -210,6 +210,30 @@ const examples: Array<RNTesterModuleExample> = [
     },
   },
   {
+    title: 'Select text on focus',
+    render: function (): React.Node {
+      return (
+        <View>
+          <Text>Select text on focus:</Text>
+          <ExampleTextInput
+            selectTextOnFocus={true}
+            style={styles.singleLine}
+            testID="select-text-on-focus"
+          />
+          <Text>
+            Do not select text on focus if clear text on focus is enabled:
+          </Text>
+          <ExampleTextInput
+            selectTextOnFocus={true}
+            clearTextOnFocus={true}
+            style={styles.singleLine}
+            testID="select-text-on-focus-while-clear-text-on-focus"
+          />
+        </View>
+      );
+    },
+  },
+  {
     title: 'Colors and text inputs',
     render: function (): React.Node {
       return (

--- a/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
@@ -504,6 +504,59 @@ describe('TextInput Tests', () => {
     // Verify the textInput contents are cleared after regaining focus
     expect(await componentFocusTrue.getText()).toBe('');
   });
+  test('TextInputs can select text on focus', async () => {
+    const component = await app.findElementByTestID('select-text-on-focus');
+    await component.waitForDisplayed({timeout: 5000});
+
+    await app.waitUntil(
+      async () => {
+        await component.setValue('Hello World');
+        return (await component.getText()) === 'Hello World';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
+
+    // Check if the text is selected on focus.
+    await component.click();
+
+    const dump = await dumpVisualTree('select-text-on-focus');
+    expect(dump).toMatchSnapshot();
+  });
+  test('TextInputs can clear text on focus even if selectTextOnFocus == true', async () => {
+    const targetComponent = await app.findElementByTestID(
+      'select-text-on-focus-while-clear-text-on-focus',
+    );
+    await targetComponent.waitForDisplayed({timeout: 5000});
+
+    await app.waitUntil(
+      async () => {
+        await targetComponent.setValue('Hello World');
+        return (await targetComponent.getText()) === 'Hello World';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
+
+    // Click on the previous textInput to move focus away from this TextInput
+    const anotherTextInput = await app.findElementByTestID(
+      'select-text-on-focus',
+    );
+    await anotherTextInput.waitForDisplayed({timeout: 5000});
+    await anotherTextInput.click();
+
+    // Now click on the tested component, make sure the text is cleared.
+    await targetComponent.click();
+
+    // Verify the textInput contents are cleared after regaining focus
+    expect(await targetComponent.getText()).toBe('');
+  });
   test('TextInputs can have inline images', async () => {
     const component = await app.findElementByTestID('textinput-inline-images');
     await component.waitForDisplayed({timeout: 5000});

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -639,7 +639,7 @@ exports[`TextInput Tests TextInputs can autocomplete, address country 1`] = `
   "Visual Tree": {
     "Comment": "textinput-autocomplete-address-country",
     "Offset": "0, 0, 0",
-    "Size": "916, 28",
+    "Size": "916, 29",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -717,7 +717,7 @@ exports[`TextInput Tests TextInputs can autocomplete, country 1`] = `
   "Visual Tree": {
     "Comment": "textinput-autocomplete-country",
     "Offset": "0, 0, 0",
-    "Size": "916, 29",
+    "Size": "916, 28",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -1144,12 +1144,12 @@ exports[`TextInput Tests TextInputs can be defined as a set using accessibilityP
       },
       {
         "Offset": "0, 31, 0",
-        "Size": "916, 33",
+        "Size": "916, 32",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "916, 33",
+            "Size": "916, 32",
             "Visual Type": "SpriteVisual",
             "__Children": [
               {
@@ -1208,12 +1208,12 @@ exports[`TextInput Tests TextInputs can be defined as a set using accessibilityP
       },
       {
         "Offset": "0, 62, 0",
-        "Size": "916, 32",
+        "Size": "916, 33",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "916, 32",
+            "Size": "916, 33",
             "Visual Type": "SpriteVisual",
             "__Children": [
               {
@@ -1605,7 +1605,7 @@ exports[`TextInput Tests TextInputs can be set to not editable 1`] = `
   "Visual Tree": {
     "Comment": "textinput-not-editable",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -2757,7 +2757,7 @@ exports[`TextInput Tests TextInputs can have custom return key label, Compile 1`
   "Visual Tree": {
     "Comment": "textinput-return-Compile",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3069,7 +3069,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, next 1`] = 
   "Visual Tree": {
     "Comment": "textinput-return-next",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3147,7 +3147,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, none 1`] = 
   "Visual Tree": {
     "Comment": "textinput-return-none",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3303,7 +3303,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, search 1`] 
   "Visual Tree": {
     "Comment": "textinput-return-search",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3381,7 +3381,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, send 1`] = 
   "Visual Tree": {
     "Comment": "textinput-return-send",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3615,7 +3615,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=2 
   "Visual Tree": {
     "Comment": "textinput-letterspacing-2",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -3693,7 +3693,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=9 
   "Visual Tree": {
     "Comment": "textinput-letterspacing-9",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4099,7 +4099,7 @@ exports[`TextInput Tests TextInputs can have inline images, drawable props not s
   "Visual Tree": {
     "Comment": "textinput-inline-images-3",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4177,7 +4177,7 @@ exports[`TextInput Tests TextInputs can have inline images, drawableLeft and dra
   "Visual Tree": {
     "Comment": "textinput-inline-images-2",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4848,6 +4848,83 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with U
 }
 `;
 
+exports[`TextInput Tests TextInputs can select text on focus 1`] = `
+{
+  "Automation Tree": {
+    "AutomationId": "select-text-on-focus",
+    "ControlType": 50004,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "edit",
+    "TextRangePattern.GetText": "Hello World",
+    "ValuePattern.Value": "Hello World",
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.WindowsTextInputComponentView",
+    "_Props": {
+      "TestId": "select-text-on-focus",
+    },
+  },
+  "Visual Tree": {
+    "Comment": "select-text-on-focus",
+    "Offset": "0, 0, 0",
+    "Size": "916, 32",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "0, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, 0, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 0, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "-1, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "1, -1, 0",
+        "Size": "-2, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, -1, 0",
+        "Size": "1, 1",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Offset": "0, 1, 0",
+        "Size": "1, -2",
+        "Visual Type": "SpriteVisual",
+      },
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": "83, 5, 0",
+        "Opacity": 0,
+        "Size": "1, 19",
+        "Visual Type": "SpriteVisual",
+      },
+    ],
+  },
+}
+`;
+
 exports[`TextInput Tests TextInputs can set their readOnly prop to false 1`] = `
 {
   "Automation Tree": {
@@ -4868,7 +4945,7 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to false 1`] = `
   "Visual Tree": {
     "Comment": "textinput-readonly-false",
     "Offset": "0, 0, 0",
-    "Size": "916, 29",
+    "Size": "916, 28",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -4946,7 +5023,7 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to true 1`] = `
   "Visual Tree": {
     "Comment": "textinput-readyonly",
     "Offset": "0, 0, 0",
-    "Size": "916, 28",
+    "Size": "916, 29",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5175,7 +5252,7 @@ exports[`TextInput Tests TextInputs have a custom highlight color 1`] = `
   "Visual Tree": {
     "Comment": "textinput-custom-highlight-color",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5253,7 +5330,7 @@ exports[`TextInput Tests TextInputs have a custom placeholder text color 1`] = `
   "Visual Tree": {
     "Comment": "textinput-custom-placeholder-color",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5330,7 +5407,7 @@ exports[`TextInput Tests TextInputs have a custom text color 1`] = `
   "Visual Tree": {
     "Comment": "textinput-custom-color",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5563,7 +5640,7 @@ exports[`TextInput Tests TextInputs have a default text color 1`] = `
   "Visual Tree": {
     "Comment": "textinput-default-color",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5641,7 +5718,7 @@ exports[`TextInput Tests TextInputs have a default underline color 1`] = `
   "Visual Tree": {
     "Comment": "textinput-default-underline-color",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 33",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5796,7 +5873,7 @@ exports[`TextInput Tests TextInputs support secure entry, with placeholder text 
   "Visual Tree": {
     "Comment": "textinput-password-placeholder",
     "Offset": "0, 0, 0",
-    "Size": "916, 33",
+    "Size": "916, 32",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5886,7 +5963,7 @@ exports[`TextInput Tests TextInputs which have a searchbox role should also supp
   "Visual Tree": {
     "Comment": "textinput-searchbox",
     "Offset": "0, 0, 0",
-    "Size": "916, 32",
+    "Size": "916, 31",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -78016,6 +78016,64 @@ exports[`snapshotAllPages TextInput 22`] = `
 
 exports[`snapshotAllPages TextInput 23`] = `
 <View>
+  <Text>
+    Select text on focus:
+  </Text>
+  <TextInput
+    selectTextOnFocus={true}
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        {
+          "fontSize": 16,
+        },
+      ]
+    }
+    testID="select-text-on-focus"
+  />
+  <Text>
+    Do not select text on focus if clear text on focus is enabled:
+  </Text>
+  <TextInput
+    clearTextOnFocus={true}
+    selectTextOnFocus={true}
+    style={
+      [
+        {
+          "backgroundColor": "#ffffffff",
+          "borderColor": "#3c3c432d",
+          "color": "#000000ff",
+        },
+        {
+          "borderWidth": 1,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "fontSize": 13,
+          "padding": 4,
+        },
+        {
+          "fontSize": 16,
+        },
+      ]
+    }
+    testID="select-text-on-focus-while-clear-text-on-focus"
+  />
+</View>
+`;
+
+exports[`snapshotAllPages TextInput 24`] = `
+<View>
   <TextInput
     defaultValue="Default color text"
     style={
@@ -78274,7 +78332,7 @@ exports[`snapshotAllPages TextInput 23`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 24`] = `
+exports[`snapshotAllPages TextInput 25`] = `
 <View>
   <TextInput
     defaultValue="Font Weight (default)"
@@ -78612,7 +78670,7 @@ exports[`snapshotAllPages TextInput 24`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 25`] = `
+exports[`snapshotAllPages TextInput 26`] = `
 <View
   testID="style-fontFamily"
 >
@@ -78840,7 +78898,7 @@ exports[`snapshotAllPages TextInput 25`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 26`] = `
+exports[`snapshotAllPages TextInput 27`] = `
 <TextInput
   placeholder="If you set height, beware of padding set from themes"
   style={
@@ -78868,7 +78926,7 @@ exports[`snapshotAllPages TextInput 26`] = `
 />
 `;
 
-exports[`snapshotAllPages TextInput 27`] = `
+exports[`snapshotAllPages TextInput 28`] = `
 <View>
   <TextInput
     placeholder="letterSpacing = 0"
@@ -78985,7 +79043,7 @@ exports[`snapshotAllPages TextInput 27`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 28`] = `
+exports[`snapshotAllPages TextInput 29`] = `
 <View>
   <TextInput
     defaultValue="iloveturtles"
@@ -79044,7 +79102,7 @@ exports[`snapshotAllPages TextInput 28`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 29`] = `
+exports[`snapshotAllPages TextInput 30`] = `
 <TextInput
   defaultValue="Can't touch this! (>'-')> ^(' - ')^ <('-'<) (>'-')> ^(' - ')^"
   editable={false}
@@ -79071,7 +79129,7 @@ exports[`snapshotAllPages TextInput 29`] = `
 />
 `;
 
-exports[`snapshotAllPages TextInput 30`] = `
+exports[`snapshotAllPages TextInput 31`] = `
 <View>
   <TextInput
     autoCorrect={true}
@@ -79187,7 +79245,7 @@ exports[`snapshotAllPages TextInput 30`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 31`] = `
+exports[`snapshotAllPages TextInput 32`] = `
 <View>
   <TextInput
     editable={true}
@@ -79280,7 +79338,7 @@ exports[`snapshotAllPages TextInput 31`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 32`] = `
+exports[`snapshotAllPages TextInput 33`] = `
 <View
   style={
     {
@@ -79379,7 +79437,7 @@ exports[`snapshotAllPages TextInput 32`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 33`] = `
+exports[`snapshotAllPages TextInput 34`] = `
 <View
   style={
     {
@@ -79497,7 +79555,7 @@ exports[`snapshotAllPages TextInput 33`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 34`] = `
+exports[`snapshotAllPages TextInput 35`] = `
 <View>
   <TextInput
     autoComplete="country"
@@ -79611,7 +79669,7 @@ exports[`snapshotAllPages TextInput 34`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 35`] = `
+exports[`snapshotAllPages TextInput 36`] = `
 <View>
   <TextInput
     placeholder="returnKeyType: none"
@@ -79832,7 +79890,7 @@ exports[`snapshotAllPages TextInput 35`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 36`] = `
+exports[`snapshotAllPages TextInput 37`] = `
 <View>
   <TextInput
     inlineImageLeft="ic_menu_black_24dp"
@@ -79909,7 +79967,7 @@ exports[`snapshotAllPages TextInput 36`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 37`] = `
+exports[`snapshotAllPages TextInput 38`] = `
 <View>
   <TextInput
     style={
@@ -79939,7 +79997,7 @@ exports[`snapshotAllPages TextInput 37`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 38`] = `
+exports[`snapshotAllPages TextInput 39`] = `
 <View>
   <Text
     testID="textinput-state-display"
@@ -79976,7 +80034,7 @@ exports[`snapshotAllPages TextInput 38`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 39`] = `
+exports[`snapshotAllPages TextInput 40`] = `
 <View>
   <Text>
     Default submit key (Enter):
@@ -80112,7 +80170,7 @@ exports[`snapshotAllPages TextInput 39`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 40`] = `
+exports[`snapshotAllPages TextInput 41`] = `
 [
   <View
     focusable={true}
@@ -80178,7 +80236,7 @@ exports[`snapshotAllPages TextInput 40`] = `
 ]
 `;
 
-exports[`snapshotAllPages TextInput 41`] = `
+exports[`snapshotAllPages TextInput 42`] = `
 [
   <Text>
     Spell Check Enabled:
@@ -80227,7 +80285,7 @@ exports[`snapshotAllPages TextInput 41`] = `
 ]
 `;
 
-exports[`snapshotAllPages TextInput 42`] = `
+exports[`snapshotAllPages TextInput 43`] = `
 <View>
   <Text>
     CaretHidden
@@ -80259,7 +80317,7 @@ exports[`snapshotAllPages TextInput 42`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 43`] = `
+exports[`snapshotAllPages TextInput 44`] = `
 <View>
   <Text>
     Cursorcolor
@@ -80291,7 +80349,7 @@ exports[`snapshotAllPages TextInput 43`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 44`] = `
+exports[`snapshotAllPages TextInput 45`] = `
 <View>
   <Text>
     Shadow
@@ -80329,7 +80387,7 @@ exports[`snapshotAllPages TextInput 44`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 45`] = `
+exports[`snapshotAllPages TextInput 46`] = `
 <View
   accessible={true}
   testID="textinput-set"
@@ -80412,7 +80470,7 @@ exports[`snapshotAllPages TextInput 45`] = `
 </View>
 `;
 
-exports[`snapshotAllPages TextInput 46`] = `
+exports[`snapshotAllPages TextInput 47`] = `
 <View
   accessible={true}
   testID="textinput-searchbox"

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -83,6 +83,19 @@ export default class Bootstrap extends React.Component<{}, any> {
             />
             <TextInput
               style={styles.input}
+              selectTextOnFocus={true}
+              placeholder={'Select text on focus'}
+            />
+            <TextInput
+              style={styles.input}
+              clearTextOnFocus={true}
+              selectTextOnFocus={true}
+              placeholder={
+                'Clear text on focus, even if selectTextOnFocus is true'
+              }
+            />
+            <TextInput
+              style={styles.input}
               placeholder={'SpellChecking Enabled Autocorrect Disabled'}
               spellCheck={true}
               autoCorrect={false}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -973,6 +973,10 @@ void WindowsTextInputComponentView::onLostFocus(
     LRESULT lresult;
     DrawBlock db(*this);
     m_textServices->TxSendMessage(WM_KILLFOCUS, 0, 0, &lresult);
+    if (windowsTextInputProps().selectTextOnFocus) {
+      LRESULT res;
+      m_textServices->TxSendMessage(EM_SETSEL, static_cast<WPARAM>(-1), static_cast<WPARAM>(-1), &res);
+    }
   }
   m_caretVisual.IsVisible(false);
 
@@ -1001,6 +1005,9 @@ void WindowsTextInputComponentView::onGotFocus(
 
     if (windowsTextInputProps().clearTextOnFocus) {
       m_textServices->TxSetText(L"");
+    } else if (windowsTextInputProps().selectTextOnFocus) {
+      LRESULT res;
+      m_textServices->TxSendMessage(EM_SETSEL, static_cast<WPARAM>(0), static_cast<WPARAM>(-1), &res);
     }
   }
 }


### PR DESCRIPTION
## Description

### Type of Change
New feature.

### Why
Implement selectTextOnFocus prop in TextInput. It is implemented in Paper; this PR brings the Fabric implementation.

Resolves #13133 

### What
Created a function that:
- Selects the whole text when the TextInput is focused
- Drops the selection when TextInput loses focus

Text selection will not occur if `clearTextOnFocus` prop is set to `true`. This is purely by design, as the RN documentation doesn't specify what the behavior should be. For reference, if both props are set to true, Android doesn't clear the text on focus and performs the selection, but iOS clears the text input.

Refer https://learn.microsoft.com/en-us/windows/win32/controls/em-setsel

## Screenshots

https://github.com/user-attachments/assets/889906f8-c7f2-4ef0-8d70-29eaea46723e


## Testing
Added e2e tests to TextInputComponentTest and two TextInput fields in playground, in both cases demonstrating the capabilities explained above.

## Changelog
Yes

Implement selectTextOnFocus for TextInput in Fabric

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14641)