### PR TITLE
Properly hook up root uia provider to island

### DIFF
--- a/change/react-native-windows-26d524ee-3303-4cbf-a1d5-2c876d58c088.json
+++ b/change/react-native-windows-26d524ee-3303-4cbf-a1d5-2c876d58c088.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Properly hook up root uia provider to island",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -376,11 +376,12 @@ winrt::IInspectable ReactNativeIsland::GetUiaProvider() noexcept {
   if (m_uiaProvider == nullptr) {
     m_uiaProvider =
         winrt::make<winrt::Microsoft::ReactNative::implementation::CompositionRootAutomationProvider>(*this);
-    if (m_hwnd && !m_island) {
+    if (m_hwnd || m_island) {
       auto pRootProvider =
           static_cast<winrt::Microsoft::ReactNative::implementation::CompositionRootAutomationProvider *>(
               m_uiaProvider.as<IRawElementProviderSimple>().get());
       if (pRootProvider != nullptr) {
+        pRootProvider->SetIsland(m_island);
         pRootProvider->SetHwnd(m_hwnd);
       }
     }
@@ -875,14 +876,7 @@ winrt::Microsoft::UI::Content::ContentIsland ReactNativeIsland::Island() {
             winrt::Microsoft::UI::Content::ContentIsland const &,
             winrt::Microsoft::UI::Content::ContentIslandAutomationProviderRequestedEventArgs const &args) {
           if (auto pThis = weakThis.get()) {
-            auto provider = pThis->GetUiaProvider();
-            auto pRootProvider =
-                static_cast<winrt::Microsoft::ReactNative::implementation::CompositionRootAutomationProvider *>(
-                    provider.as<IRawElementProviderSimple>().get());
-            if (pRootProvider != nullptr) {
-              pRootProvider->SetIsland(pThis->m_island);
-            }
-            args.AutomationProvider(std::move(provider));
+            args.AutomationProvider(pThis->GetUiaProvider());
             args.Handled(true);
           }
         });


### PR DESCRIPTION
If you have a UIA tool running and set focus to a component before the island, then you get asserts from the CompositionRootAutomationProvider.

This was due to the CompositionRootAutomationProvider never having the island set on it.