### PR TITLE
Re-enable test:windows call on fabric app CLI tests

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -159,12 +159,11 @@ steps:
     parameters:
       buildLogDirectory: '$(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs'
 
-  # #13705 - Temporarily disable test:windows call until we get upstream fix
   # Only run the following on fabric apps
-  # - ${{ if and(endsWith(parameters.template, '-app')) }}:
-  #   - script: call yarn test:windows
-  #     displayName: Run jest tests with react-test-renderer
-  #     workingDirectory: $(Agent.BuildDirectory)\testcli
+  - ${{ if and(endsWith(parameters.template, '-app')) }}:
+    - script: call yarn test:windows
+      displayName: Run jest tests with react-test-renderer
+      workingDirectory: $(Agent.BuildDirectory)\testcli
 
   # Only test bundling in debug since we already bundle as part of release builds
   - ${{ if and(endsWith(parameters.template, '-app'), eq(parameters.configuration, 'Debug')) }}:


### PR DESCRIPTION
## Description
Upstream needs to update the flow syntax babel plugin used by jest which was causing yarn test to fail on new template apps. Temporarily disabling calling test:windows on windows-init tests to unblock CI.

upstream PR is merged: we need switch Re-enable test:windows call on fabric app

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.
upstream PR is merged: we need switch Re-enable test:windows call on fabric app

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-windows/issues/13705

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

 Re-enable test:windows in .ado/react-native-init-windows.yaml
 
## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.
Testing in Pipeline 


## Changelog
no
