### PR TITLE
[0.78] Fixing unreferenced parameter warnings as errors in Playground-Composition and elsewhere

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -66,7 +66,7 @@ steps:
 
   - ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
     - script: |
-        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type turbo-module --react-native-version $(reactNativeDevDependency) --example vanilla testcli
+        npx --yes create-react-native-library@0.48.9 --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type turbo-module --react-native-version $(reactNativeDevDependency) --example vanilla testcli
       displayName: Init new lib project with create-react-native-library
       workingDirectory: $(Agent.BuildDirectory)
 

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -94,7 +94,7 @@ winrt::Microsoft::ReactNative::ReactNativeHost CreateReactNativeHost(
 #endif
 
   host.InstanceSettings().InstanceLoaded(
-      [](auto sender, const winrt::Microsoft::ReactNative::InstanceLoadedEventArgs &args) {
+      [](auto /*sender*/, const winrt::Microsoft::ReactNative::InstanceLoadedEventArgs &args) {
         global_reactContext = args.Context();
       });
 
@@ -168,7 +168,7 @@ WinMain(HINSTANCE /* instance */, HINSTANCE, PSTR /* commandLine */, int /* show
         // Before we shutdown the application - unload the ReactNativeHost to give the javascript a chance to save any
         // state
         auto async = host.UnloadInstance();
-        async.Completed([host](auto asyncInfo, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
+        async.Completed([host](auto /*asyncInfo*/, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
           asyncStatus;
           assert(asyncStatus == winrt::Windows::Foundation::AsyncStatus::Completed);
           host.InstanceSettings().UIDispatcher().Post([]() { PostQuitMessage(0); });
@@ -331,7 +331,7 @@ void InsertExpandCollapseStateValueIfNotDefault(
   }
 }
 
-winrt::Windows::Data::Json::JsonObject ListErrors(winrt::Windows::Data::Json::JsonValue payload) {
+winrt::Windows::Data::Json::JsonObject ListErrors(winrt::Windows::Data::Json::JsonValue /*payload*/) {
   winrt::Windows::Data::Json::JsonObject result;
   winrt::Windows::Data::Json::JsonArray jsonErrors;
   winrt::Windows::Data::Json::JsonArray jsonWarnings;

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -53,7 +53,7 @@ void RegisterCustomComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder
  */
 struct EllipseImageHandler
     : winrt::implements<EllipseImageHandler, winrt::Microsoft::ReactNative::Composition::IUriImageProvider> {
-  bool CanLoadImageUri(winrt::Microsoft::ReactNative::IReactContext context, winrt::Windows::Foundation::Uri uri) {
+  bool CanLoadImageUri(winrt::Microsoft::ReactNative::IReactContext /*context*/, winrt::Windows::Foundation::Uri uri) {
     return uri.SchemeName() == L"ellipse";
   }
 
@@ -118,7 +118,6 @@ winrt::Windows::UI::Composition::Compositor g_compositor{nullptr};
 constexpr auto WindowDataProperty = L"WindowData";
 
 int RunPlayground(int showCmd, bool useWebDebugger);
-winrt::Microsoft::ReactNative::IReactPackageProvider CreateStubDeviceInfoPackageProvider() noexcept;
 
 struct WindowData {
   static HINSTANCE s_instance;
@@ -280,7 +279,7 @@ struct WindowData {
                 // Disable user sizing of the hwnd
                 ::SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) & ~WS_SIZEBOX);
                 m_compRootView.SizeChanged(
-                    [hwnd](auto sender, const winrt::Microsoft::ReactNative::RootViewSizeChangedEventArgs &args) {
+                    [hwnd](auto /*sender*/, const winrt::Microsoft::ReactNative::RootViewSizeChangedEventArgs &args) {
                       RECT rcClient, rcWindow;
                       GetClientRect(hwnd, &rcClient);
                       GetWindowRect(hwnd, &rcWindow);
@@ -375,7 +374,7 @@ struct WindowData {
       case IDM_UNLOAD: {
         auto async = Host().UnloadInstance();
         async.Completed([&, uidispatch = InstanceSettings().UIDispatcher()](
-                            auto asyncInfo, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
+                            auto /*asyncInfo*/, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
           asyncStatus;
           OutputDebugStringA("Instance Unload completed\n");
 
@@ -609,7 +608,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) 
             L"ReactNative.Composition", L"CompositionContext"});
 
         auto async = data->m_host.UnloadInstance();
-        async.Completed([host = data->m_host](auto asyncInfo, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
+        async.Completed([host = data->m_host](auto /*asyncInfo*/, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
           asyncStatus;
           assert(asyncStatus == winrt::Windows::Foundation::AsyncStatus::Completed);
           host.InstanceSettings().UIDispatcher().Post([]() { PostQuitMessage(0); });


### PR DESCRIPTION
Backporting PR #14678 to RNW 0.78.

## Description
Resolved all warnings which caused build errors in Playground-Composition and RNTesterApp-Fabric.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Fix build errors in CI and blocking PRs.

Resolves #14677 

### What
Commented out unreferenced variable names.

## Screenshots
N/A

## Testing
Verified projects built without warnings in latest VS.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14679)