### PR TITLE
[0.76] Fixing unreferenced parameter warnings as errors in Playground-Composition and elsewhere

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -63,7 +63,7 @@ steps:
 
   - ${{ if and(endsWith(parameters.template, '-lib'), not(startsWith(parameters.template, 'old'))) }}:
     - script: |
-        npx --yes create-react-native-library@latest --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type turbo-module --react-native-version $(reactNativeDevDependency) --example vanilla testcli
+        npx --yes create-react-native-library@0.48.9 --slug testcli --description testcli --author-name "React-Native-Windows Bot" --author-email 53619745+rnbot@users.noreply.github.com --author-url http://example.com --repo-url http://example.com --languages kotlin-objc --type turbo-module --react-native-version $(reactNativeDevDependency) --example vanilla testcli
       displayName: Init new lib project with create-react-native-library
       workingDirectory: $(Agent.BuildDirectory)
 

--- a/change/@react-native-windows-automation-0671783d-ada6-43fb-9882-81d449c16124.json
+++ b/change/@react-native-windows-automation-0671783d-ada6-43fb-9882-81d449c16124.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "add the new generated headers",
-  "packageName": "@react-native-windows/automation",
-  "email": "email not defined",
-  "dependentChangeType": "none"
-}

--- a/change/@react-native-windows-automation-channel-243f361c-0d3e-471e-a30f-bbaec98e4a20.json
+++ b/change/@react-native-windows-automation-channel-243f361c-0d3e-471e-a30f-bbaec98e4a20.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "add the new generated headers",
-  "packageName": "@react-native-windows/automation-channel",
-  "email": "email not defined",
-  "dependentChangeType": "none"
-}

--- a/change/@react-native-windows-automation-channel-4c7447b5-805b-4261-a652-820c2d3ed0cc.json
+++ b/change/@react-native-windows-automation-channel-4c7447b5-805b-4261-a652-820c2d3ed0cc.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "[0.76] Add RnwNewArch property and RNW_NEW_ARCH constants when building projects for the new architecture",
-  "packageName": "@react-native-windows/automation-channel",
-  "email": "jthysell@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@react-native-windows-automation-commands-638e11af-371a-497c-8d4a-c794b3f6c67b.json
+++ b/change/@react-native-windows-automation-commands-638e11af-371a-497c-8d4a-c794b3f6c67b.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "add the new generated headers",
-  "packageName": "@react-native-windows/automation-commands",
-  "email": "email not defined",
-  "dependentChangeType": "none"
-}

--- a/change/react-native-windows-00e3a2ef-4351-4984-8e44-3b509368727f.json
+++ b/change/react-native-windows-00e3a2ef-4351-4984-8e44-3b509368727f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.76] Fixing unreferenced parameter warnings as errors in Playground-Composition and elsewhere",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -94,7 +94,7 @@ winrt::Microsoft::ReactNative::ReactNativeHost CreateReactNativeHost(
 #endif
 
   host.InstanceSettings().InstanceLoaded(
-      [](auto sender, const winrt::Microsoft::ReactNative::InstanceLoadedEventArgs &args) {
+      [](auto /*sender*/, const winrt::Microsoft::ReactNative::InstanceLoadedEventArgs &args) {
         global_reactContext = args.Context();
       });
 
@@ -168,7 +168,7 @@ WinMain(HINSTANCE /* instance */, HINSTANCE, PSTR /* commandLine */, int /* show
         // Before we shutdown the application - unload the ReactNativeHost to give the javascript a chance to save any
         // state
         auto async = host.UnloadInstance();
-        async.Completed([host](auto asyncInfo, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
+        async.Completed([host](auto /*asyncInfo*/, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
           asyncStatus;
           assert(asyncStatus == winrt::Windows::Foundation::AsyncStatus::Completed);
           host.InstanceSettings().UIDispatcher().Post([]() { PostQuitMessage(0); });
@@ -331,7 +331,7 @@ void InsertExpandCollapseStateValueIfNotDefault(
   }
 }
 
-winrt::Windows::Data::Json::JsonObject ListErrors(winrt::Windows::Data::Json::JsonValue payload) {
+winrt::Windows::Data::Json::JsonObject ListErrors(winrt::Windows::Data::Json::JsonValue /*payload*/) {
   winrt::Windows::Data::Json::JsonObject result;
   winrt::Windows::Data::Json::JsonArray jsonErrors;
   winrt::Windows::Data::Json::JsonArray jsonWarnings;

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -243,7 +243,7 @@ struct WindowData {
                           winrt::Microsoft::ReactNative::Composition::CompositionUIService::GetCompositor(props);
                       auto async = compositor.RequestCommitAsync();
                       async.Completed([hwnd, size = args.Size()](
-                                          auto asyncInfo, winrt::Windows::Foundation::AsyncStatus /*asyncStatus*/) {
+                                          auto /*asyncInfo*/, winrt::Windows::Foundation::AsyncStatus /*asyncStatus*/) {
                         RECT rcClient, rcWindow;
                         GetClientRect(hwnd, &rcClient);
                         GetWindowRect(hwnd, &rcWindow);

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -53,7 +53,7 @@ void RegisterCustomComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder
  */
 struct EllipseImageHandler
     : winrt::implements<EllipseImageHandler, winrt::Microsoft::ReactNative::Composition::IUriImageProvider> {
-  bool CanLoadImageUri(winrt::Microsoft::ReactNative::IReactContext context, winrt::Windows::Foundation::Uri uri) {
+  bool CanLoadImageUri(winrt::Microsoft::ReactNative::IReactContext /*context*/, winrt::Windows::Foundation::Uri uri) {
     return uri.SchemeName() == L"ellipse";
   }
 
@@ -114,7 +114,6 @@ winrt::Windows::UI::Composition::Compositor g_compositor{nullptr};
 constexpr auto WindowDataProperty = L"WindowData";
 
 int RunPlayground(int showCmd, bool useWebDebugger);
-winrt::Microsoft::ReactNative::IReactPackageProvider CreateStubDeviceInfoPackageProvider() noexcept;
 
 struct WindowData {
   static HINSTANCE s_instance;
@@ -239,7 +238,7 @@ struct WindowData {
                 ::SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) & ~WS_SIZEBOX);
                 m_compRootView.SizeChanged(
                     [hwnd, props = InstanceSettings().Properties()](
-                        auto sender, const winrt::Microsoft::ReactNative::RootViewSizeChangedEventArgs &args) {
+                        auto /*sender*/, const winrt::Microsoft::ReactNative::RootViewSizeChangedEventArgs &args) {
                       auto compositor =
                           winrt::Microsoft::ReactNative::Composition::CompositionUIService::GetCompositor(props);
                       auto async = compositor.RequestCommitAsync();
@@ -340,7 +339,7 @@ struct WindowData {
       case IDM_UNLOAD: {
         auto async = Host().UnloadInstance();
         async.Completed([&, uidispatch = InstanceSettings().UIDispatcher()](
-                            auto asyncInfo, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
+                            auto /*asyncInfo*/, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
           asyncStatus;
           OutputDebugStringA("Instance Unload completed\n");
 
@@ -583,7 +582,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) 
             L"ReactNative.Composition", L"CompositionContext"});
 
         auto async = data->m_host.UnloadInstance();
-        async.Completed([host = data->m_host](auto asyncInfo, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
+        async.Completed([host = data->m_host](auto /*asyncInfo*/, winrt::Windows::Foundation::AsyncStatus asyncStatus) {
           asyncStatus;
           assert(asyncStatus == winrt::Windows::Foundation::AsyncStatus::Completed);
           host.InstanceSettings().UIDispatcher().Post([]() { PostQuitMessage(0); });

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/bridging/CallbackWrapper.h
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/bridging/CallbackWrapper.h
@@ -29,7 +29,7 @@ class CallbackWrapper : public LongLivedObject {
         jsInvoker_(std::move(jsInvoker)) {}
 
   CallbackWrapper(
-      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection,
+      std::shared_ptr<LongLivedObjectCollection> /*longLivedObjectCollection*/, // [Windows]
       jsi::Function &&callback,
       jsi::Runtime &runtime,
       std::shared_ptr<CallInvoker> jsInvoker)


### PR DESCRIPTION
Backporting PR #14678 to RNW 0.76.

## Description
Resolved all warnings which caused build errors in Playground-Composition and RNTesterApp-Fabric.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Fix build errors in CI and blocking PRs.

Resolves #14677

### What
Commented out unreferenced variable names.

## Screenshots
N/A

## Testing
Verified projects built without warnings in latest VS.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14682)