### PR TITLE
[0.74] Fix await on new arch - switching to CallInvoker for TM callbacks

### DIFF
--- a/change/react-native-windows-ad718918-4357-4159-a94e-c6d14bb6c3bf.json
+++ b/change/react-native-windows-ad718918-4357-4159-a94e-c6d14bb6c3bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.74] Fix await on new arch - switching to CallInvoker for TM callbacks",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "CallInvokerWriter.h"
+#include <JSI/JSIDynamic.h>
+#include <crash/verifyElseCrash.h>
+
+namespace winrt::Microsoft::ReactNative {
+
+//===========================================================================
+// CallInvokerWriter implementation
+//===========================================================================
+
+CallInvokerWriter::CallInvokerWriter(
+    const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
+    std::weak_ptr<LongLivedJsiRuntime> jsiRuntimeHolder) noexcept
+    : m_callInvoker(jsInvoker), m_jsiRuntimeHolder(std::move(jsiRuntimeHolder)) {}
+
+CallInvokerWriter::~CallInvokerWriter() {
+  if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
+    jsiRuntimeHolder->allowRelease();
+  }
+}
+
+void CallInvokerWriter::WithResultArgs(
+    Mso::Functor<void(facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t argCount)>
+        handler) noexcept {
+  /*
+    if (m_jsDispatcher.HasThreadAccess()) {
+      VerifyElseCrash(!m_dynamicWriter);
+      if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
+        const facebook::jsi::Value *args{nullptr};
+        size_t argCount{0};
+        m_jsiWriter->AccessResultAsArgs(args, argCount);
+        handler(jsiRuntimeHolder->Runtime(), args, argCount);
+        m_jsiWriter = nullptr;
+      }
+    } else {
+  */
+  VerifyElseCrash(!m_jsiWriter);
+  folly::dynamic dynValue = m_dynamicWriter->TakeValue();
+  VerifyElseCrash(dynValue.isArray());
+  m_callInvoker->invokeAsync(
+      [handler, dynValue = std::move(dynValue), weakJsiRuntimeHolder = m_jsiRuntimeHolder, self = get_strong()]() {
+        if (auto jsiRuntimeHolder = weakJsiRuntimeHolder.lock()) {
+          std::vector<facebook::jsi::Value> args;
+          args.reserve(dynValue.size());
+          auto &runtime = jsiRuntimeHolder->Runtime();
+          for (auto const &item : dynValue) {
+            args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
+          }
+          handler(runtime, args.data(), args.size());
+        }
+      });
+  //}
+}
+
+void CallInvokerWriter::WriteNull() noexcept {
+  GetWriter().WriteNull();
+}
+
+void CallInvokerWriter::WriteBoolean(bool value) noexcept {
+  GetWriter().WriteBoolean(value);
+}
+
+void CallInvokerWriter::WriteInt64(int64_t value) noexcept {
+  GetWriter().WriteInt64(value);
+}
+
+void CallInvokerWriter::WriteDouble(double value) noexcept {
+  GetWriter().WriteDouble(value);
+}
+
+void CallInvokerWriter::WriteString(const winrt::hstring &value) noexcept {
+  GetWriter().WriteString(value);
+}
+
+void CallInvokerWriter::WriteObjectBegin() noexcept {
+  GetWriter().WriteObjectBegin();
+}
+
+void CallInvokerWriter::WritePropertyName(const winrt::hstring &name) noexcept {
+  GetWriter().WritePropertyName(name);
+}
+
+void CallInvokerWriter::WriteObjectEnd() noexcept {
+  GetWriter().WriteObjectEnd();
+}
+
+void CallInvokerWriter::WriteArrayBegin() noexcept {
+  GetWriter().WriteArrayBegin();
+}
+
+void CallInvokerWriter::WriteArrayEnd() noexcept {
+  GetWriter().WriteArrayEnd();
+}
+
+IJSValueWriter CallInvokerWriter::GetWriter() noexcept {
+  if (!m_writer) {
+    /*
+        if (m_jsDispatcher.HasThreadAccess()) {
+          if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
+            m_jsiWriter = winrt::make_self<JsiWriter>(jsiRuntimeHolder->Runtime());
+            m_writer = m_jsiWriter.as<IJSValueWriter>();
+          } else {
+            m_writer = winrt::make<JSNoopWriter>();
+          }
+        } else {
+         */
+    m_dynamicWriter = winrt::make_self<DynamicWriter>();
+    m_writer = m_dynamicWriter.as<IJSValueWriter>();
+    //}
+  }
+  Debug(VerifyElseCrash(m_dynamicWriter != nullptr /* || m_jsDispatcher.HasThreadAccess()*/));
+  return m_writer;
+}
+
+//===========================================================================
+// JSNoopWriter implementation
+//===========================================================================
+
+void JSNoopWriter::WriteNull() noexcept {}
+void JSNoopWriter::WriteBoolean(bool /*value*/) noexcept {}
+void JSNoopWriter::WriteInt64(int64_t /*value*/) noexcept {}
+void JSNoopWriter::WriteDouble(double /*value*/) noexcept {}
+void JSNoopWriter::WriteString(const winrt::hstring & /*value*/) noexcept {}
+void JSNoopWriter::WriteObjectBegin() noexcept {}
+void JSNoopWriter::WritePropertyName(const winrt::hstring & /*name*/) noexcept {}
+void JSNoopWriter::WriteObjectEnd() noexcept {}
+void JSNoopWriter::WriteArrayBegin() noexcept {}
+void JSNoopWriter::WriteArrayEnd() noexcept {}
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
@@ -17,7 +17,7 @@ CallInvokerWriter::CallInvokerWriter(
     std::weak_ptr<LongLivedJsiRuntime> jsiRuntimeHolder) noexcept
     : m_callInvoker(jsInvoker),
       m_jsiRuntimeHolder(std::move(jsiRuntimeHolder)),
-      m_threadId(std::this_thread::get_id()){} {}
+      m_threadId(std::this_thread::get_id()) {}
 
 CallInvokerWriter::~CallInvokerWriter() {
   if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
@@ -42,10 +42,10 @@ void CallInvokerWriter::WithResultArgs(
     folly::dynamic dynValue = m_dynamicWriter->TakeValue();
     VerifyElseCrash(dynValue.isArray());
     m_callInvoker->invokeAsync(
-        [handler, dynValue = std::move(dynValue), weakJsiRuntimeHolder = m_jsiRuntimeHolder, self = get_strong()](
-            facebook::jsi::Runtime &runtime) {
+        [handler, dynValue = std::move(dynValue), weakJsiRuntimeHolder = m_jsiRuntimeHolder, self = get_strong()]() {
           std::vector<facebook::jsi::Value> args;
           args.reserve(dynValue.size());
+          auto &runtime = jsiRuntimeHolder->Runtime();
           for (auto const &item : dynValue) {
             args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
           }

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
@@ -45,11 +45,13 @@ void CallInvokerWriter::WithResultArgs(
         [handler, dynValue = std::move(dynValue), weakJsiRuntimeHolder = m_jsiRuntimeHolder, self = get_strong()]() {
           std::vector<facebook::jsi::Value> args;
           args.reserve(dynValue.size());
-          auto &runtime = jsiRuntimeHolder->Runtime();
-          for (auto const &item : dynValue) {
-            args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
+          if (auto jsiRuntimeHolder = weakJsiRuntimeHolder.lock()) {
+            auto &runtime = jsiRuntimeHolder->Runtime();
+            for (auto const &item : dynValue) {
+              args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
+            }
+            handler(runtime, args.data(), args.size());
           }
-          handler(runtime, args.data(), args.size());
         });
   }
 }

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.cpp
@@ -15,7 +15,9 @@ namespace winrt::Microsoft::ReactNative {
 CallInvokerWriter::CallInvokerWriter(
     const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
     std::weak_ptr<LongLivedJsiRuntime> jsiRuntimeHolder) noexcept
-    : m_callInvoker(jsInvoker), m_jsiRuntimeHolder(std::move(jsiRuntimeHolder)) {}
+    : m_callInvoker(jsInvoker),
+      m_jsiRuntimeHolder(std::move(jsiRuntimeHolder)),
+      m_threadId(std::this_thread::get_id()){} {}
 
 CallInvokerWriter::~CallInvokerWriter() {
   if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
@@ -26,34 +28,30 @@ CallInvokerWriter::~CallInvokerWriter() {
 void CallInvokerWriter::WithResultArgs(
     Mso::Functor<void(facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t argCount)>
         handler) noexcept {
-  /*
-    if (m_jsDispatcher.HasThreadAccess()) {
-      VerifyElseCrash(!m_dynamicWriter);
-      if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
-        const facebook::jsi::Value *args{nullptr};
-        size_t argCount{0};
-        m_jsiWriter->AccessResultAsArgs(args, argCount);
-        handler(jsiRuntimeHolder->Runtime(), args, argCount);
-        m_jsiWriter = nullptr;
-      }
-    } else {
-  */
-  VerifyElseCrash(!m_jsiWriter);
-  folly::dynamic dynValue = m_dynamicWriter->TakeValue();
-  VerifyElseCrash(dynValue.isArray());
-  m_callInvoker->invokeAsync(
-      [handler, dynValue = std::move(dynValue), weakJsiRuntimeHolder = m_jsiRuntimeHolder, self = get_strong()]() {
-        if (auto jsiRuntimeHolder = weakJsiRuntimeHolder.lock()) {
+  if (m_threadId == std::this_thread::get_id() && m_fastPath) {
+    VerifyElseCrash(!m_dynamicWriter);
+    if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
+      const facebook::jsi::Value *args{nullptr};
+      size_t argCount{0};
+      m_jsiWriter->AccessResultAsArgs(args, argCount);
+      handler(jsiRuntimeHolder->Runtime(), args, argCount);
+      m_jsiWriter = nullptr;
+    }
+  } else {
+    VerifyElseCrash(!m_jsiWriter);
+    folly::dynamic dynValue = m_dynamicWriter->TakeValue();
+    VerifyElseCrash(dynValue.isArray());
+    m_callInvoker->invokeAsync(
+        [handler, dynValue = std::move(dynValue), weakJsiRuntimeHolder = m_jsiRuntimeHolder, self = get_strong()](
+            facebook::jsi::Runtime &runtime) {
           std::vector<facebook::jsi::Value> args;
           args.reserve(dynValue.size());
-          auto &runtime = jsiRuntimeHolder->Runtime();
           for (auto const &item : dynValue) {
             args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
           }
           handler(runtime, args.data(), args.size());
-        }
-      });
-  //}
+        });
+  }
 }
 
 void CallInvokerWriter::WriteNull() noexcept {
@@ -98,22 +96,24 @@ void CallInvokerWriter::WriteArrayEnd() noexcept {
 
 IJSValueWriter CallInvokerWriter::GetWriter() noexcept {
   if (!m_writer) {
-    /*
-        if (m_jsDispatcher.HasThreadAccess()) {
-          if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
-            m_jsiWriter = winrt::make_self<JsiWriter>(jsiRuntimeHolder->Runtime());
-            m_writer = m_jsiWriter.as<IJSValueWriter>();
-          } else {
-            m_writer = winrt::make<JSNoopWriter>();
-          }
-        } else {
-         */
-    m_dynamicWriter = winrt::make_self<DynamicWriter>();
-    m_writer = m_dynamicWriter.as<IJSValueWriter>();
-    //}
+    if (m_threadId == std::this_thread::get_id() && m_fastPath) {
+      if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
+        m_jsiWriter = winrt::make_self<JsiWriter>(jsiRuntimeHolder->Runtime());
+        m_writer = m_jsiWriter.as<IJSValueWriter>();
+      } else {
+        m_writer = winrt::make<JSNoopWriter>();
+      }
+    } else {
+      m_dynamicWriter = winrt::make_self<DynamicWriter>();
+      m_writer = m_dynamicWriter.as<IJSValueWriter>();
+    }
   }
-  Debug(VerifyElseCrash(m_dynamicWriter != nullptr /* || m_jsDispatcher.HasThreadAccess()*/));
+  Debug(VerifyElseCrash(m_dynamicWriter != nullptr || (m_threadId == std::this_thread::get_id() && m_fastPath)));
   return m_writer;
+}
+
+void CallInvokerWriter::ExitCurrentCallInvokeScope() noexcept {
+  m_fastPath = false;
 }
 
 //===========================================================================

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.h
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include <JSI/LongLivedJsiValue.h>
+#include <ReactCommon/CallInvoker.h>
+#include <functional/functor.h>
+#include "DynamicWriter.h"
+#include "JsiWriter.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+// IJSValueWriter to ensure that JsiWriter is always used from a RuntimeExecutor.
+// In case if writing is done outside of RuntimeExecutor, it uses DynamicWriter to create
+// folly::dynamic which then is written to JsiWriter in RuntimeExecutor.
+struct CallInvokerWriter : winrt::implements<CallInvokerWriter, IJSValueWriter> {
+  ~CallInvokerWriter();
+  CallInvokerWriter(
+      const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
+      std::weak_ptr<LongLivedJsiRuntime> jsiRuntimeHolder) noexcept;
+  void WithResultArgs(Mso::Functor<void(facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t argCount)>
+                          handler) noexcept;
+
+ public: // IJSValueWriter
+  void WriteNull() noexcept;
+  void WriteBoolean(bool value) noexcept;
+  void WriteInt64(int64_t value) noexcept;
+  void WriteDouble(double value) noexcept;
+  void WriteString(const winrt::hstring &value) noexcept;
+  void WriteObjectBegin() noexcept;
+  void WritePropertyName(const winrt::hstring &name) noexcept;
+  void WriteObjectEnd() noexcept;
+  void WriteArrayBegin() noexcept;
+  void WriteArrayEnd() noexcept;
+
+ private:
+  IJSValueWriter GetWriter() noexcept;
+
+ private:
+  const std::shared_ptr<facebook::react::CallInvoker> m_callInvoker;
+  std::weak_ptr<LongLivedJsiRuntime> m_jsiRuntimeHolder;
+  winrt::com_ptr<DynamicWriter> m_dynamicWriter;
+  winrt::com_ptr<JsiWriter> m_jsiWriter;
+  IJSValueWriter m_writer;
+};
+
+// Special IJSValueWriter that does nothing.
+// We use it instead of JsiWriter when JSI runtime is not available anymore.
+struct JSNoopWriter : winrt::implements<JSNoopWriter, IJSValueWriter> {
+ public: // IJSValueWriter
+  void WriteNull() noexcept;
+  void WriteBoolean(bool value) noexcept;
+  void WriteInt64(int64_t value) noexcept;
+  void WriteDouble(double value) noexcept;
+  void WriteString(const winrt::hstring &value) noexcept;
+  void WriteObjectBegin() noexcept;
+  void WritePropertyName(const winrt::hstring &name) noexcept;
+  void WriteObjectEnd() noexcept;
+  void WriteArrayBegin() noexcept;
+  void WriteArrayEnd() noexcept;
+};
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.h
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.h
@@ -34,6 +34,10 @@ struct CallInvokerWriter : winrt::implements<CallInvokerWriter, IJSValueWriter> 
   void WriteArrayBegin() noexcept;
   void WriteArrayEnd() noexcept;
 
+  // This should be called before the code flow exits the scope of the CallInvoker,
+  // thus requiring the CallInokerWriter to call m_callInvoker->invokeAsync to call back into JS.
+  void ExitCurrentCallInvokeScope() noexcept;
+
  private:
   IJSValueWriter GetWriter() noexcept;
 
@@ -43,6 +47,12 @@ struct CallInvokerWriter : winrt::implements<CallInvokerWriter, IJSValueWriter> 
   winrt::com_ptr<DynamicWriter> m_dynamicWriter;
   winrt::com_ptr<JsiWriter> m_jsiWriter;
   IJSValueWriter m_writer;
+
+  // If a callback is invoked synchronously we can call the JS callback directly.
+  // However, if we post to another thread, or call the callback on the same thread but after we exit the current
+  // RuntimeExecutor callback, then we need to save the callback args in a dynamic and post it back to the CallInvoker
+  bool m_fastPath{true};
+  const std::thread::id m_threadId;
 };
 
 // Special IJSValueWriter that does nothing.

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -202,7 +202,7 @@ class TurboModuleImpl : public facebook::react::TurboModule {
                     auto writer = winrt::make<CallInvokerWriter>(jsInvoker, jsiRuntimeHolder);
                     method(
                         winrt::make<JsiReader>(rt, args, argCount - 1),
-                        writer),
+                        writer,
                         MakeCallback(rt, strongLongLivedObjectCollection, args[argCount - 1]),
                         nullptr);
                     winrt::get_self<CallInvokerWriter>(writer)->ExitCurrentCallInvokeScope();

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -397,7 +397,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IReactDispatcher.cpp">
       <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IReactDispatcher.idl</DependentUpon>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\JSDispatcherWriter.cpp">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\CallInvokerWriter.cpp">
       <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IJSValueWriter.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Timer.cpp">


### PR DESCRIPTION
## Description
In some cases, JS code using await will not run the continuation until some other event triggers JS code to run.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Callbacks from TurboModules were running through the JSDispatcher, rather than the CallInvoker. On Paper the JSDispatcher is built on top of CallInvoker, and so calls into a TurboModule callback will trigger continuations after the JS code completes.

In new arch, JS can run in multiple threads, so we should use the CallInvoker to guarantee the callback can safely enter the JS runtime.  But also to ensure that continuations get triggered after the JS code completes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14690)