### PR TITLE
Reenable optimization in TMs to avoid going through a dynamic for callbacks/promises

### DIFF
--- a/change/react-native-windows-9adb4921-0e07-4622-8839-b36a3e017a3a.json
+++ b/change/react-native-windows-9adb4921-0e07-4622-8839-b36a3e017a3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Reenable optimization in TMs to avoid going through a dynamic for callbacks/promises",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CallInvokerWriter.h
+++ b/vnext/Microsoft.ReactNative/CallInvokerWriter.h
@@ -34,6 +34,10 @@ struct CallInvokerWriter : winrt::implements<CallInvokerWriter, IJSValueWriter> 
   void WriteArrayBegin() noexcept;
   void WriteArrayEnd() noexcept;
 
+  // This should be called before the code flow exits the scope of the CallInvoker,
+  // thus requiring the CallInokerWriter to call m_callInvoker->invokeAsync to call back into JS.
+  void ExitCurrentCallInvokeScope() noexcept;
+
  private:
   IJSValueWriter GetWriter() noexcept;
 
@@ -43,6 +47,12 @@ struct CallInvokerWriter : winrt::implements<CallInvokerWriter, IJSValueWriter> 
   winrt::com_ptr<DynamicWriter> m_dynamicWriter;
   winrt::com_ptr<JsiWriter> m_jsiWriter;
   IJSValueWriter m_writer;
+
+  // If a callback is invoked synchronously we can call the JS callback directly.
+  // However, if we post to another thread, or call the callback on the same thread but after we exit the current
+  // RuntimeExecutor callback, then we need to save the callback args in a dynamic and post it back to the CallInvoker
+  bool m_fastPath{true};
+  const std::thread::id m_threadId;
 };
 
 // Special IJSValueWriter that does nothing.

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -225,11 +225,13 @@ class TurboModuleImpl : public facebook::react::TurboModule {
                   VerifyElseCrash(argCount > 0);
                   if (auto strongLongLivedObjectCollection = longLivedObjectCollection.lock()) {
                     auto jsiRuntimeHolder = LongLivedJsiRuntime::CreateWeak(strongLongLivedObjectCollection, rt);
+                    auto writer = winrt::make<CallInvokerWriter>(jsInvoker, jsiRuntimeHolder);
                     method(
                         winrt::make<JsiReader>(rt, args, argCount - 1),
-                        winrt::make<CallInvokerWriter>(jsInvoker, jsiRuntimeHolder),
+                        writer,
                         MakeCallback(rt, strongLongLivedObjectCollection, args[argCount - 1]),
                         nullptr);
+                    winrt::get_self<CallInvokerWriter>(writer)->ExitCurrentCallInvokeScope();
                   }
                   return facebook::jsi::Value::undefined();
                 });
@@ -253,9 +255,10 @@ class TurboModuleImpl : public facebook::react::TurboModule {
                     auto weakCallback2 = LongLivedJsiFunction::CreateWeak(
                         strongLongLivedObjectCollection, rt, args[argCount - 1].getObject(rt).getFunction(rt));
 
+                    auto writer = winrt::make<CallInvokerWriter>(jsInvoker, jsiRuntimeHolder);
                     method(
                         winrt::make<JsiReader>(rt, args, argCount - 2),
-                        winrt::make<CallInvokerWriter>(jsInvoker, jsiRuntimeHolder),
+                        writer,
                         [weakCallback1, weakCallback2, jsiRuntimeHolder](const IJSValueWriter &writer) noexcept {
                           writer.as<CallInvokerWriter>()->WithResultArgs(
                               [weakCallback1, weakCallback2, jsiRuntimeHolder](
@@ -288,6 +291,7 @@ class TurboModuleImpl : public facebook::react::TurboModule {
                                 }
                               });
                         });
+                    winrt::get_self<CallInvokerWriter>(writer)->ExitCurrentCallInvokeScope();
                   }
                   return facebook::jsi::Value::undefined();
                 });
@@ -369,6 +373,7 @@ class TurboModuleImpl : public facebook::react::TurboModule {
                                       }
                                     });
                               });
+                          winrt::get_self<CallInvokerWriter>(argWriter)->ExitCurrentCallInvokeScope();
                         });
                   }
                   return facebook::jsi::Value::undefined();


### PR DESCRIPTION
## Description
Optimize CallInvokerWriter to avoid writing to a intermediate dynamic object if we can write the data directly into JS.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
When I switched TMs from JSDispatcherWriter to CallInvokerWriter I didn't implement the optimization to avoid the dynamic.  This fill in that gap restoring the previous perfomance.

Resolves #14668

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14691)