### PR TITLE
Fix descriptions for new project templates

### DIFF
--- a/change/react-native-windows-fc2b9290-c8f1-4b30-88d1-cfb20767315d.json
+++ b/change/react-native-windows-fc2b9290-c8f1-4b30-88d1-cfb20767315d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix descriptions for new project templates",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-app/template.config.js
+++ b/vnext/templates/cpp-app/template.config.js
@@ -142,9 +142,9 @@ async function postInstall(config = {}, options = {}) {
 }
 
 module.exports = {
-  name: 'React Native Windows Application (New Arch, C++, Win32, Hermes)',
+  name: 'React Native Windows Application (New Arch, WinAppSDK, C++)',
   description:
-    "[Experimental] A RNW app targeting RN's new architecture, with the Hermes JS engine.",
+    "[Preview] A RNW app using RN's New Architecture, built in C++ and targeting WinAppSDK.",
   preInstall,
   getFileMappings,
   postInstall,

--- a/vnext/templates/cpp-lib/template.config.js
+++ b/vnext/templates/cpp-lib/template.config.js
@@ -244,7 +244,7 @@ async function postInstall(config = {}, options = {}) {
 module.exports = {
   name: 'React Native Windows Library (C++)',
   description:
-    "A RNW native/turbo module supporting both RN's old and new architecture.",
+    "A RNW (Turbo) Native Module supporting RN's New and Old Architectures built in C++.",
   preInstall,
   getFileMappings,
   postInstall,

--- a/vnext/templates/old/generateWrapper.js
+++ b/vnext/templates/old/generateWrapper.js
@@ -9,27 +9,13 @@
 const generateWindows = require('../../generate');
 const templateUtils = require('../templateUtils');
 
-function makeGenerateWindowsWrapper(
-  language = 'cpp',
-  projectType = 'app',
-  isDefault = false,
-) {
-  const name =
-    projectType === 'lib'
-      ? `React Native Windows Library (Old Arch, UWP, ${
-          language === 'cs' ? 'C#' : 'C++'
-        })`
-      : `React Native Windows Application (Old Arch, UWP, ${
-          language === 'cs' ? 'C#' : 'C++'
-        }, Hermes)`;
-  const description =
-    projectType === 'lib'
-      ? `A RNW module written in ${
-          language === 'cs' ? 'C#' : 'C++'
-        }, targeting UWP and RN's old architecture.`
-      : `A RNW app written in ${
-          language === 'cs' ? 'C#' : 'C++'
-        }, targeting UWP and RN's old architecture, with the Hermes JS engine.`;
+function makeGenerateWindowsWrapper(language = 'cpp', isDefault = false) {
+  const name = `React Native Windows Application (Old Arch, UWP, ${
+    language === 'cs' ? 'C#' : 'C++'
+  })`;
+  const description = `A RNW app using RN's Old Architecture, built in ${
+    language === 'cs' ? 'C#' : 'C++'
+  } and targeting UWP.`;
 
   const postInstall = async (config = {}, options = {}) => {
     const experimentalFeatures = config?.project?.windows?.experimentalFeatures;

--- a/vnext/templates/old/generateWrapper.js
+++ b/vnext/templates/old/generateWrapper.js
@@ -25,7 +25,7 @@ function makeGenerateWindowsWrapper(language = 'cpp', isDefault = false) {
     const generateOptions = {
       overwrite: !!options.overwrite,
       language,
-      projectType,
+      projectType: 'app',
       experimentalNuGetDependency:
         experimentalFeatures?.UseExperimentalNuget === 'true' ?? false,
       useWinUI3: experimentalFeatures?.UseWinUI3 === 'true' ?? false,

--- a/vnext/templates/old/uwp-cpp-app/template.config.js
+++ b/vnext/templates/old/uwp-cpp-app/template.config.js
@@ -12,4 +12,4 @@
 
 const {makeGenerateWindowsWrapper} = require('../generateWrapper');
 
-module.exports = makeGenerateWindowsWrapper('cpp', 'app', true); // TODO: Remove this as the default
+module.exports = makeGenerateWindowsWrapper('cpp', true); // TODO: Remove this as the default

--- a/vnext/templates/old/uwp-cs-app/template.config.js
+++ b/vnext/templates/old/uwp-cs-app/template.config.js
@@ -12,4 +12,4 @@
 
 const {makeGenerateWindowsWrapper} = require('../generateWrapper');
 
-module.exports = makeGenerateWindowsWrapper('cs', 'app');
+module.exports = makeGenerateWindowsWrapper('cs');


### PR DESCRIPTION
## Description

This PR updates the descriptions for the new project templates to be more user-friendly and informative.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
As we are in the process of deprecating and/or changing the defaults for templates, I want to make sure we have clear consistent documentation of what each template looks like.

### What
Updated the descriptions and removed the wrapper code that allowed for the (now removed) old lib templates.

## Screenshots
![image](https://github.com/user-attachments/assets/92daaef4-a8a3-4d50-82df-63c94487d26b)

## Testing
Verified `init-windows --list` works.

## Changelog
Should this change be included in the release notes: _yes_

Fix descriptions for new project templates