### PR TITLE
Clean up error messages

### DIFF
--- a/change/react-native-windows-3c8e3cc4-43d0-4278-8808-fef1574c5b17.json
+++ b/change/react-native-windows-3c8e3cc4-43d0-4278-8808-fef1574c5b17.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Clean up error messages",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeIsland.cpp
@@ -530,9 +530,9 @@ void ReactNativeIsland::UninitRootView() noexcept {
     if (m_context.Handle().LoadingState() == winrt::Microsoft::ReactNative::LoadingState::HasError)
       return;
 
-    auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-        winrt::Microsoft::ReactNative::ReactPropertyBag(m_context.Properties()));
-    uiManager->stopSurface(static_cast<facebook::react::SurfaceId>(RootTag()));
+    if (auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
+            winrt::Microsoft::ReactNative::ReactPropertyBag(m_context.Properties())))
+      uiManager->stopSurface(static_cast<facebook::react::SurfaceId>(RootTag()));
   }
 
   m_rootTag = -1;

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -46,7 +46,10 @@ FabicUIManagerProperty() noexcept {
 
 /*static*/ std::shared_ptr<FabricUIManager> FabricUIManager::FromProperties(
     const winrt::Microsoft::ReactNative::ReactPropertyBag &props) {
-  return props.Get(FabicUIManagerProperty()).Value();
+  auto p = props.Get(FabicUIManagerProperty());
+  if (p)
+    return p.Value();
+  return {};
 }
 
 FabricUIManager::FabricUIManager() {}


### PR DESCRIPTION
## Description

Redbox errors from Transform errors are almost unreadable.  This change make it much easier to read the error. 

Also fixed a crash reloading an already crashed instance.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Reading the JSON with color codes within it is very hard.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14695)