### PR TITLE
fix: remove unused `react-shallow-renderer` dependency (#14701)

### DIFF
--- a/change/@office-iss-react-native-win32-7ff6b9f3-7aac-4292-895e-0e1bf3205653.json
+++ b/change/@office-iss-react-native-win32-7ff6b9f3-7aac-4292-895e-0e1bf3205653.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed unused `react-shallow-renderer` dependency",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-integrate-rn-76872c2b-b189-4a34-8b3d-068d0c640812.json
+++ b/change/@rnw-scripts-integrate-rn-76872c2b-b189-4a34-8b3d-068d0c640812.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removed unused `react-shallow-renderer` dependency",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/react-native-windows-6b9d9648-7997-46de-b216-67d2ba2e4ac1.json
+++ b/change/react-native-windows-6b9d9648-7997-46de-b216-67d2ba2e4ac1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed unused `react-shallow-renderer` dependency",
+  "packageName": "react-native-windows",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -61,7 +61,6 @@
     "react-clone-referenced-element": "^1.0.1",
     "react-devtools-core": "^6.0.1",
     "react-refresh": "^0.14.0",
-    "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "0.25.0",
     "semver": "^7.1.3",

--- a/packages/@rnw-scripts/integrate-rn/src/test/upgradeDependencies.test.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/test/upgradeDependencies.test.ts
@@ -91,7 +91,6 @@ const olderRepoConfig: PackageDeps = {
     mkdirp: '^0.5.1',
     prettier: '1.19.1',
     react: '16.13.1',
-    'react-shallow-renderer': '16.13.1',
     'react-test-renderer': '16.13.1',
     shelljs: '^0.7.8',
     signedsource: '^1.0.0',
@@ -110,7 +109,6 @@ const newerRepoConfig: PackageDeps = {
     mkdirp: '^0.5.1',
     prettier: '1.19.1',
     react: '16.13.1',
-    'react-shallow-renderer': '16.13.2',
     'react-test-renderer': '16.13.1',
     shelljs: '^0.7.8',
     signedsource: '^1.0.0',
@@ -494,9 +492,7 @@ test('Out-of-tree platform (Newer devDependencies)', () => {
 test('Out-of-tree platform (repo-config devDependencies)', () => {
   const outOfTreeDeps: LocalPackageDeps = {
     ...olderReactNative,
-    devDependencies: {
-      'react-shallow-renderer': '16.13.1',
-    },
+    devDependencies: {},
     packageName: 'react-native-windows',
     outOfTreePlatform: true,
   };
@@ -514,9 +510,7 @@ test('Out-of-tree platform (repo-config devDependencies)', () => {
     ...outOfTreeDeps,
     dependencies: newerReactNative.dependencies,
     peerDependencies: newerReactNative.peerDependencies,
-    devDependencies: {
-      'react-shallow-renderer': '16.13.2',
-    },
+    devDependencies: {},
   });
 
   expectSortedDeps(deps);

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -57,7 +57,6 @@
     "promise": "^8.3.0",
     "react-devtools-core": "^6.0.1",
     "react-refresh": "^0.14.0",
-    "react-shallow-renderer": "^16.15.0",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "0.25.0",
     "semver": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10197,11 +10197,6 @@ react-devtools-core@^6.0.1:
     shell-quote "^1.6.1"
     ws "^7"
 
-"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
-  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
-
 react-is@^16.13.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -10211,6 +10206,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-is@^19.0.0:
   version "19.0.0"
@@ -10270,14 +10270,6 @@ react-refresh@^0.14.0:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
-
-react-shallow-renderer@^16.15.0:
-  version "16.15.0"
-  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
-  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
-  dependencies:
-    object-assign "^4.1.1"
-    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
 
 react-test-renderer@19.0.0:
   version "19.0.0"


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

`react-shallow-renderer` was removed upstream in 0.75 (see https://github.com/facebook/react-native/commit/ffc0640bf8fae7c12427b307dffe114212da519a). It is currently causing warnings because RN has moved to React 19:

```
➤ YN0060: │ react is listed by your project with version 19.0.0 (pa7126), which doesn't satisfy what react-shallow-renderer (via react-native-windows) and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react is listed by your project with version 19.0.0 (pdb265), which doesn't satisfy what react-shallow-renderer (via react-native-windows) and other dependencies request (but they have non-overlapping ranges!).
```

Cherry-picks #14701

### What

All references to `react-shallow-renderer` have been removed.

## Screenshots

n/a

## Testing

Tests were updated.

## Changelog

Should this change be included in the release notes: no