### PR TITLE
Update native module doc links in cpp-lib template

### DIFF
--- a/change/react-native-windows-d485bfde-7e07-409b-949c-3c79e2e9c4ed.json
+++ b/change/react-native-windows-d485bfde-7e07-409b-949c-3c79e2e9c4ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update native module doc links in cpp-lib template",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-lib/windows/MyLib/MyLib.cpp
+++ b/vnext/templates/cpp-lib/windows/MyLib/MyLib.cpp
@@ -5,7 +5,7 @@
 namespace winrt::{{ namespaceCpp }}
 {
 
-// See https://microsoft.github.io/react-native-windows/docs/native-modules for details on writing native modules
+// See https://microsoft.github.io/react-native-windows/docs/native-platform for help writing native modules
 
 void {{ pascalName }}::Initialize(React::ReactContext const &reactContext) noexcept {
   m_context = reactContext;

--- a/vnext/templates/cpp-lib/windows/MyLib/MyLib.h
+++ b/vnext/templates/cpp-lib/windows/MyLib/MyLib.h
@@ -13,6 +13,8 @@
 namespace winrt::{{ namespaceCpp }}
 {
 
+// See https://microsoft.github.io/react-native-windows/docs/native-platform for help writing native modules
+
 REACT_MODULE({{ pascalName }})
 struct {{ pascalName }}
 {


### PR DESCRIPTION
## Description

As we are creating new documentation for implementing native modules, this PR updates the links used in the `cpp-lib` template.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The old docs may eventually retire and therefore break the links.

### What
See above.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: _yes_

Update native module doc links in cpp-lib template
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14704)