### PR TITLE
Pointer events

### DIFF
--- a/change/react-native-windows-1ff7a358-a5fe-45d6-8df4-ecd913ae9509.json
+++ b/change/react-native-windows-1ff7a358-a5fe-45d6-8df4-ecd913ae9509.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "PointerEvent fixes",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -636,17 +636,6 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
 
   auto eventPathViews = GetTouchableViewsInPathToRoot(targetView);
 
-  // Over
-  if (targetView != nullptr && previousTargetTag != targetView.Tag()) {
-    bool shouldEmitOverEvent =
-        IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerOver);
-    const auto eventEmitter = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetView)
-                                  ->eventEmitterAtPoint(event.offsetPoint);
-    if (shouldEmitOverEvent && eventEmitter != nullptr) {
-      eventEmitter->onPointerOver(event);
-    }
-  }
-
   // Entering
 
   // We only want to emit events to JS if there is a view that is currently listening to said event
@@ -663,7 +652,6 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
     auto componentView = *itComponentView;
     bool shouldEmitEvent = componentView != nullptr &&
         (hasParentEnterListener ||
-         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::PointerEnter) ||
          IsViewListeningToEvent(componentView, facebook::react::WindowsViewEvents::Offset::MouseEnter));
 
     if (std::find(currentlyHoveredViews.begin(), currentlyHoveredViews.end(), componentView) ==
@@ -673,16 +661,12 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
               m_context, componentView.Tag(), pointerPoint, keyModifiers);
       winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(componentView)
           ->OnPointerEntered(args);
-
       if (shouldEmitEvent) {
         const auto eventEmitter =
             winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(componentView)
                 ->eventEmitter();
-        if (eventEmitter) {
-          eventEmitter->onPointerEnter(event);
-          if (IsMousePointerEvent(event)) {
-            eventEmitter->onMouseEnter(event);
-          }
+        if (eventEmitter && IsMousePointerEvent(event)) {
+          eventEmitter->onMouseEnter(event);
         }
       }
     }
@@ -695,26 +679,13 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
   // Call the underlaying pointer handler
   handler(eventPathViews);
 
-  // Out
-  if (previousTargetTag != -1 && previousTargetTag != (targetView ? targetView.Tag() : -1)) {
-    bool shouldEmitOutEvent =
-        IsAnyViewInPathListeningToEvent(currentlyHoveredViews, facebook::react::ViewEvents::Offset::PointerOut);
-    const auto eventEmitter =
-        winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(prevTargetView)->eventEmitter();
-    if (shouldEmitOutEvent && eventEmitter != nullptr) {
-      eventEmitter->onPointerOut(event);
-    }
-  }
-
   // Leaving
 
   // pointerleave events need to be emitted from the deepest target to the root but
   // we also need to efficiently keep track of if a view has a parent which is listening to the leave events,
   // so we first iterate from the root to the target, collecting the views which need events fired for, of which
   // we reverse iterate (now from target to root), actually emitting the events.
-  std::vector<winrt::Microsoft::ReactNative::ComponentView>
-      viewsToEmitJSLeaveEventsTo; // NSMutableOrderedSet<UIView *> *viewsToEmitLeaveEventsTo =
-                                  // [NSMutableOrderedSet orderedSet];
+  std::vector<winrt::Microsoft::ReactNative::ComponentView> viewsToEmitJSLeaveEventsTo;
 
   std::vector<winrt::Microsoft::ReactNative::ComponentView> viewsToEmitLeaveEventsTo;
 
@@ -722,14 +693,11 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
 
   bool hasParentLeaveListener = false;
   for (auto itComponentView = currentlyHoveredViews.rbegin(); itComponentView != currentlyHoveredViews.rend();
-       itComponentView++) { //  for (RCTReactTaggedView *taggedView in [currentlyHoveredViews
-                            //  reverseObjectEnumerator])
-                            //  {
+       itComponentView++) {
     auto componentView = *itComponentView;
 
     bool shouldEmitJSEvent = componentView != nullptr &&
         (hasParentLeaveListener ||
-         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::PointerLeave) ||
          IsViewListeningToEvent(componentView, facebook::react::WindowsViewEvents::Offset::MouseLeave));
 
     if (std::find(eventPathViews.begin(), eventPathViews.end(), componentView) == eventPathViews.end()) {
@@ -754,17 +722,13 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
   }
 
   for (auto itComponentView = viewsToEmitJSLeaveEventsTo.rbegin(); itComponentView != viewsToEmitJSLeaveEventsTo.rend();
-       itComponentView++) { //  for (UIView *componentView in [viewsToEmitJSLeaveEventsTo
-                            //  reverseObjectEnumerator]) {
+       itComponentView++) {
     auto componentView = *itComponentView;
 
     const auto eventEmitter =
         winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(componentView)->eventEmitter();
-    if (eventEmitter) {
-      eventEmitter->onPointerLeave(event);
-      if (IsMousePointerEvent(event)) {
-        eventEmitter->onMouseLeave(event);
-      }
+    if (eventEmitter && IsMousePointerEvent(event)) {
+      eventEmitter->onMouseLeave(event);
     }
   }
 
@@ -1063,19 +1027,17 @@ void CompositionEventHandler::onPointerMoved(
     auto activeTouch = m_activeTouches.find(pointerId);
     bool isActiveTouch = activeTouch != m_activeTouches.end() && activeTouch->second.eventEmitter != nullptr;
 
-    auto handler = [&targetView, &pointerEvent, isActiveTouch](
+    auto handler = [&, targetView, pointerEvent, isActiveTouch](
                        std::vector<winrt::Microsoft::ReactNative::ComponentView> &eventPathViews) {
       const auto eventEmitter = targetView
           ? winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetView)
                 ->eventEmitterAtPoint(pointerEvent.offsetPoint)
-          : nullptr;
-      bool hasMoveEventListeners = isActiveTouch ||
-          IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMove) ||
-          IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMoveCapture);
+          : RootComponentView().eventEmitterAtPoint(pointerEvent.offsetPoint);
 
-      if (eventEmitter != nullptr && hasMoveEventListeners) {
-        // Add logging before dispatching the event
+      if (eventEmitter != nullptr) {
         eventEmitter->onPointerMove(pointerEvent);
+      } else {
+        ClearAllHoveredForPointer(pointerEvent);
       }
     };
 
@@ -1085,6 +1047,23 @@ void CompositionEventHandler::onPointerMoved(
       // For active touches with responders, also dispatch through touch event system
       UpdateActiveTouch(activeTouch->second, ptScaled, ptLocal);
       DispatchTouchEvent(TouchEventType::Move, pointerId, pointerPoint, keyModifiers);
+    }
+  }
+}
+
+void CompositionEventHandler::ClearAllHoveredForPointer(const facebook::react::PointerEvent &pointerEvent) noexcept {
+  // special case if we have no target
+  // PointerEventsProcessor requires move events to keep track of the hovered components in core.
+  // It also treats a onPointerLeave event as a special case that removes the hover state of all currently hovered
+  // events. If we get null for the targetView, that means that the mouse is no over any components, so we have no
+  // element to send the move event to. However we need to send something so that any previously hovered elements
+  // are no longer hovered.
+  auto children = RootComponentView().Children();
+  if (auto size = children.Size()) {
+    auto firstChild = children.GetAt(0);
+    if (auto childEventEmitter =
+            winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(firstChild)->eventEmitter()) {
+      childEventEmitter->onPointerLeave(pointerEvent);
     }
   }
 }
@@ -1111,7 +1090,9 @@ void CompositionEventHandler::onPointerExited(
 
     facebook::react::PointerEvent pointerEvent = CreatePointerEventFromIncompleteHoverData(ptScaled, ptLocal);
 
-    auto handler = [](std::vector<winrt::Microsoft::ReactNative::ComponentView> &eventPathViews) {};
+    auto handler = [&](std::vector<winrt::Microsoft::ReactNative::ComponentView> &eventPathViews) {
+      ClearAllHoveredForPointer(pointerEvent);
+    };
 
     HandleIncomingPointerEvent(pointerEvent, nullptr, pointerPoint, keyModifiers, handler);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -98,6 +98,7 @@ class CompositionEventHandler : public std::enable_shared_from_this<CompositionE
       const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
       winrt::Windows::System::VirtualKeyModifiers keyModifiers,
       std::function<void(std::vector<winrt::Microsoft::ReactNative::ComponentView> &)> handler);
+  void ClearAllHoveredForPointer(const facebook::react::PointerEvent &pointerEvent) noexcept;
 
   struct ActiveTouch {
     facebook::react::Touch touch;

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
@@ -38,12 +38,12 @@ void HostPlatformViewEventEmitter::onBlur() const {
 
 #pragma mark - Mouse Events
 
-void HostPlatformViewEventEmitter::onMouseEnter(PointerEvent const &pointerEvent) const {
-  dispatchEvent("mouseEnter", std::make_shared<PointerEvent>(pointerEvent), RawEvent::Category::ContinuousStart);
+void HostPlatformViewEventEmitter::onMouseEnter(MouseEvent const &pointerEvent) const {
+  dispatchEvent("mouseEnter", std::make_shared<MouseEvent>(pointerEvent), RawEvent::Category::ContinuousStart);
 }
 
-void HostPlatformViewEventEmitter::onMouseLeave(PointerEvent const &pointerEvent) const {
-  dispatchEvent("mouseLeave", std::make_shared<PointerEvent>(pointerEvent), RawEvent::Category::ContinuousStart);
+void HostPlatformViewEventEmitter::onMouseLeave(MouseEvent const &pointerEvent) const {
+  dispatchEvent("mouseLeave", std::make_shared<MouseEvent>(pointerEvent), RawEvent::Category::ContinuousStart);
 }
 
 #pragma mark - Touch Events

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -5,6 +5,7 @@
 
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 #include "KeyEvent.h"
+#include "MouseEvent.h"
 
 namespace facebook::react {
 
@@ -32,8 +33,8 @@ class HostPlatformViewEventEmitter : public BaseViewEventEmitter {
 
 #pragma mark - Mouse Events
 
-  void onMouseEnter(PointerEvent const &pointerEvent) const;
-  void onMouseLeave(PointerEvent const &pointerEvent) const;
+  void onMouseEnter(MouseEvent const &pointerEvent) const;
+  void onMouseLeave(MouseEvent const &pointerEvent) const;
 
 #pragma mark - Touch Events
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/MouseEvent.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/MouseEvent.h
@@ -8,12 +8,13 @@
 namespace facebook::react {
 
 struct MouseEvent : public PointerEvent {
+  MouseEvent(PointerEvent &event) : PointerEvent(event){};
 
-    MouseEvent(PointerEvent& event) : PointerEvent(event) {};
-
-    // We override the type so that it is not recorded as a PointerType, 
-    // otherwise PointerEventsProcessor gets confused by the Windows specific MouseEvents
-    EventPayloadType getType() const override { return static_cast<EventPayloadType>(-1); };
+  // We override the type so that it is not recorded as a PointerType,
+  // otherwise PointerEventsProcessor gets confused by the Windows specific MouseEvents
+  EventPayloadType getType() const override {
+    return static_cast<EventPayloadType>(-1);
+  };
 };
 
-}
+} // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/MouseEvent.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/MouseEvent.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <react/renderer/components/view/PointerEvent.h>
+
+namespace facebook::react {
+
+struct MouseEvent : public PointerEvent {
+
+    MouseEvent(PointerEvent& event) : PointerEvent(event) {};
+
+    // We override the type so that it is not recorded as a PointerType, 
+    // otherwise PointerEventsProcessor gets confused by the Windows specific MouseEvents
+    EventPayloadType getType() const override { return static_cast<EventPayloadType>(-1); };
+};
+
+}


### PR DESCRIPTION
## Description
When moving a pointer from a view with a hover handler, to an empty space within the rootview, or outside of the rootview, the hover would get stuck.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #14672

### What
Prior to this change we were handling firing the PointerIn/Out/Enter/Leave events from windows platform code in ComponentEventHandler.  Since this code was written, core introduced a PointerEventsProcessor which takes pointermove events from the platform code and does the tracking of which component have hover state, and firing the appropriate JS pointer events.

Since PointerEventsProcessor will handle firing most of the pointer events, we no longer need to in ComponentEventHandler.  However there are some specific cases we need to handle.  In particular when the pointer leaves all views within the rootview, or leaves the reactnativeisland entirely.  In those cases, we need to forward a onPointerLeave event to JS so that the PointerEventsProcessor knows to unhover all components.

I also modified the MouseEvents to use a non-PointerEvent type, so that the PointerEventsProcessor does not intercepts those events, which cause duplicate PointerEvents to be fired.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14713)