### PR TITLE
Add aria-level, aria-posinset and aria-setsize in Image

### DIFF
--- a/change/react-native-windows-68a05a4e-5601-409f-85ce-8bdc6b706608.json
+++ b/change/react-native-windows-68a05a4e-5601-409f-85ce-8bdc6b706608.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add aria-level, aria-posinset and aria-setsize in Image",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -268,6 +268,9 @@ export default class Bootstrap extends React.Component<
               onLoadStart={() => console.log('onLoadStart')}
               onLoadEnd={() => console.log('onLoadEnd')}
               onProgress={this.handleOnProgress}
+              aria-level={1}
+              aria-posinset={10}
+              aria-setsize={100}
             />
           )}
         </View>

--- a/vnext/src-win/Libraries/Image/Image.windows.js
+++ b/vnext/src-win/Libraries/Image/Image.windows.js
@@ -149,7 +149,10 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
     'aria-selected': ariaSelected,
     'aria-readonly': ariaReadOnly, // Windows
     'aria-multiselectable': ariaMultiselectable, // Windows
-    'aria-required': ariaRequired, // Windows
+    'aria-required': ariaRequired, // Windows,
+    'aria-level': ariaLevel, // Windows
+    'aria-posinset': ariaPosinset, // Windows
+    'aria-setsize': ariaSetsize, // Windows
     height,
     src,
     ...restProps
@@ -167,6 +170,9 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
     required: ariaRequired ?? props.accessibilityState?.required, // Windows
   };
   const accessibilityLabel = props['aria-label'] ?? props.accessibilityLabel;
+  const accessibilityLevel = ariaLevel ?? props.accessibilityLevel; // Windows
+  const accessibilityPosInSet = ariaPosinset ?? props.accessibilityPosInSet; // Windows
+  const accessibilitySetSize = ariaSetsize ?? props.accessibilitySetSize; // Windows
 
   const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
 
@@ -189,6 +195,9 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
                   {...restProps}
                   accessible={props.alt !== undefined ? true : props.accessible}
                   accessibilityLabel={accessibilityLabel ?? props.alt}
+                  accessibilityLevel={accessibilityLevel} // Windows
+                  accessibilityPosInSet={accessibilityPosInSet} // Windows
+                  accessibilitySetSize={accessibilitySetSize} // Windows
                   ref={actualRef}
                   style={style}
                   resizeMode={resizeMode}
@@ -211,6 +220,9 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
             {...restProps}
             accessible={props.alt !== undefined ? true : props.accessible}
             accessibilityLabel={accessibilityLabel ?? props.alt}
+            accessibilityLevel={accessibilityLevel} // Windows
+            accessibilityPosInSet={accessibilityPosInSet} // Windows
+            accessibilitySetSize={accessibilitySetSize} // Windows
             ref={actualRef}
             style={style}
             resizeMode={resizeMode}


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Add aria-level, aria-posinset and aria-setsize in Image

Resolves https://github.com/microsoft/react-native-windows/issues/14722

### What
Add aria-level, aria-posinset and aria-setsize in Image.windows.js, this file is already overridden.

Call Stack:
```
Image.windows.js
ImageComponentView::updateProps
ViewComponentView::updateProps
ComponentView::updateAccessibilityProps
```

## Screenshots
### Before [Values were not updated]:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/c506c6f2-67db-4ceb-acf1-47486c350d5c" />
<img width="314" alt="image" src="https://github.com/user-attachments/assets/14bdbdbf-460b-439f-bfa5-5c9a3b246e6e" />

### After [Values updated]:
![image](https://github.com/user-attachments/assets/0a956ada-bc1f-4960-9316-690bf8a6bed2)
![image](https://github.com/user-attachments/assets/040b8053-7cb5-46f8-9cee-823eb83b6673)

## Testing
Tested in playground

## Changelog
Should this change be included in the release notes: YES

Add a brief summary of the change to use in the release notes for the next release: Add aria-level, aria-posinset and aria-setsize in Image

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14721)