### PR TITLE
Update lock file to only bring in @types/react 19 - fix a few type errors from 18=>19 bump

### DIFF
--- a/change/@office-iss-react-native-win32-bb0a2f17-47f8-4b3c-a3d5-83f59f87b208.json
+++ b/change/@office-iss-react-native-win32-bb0a2f17-47f8-4b3c-a3d5-83f59f87b208.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update to @types/react 19",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-9fe6828d-4ba7-4748-933a-b07d1f404589.json
+++ b/change/react-native-windows-9fe6828d-4ba7-4748-933a-b07d1f404589.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update to @types/react 19",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/src/js/components/TextWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32-tester/src/js/components/TextWin32Test.tsx
@@ -121,56 +121,56 @@ export const examples = [
     {
       title: 'Text Runs Example',
       description: 'text runs in action',
-      render(): JSX.Element {
+      render() {
         return (<TextRunsTest />);
       },
     },
     {
       title: 'Focusable Example',
       description: 'focusable in action',
-      render(): JSX.Element {
+      render() {
         return (<FocusableTextTest />);
       },
     },
     {
       title: 'Selectable Example',
       description: 'selectable in action',
-      render(): JSX.Element {
+      render() {
         return (<SelectableTextTest />);
       },
     },
     {
       title: 'TextStyle Example',
       description: 'TextStyles in action',
-      render(): JSX.Element {
+      render() {
         return (<TextStyleTest />);
       },
     },
     {
       title: 'Acessibility Example',
       description: 'Acessibility on Text in action',
-      render(): JSX.Element {
+      render() {
         return (<TextAcessibilityTest />);
       },
     },
     {
       title: 'Tooltip Example',
       description: 'tooltips in action',
-      render(): JSX.Element {
+      render() {
         return (<TooltipTextTest />);
       },
     },
     {
       title: 'TextPromotion Example',
       description: 'dynamic increases in focusability in action',
-      render(): JSX.Element {
+      render() {
         return (<TextPromotionTest />);
       },
     },
     {
       title: 'Focus and Blur Example',
       description: 'onFocus/onBlur in action',
-      render(): JSX.Element {
+      render() {
         return (<BlurringAndFocusingTextTest />);
       },
     },

--- a/packages/@office-iss/react-native-win32-tester/src/js/components/ViewWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32-tester/src/js/components/ViewWin32Test.tsx
@@ -285,7 +285,7 @@ export const examples = [
   {
     title: 'focus() method example',
     description: 'Each of these black boxes moves focus to the ViewWin32 on the right',
-    render(): JSX.Element {
+    render() {
       return (
         <ViewWin32>
           <FocusMoverTestComponent />
@@ -298,35 +298,35 @@ export const examples = [
   {
     title: 'KeyboardEvents example',
     description: 'Native keyboarding has been prevented',
-    render(): JSX.Element {
+    render() {
       return <KeyboardTestComponent />;
     },
   },
   {
     title: 'Hover example',
     description: 'Hover a rainbow',
-    render(): JSX.Element {
+    render() {
       return <HoverExample />;
     },
   },
   {
     title: 'Tooltip example',
     description: 'Displays a tooltip on hover',
-    render(): JSX.Element {
+    render() {
       return <ToolTipExample />;
     },
   },
   {
     title: 'Cursor example',
     description: 'Each of these boxes should display a different cursor',
-    render(): JSX.Element {
+    render() {
       return <CursorExample />;
     },
   },
   {
     title: 'EnableFocusRing example',
     description: 'Displays focus visuals that are driven by native',
-    render(): JSX.Element {
+    render() {
       return <EnableFocusRingExample />;
     },
   },

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
@@ -329,7 +329,7 @@ const getItemLayout = (data: ArrayLike<IListProps>, index: number) => ({ length:
 const keyExtractor = (item: IListProps) => item.label.toString();
 
 interface IFlatListProps {
-  renderItem: (item: ListRenderItemInfo<IListProps>) => JSX.Element;
+  renderItem: (item: ListRenderItemInfo<IListProps>) => React.JSX.Element;
   getItemLayout?: (
     data: ArrayLike<IListProps>,
     index: number

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Theming/ThemingModuleAPI.tsx
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Theming/ThemingModuleAPI.tsx
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
 
 const Theming = NativeModules.Theming;
 
-const ifModuleAvailable = (wrappedComponent: JSX.Element) => {
+const ifModuleAvailable = (wrappedComponent: React.JSX.Element) => {
   return Theming ? wrappedComponent : <Text>Theming Native Module not available</Text>;
 };
 

--- a/packages/@office-iss/react-native-win32/src-win/Libraries/Components/TextInput/Tests/TextInputTest.tsx
+++ b/packages/@office-iss/react-native-win32/src-win/Libraries/Components/TextInput/Tests/TextInputTest.tsx
@@ -114,49 +114,49 @@ export const examples = [
     {
       title: 'Autofocus Example',
       description: 'autoFocus in action',
-      render(): JSX.Element {
+      render() {
         return (<AutoFocusingTextInputTest />);
       },
     },
     {
       title: 'Placeholders Example',
       description: 'placeholder in action',
-      render(): JSX.Element {
+      render() {
         return (<PlaceholderTextInputTest />);
       },
     },
     {
       title: 'Controlled Example',
       description: 'Controlling inputs in action',
-      render(): JSX.Element {
+      render() {
         return (<ControllingTextInputTest />);
       },
     },
     {
       title: 'Focus and Blur Example',
       description: 'onFocus/onBlur in action',
-      render(): JSX.Element {
+      render() {
         return (<BlurringAndFocusingTextInputTest />);
       },
     },
     {
       title: 'ContentSizeChange Example',
       description: 'onContentSizeChange in action',
-      render(): JSX.Element {
+      render() {
         return (<LayoutListeningTextInputTest />);
       },
     },
     {
       title: 'Control via onKeyPress Example',
       description: 'onKeyPress in action',
-      render(): JSX.Element {
+      render() {
         return (<KeyPressListeningTextInputTest />);
       },
     },
     {
       title: 'Super Styling Example',
       description: 'Styling in action',
-      render(): JSX.Element {
+      render() {
         return (<StyleTextInputTest />);
       },
     },

--- a/packages/@office-iss/react-native-win32/src-win/Libraries/Components/Touchable/Tests/TouchableWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src-win/Libraries/Components/Touchable/Tests/TouchableWin32Test.tsx
@@ -481,21 +481,21 @@ export const examples = [
   {
     title: 'TouchableWithoutFeedback Example',
     description: 'A simple example implementation of without feedback behavior',
-    render(): JSX.Element {
+    render() {
       return <TouchableWithoutFeedbackExample />;
     },
   },
   {
     title: 'TouchableHighlight Example',
     description: 'A simple example implementation of highlight behavior',
-    render(): JSX.Element {
+    render() {
       return <TouchableHighlightExample />;
     },
   },
   {
     title: 'Imperative Focus on TouchableWin32 Example',
     description: 'A simple example implementation of imperative focus behavior',
-    render(): JSX.Element {
+    render() {
       return <TouchableFocusExample />;
     },
   }

--- a/packages/@office-iss/react-native-win32/src-win/Libraries/Image/Tests/ImageWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src-win/Libraries/Image/Tests/ImageWin32Test.tsx
@@ -10,7 +10,7 @@ export const examples = [
     {
       title: 'Win32 Image control test',
       description: 'Test Image',
-      render(): JSX.Element {
+      render() {
         return (
           <Image
             style={ { width: 100, height: 100 } }

--- a/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityExampleWindows.tsx
@@ -594,31 +594,31 @@ export const description = 'Usage of accessibility properties.';
 export const examples = [
   {
     title: 'Label, Hint',
-    render: function (): JSX.Element {
+    render: function () {
       return <AccessibilityBaseExample />;
     },
   },
   {
     title: 'Touchables',
-    render: function (): JSX.Element {
+    render: function () {
       return <TouchableExamples />;
     },
   },
   {
     title: 'HighContrast',
-    render: function (): JSX.Element {
+    render: function () {
       return <HighContrastExample />;
     },
   },
   {
     title: 'States',
-    render: function (): JSX.Element {
+    render: function () {
       return <AccessibilityStateExamples />;
     },
   },
   {
     title: 'Lists',
-    render: function (): JSX.Element {
+    render: function () {
       return <AccessibilityListExamples />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/DisplayNone/DisplayNoneExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/DisplayNone/DisplayNoneExample.windows.tsx
@@ -58,7 +58,7 @@ export const description =
   'Style prop which will collapse the element in XAML tree.';
 export const examples = [
   {
-    render: function (): JSX.Element {
+    render: function () {
       return <DisplayNoneExample />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/Flyout/FlyoutExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Flyout/FlyoutExample.windows.tsx
@@ -343,7 +343,7 @@ export const description =
 export const examples = [
   {
     title: 'Flyout Anchor to text input',
-    render: function (): JSX.Element {
+    render: function () {
       return <FlyoutExample />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/Glyph/GlyphExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Glyph/GlyphExample.tsx
@@ -53,7 +53,7 @@ export const description = 'Usage of Glyph control.';
 export const examples = [
   {
     title: 'Glyph examples',
-    render: function (): JSX.Element {
+    render: function () {
       return <GlyphExamples />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExample.tsx
@@ -108,7 +108,7 @@ export const description = 'Usage of keyboard properties.';
 export const examples = [
   {
     title: 'Tabstops',
-    render: function (): JSX.Element {
+    render: function () {
       return <TabStopExample />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExtensionExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExtensionExample.windows.tsx
@@ -76,7 +76,7 @@ class ViewWindowsKeyboardExample extends React.Component<
     };
   }
 
-  public render(): JSX.Element {
+  public render() {
     return (
       <ViewWindows>
         <ViewWindows
@@ -182,7 +182,7 @@ export const description = 'Demo of keyboard properties.';
 export const examples = [
   {
     title: 'Keyboard extension example',
-    render(): JSX.Element {
+    render() {
       return <ViewWindowsKeyboardExample />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardFocusExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardFocusExample.windows.tsx
@@ -82,7 +82,7 @@ class KeyboardFocusExample extends React.Component<
     };
   }
 
-  public render(): JSX.Element {
+  public render() {
     const pickerItems = [
       'View',
       'Picker',
@@ -248,7 +248,7 @@ export const description = 'Demo of keyboard focus.';
 export const examples = [
   {
     title: 'Keyboard Focus example',
-    render(): JSX.Element {
+    render() {
       return <KeyboardFocusExample />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ControlStyleTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ControlStyleTestPage.tsx
@@ -91,7 +91,7 @@ export const title = 'LegacyControlStyleTest';
 export const description = 'Legacy e2e test for Control Styles';
 export const examples = [
   {
-    render: function(): JSX.Element {
+    render: function() {
       return <ControlStyleTestPage />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ImageTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/ImageTestPage.tsx
@@ -99,7 +99,7 @@ export const title = 'LegacyImageTest';
 export const description = 'Legacy e2e test for Image';
 export const examples = [
   {
-    render: function(): JSX.Element {
+    render: function() {
       return <ImageTestPage />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/LoginTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/LoginTestPage.tsx
@@ -102,7 +102,7 @@ export const title = 'LegacyLoginTest';
 export const description = 'Legacy e2e test for TextInput with password';
 export const examples = [
   {
-    render: function(): JSX.Element {
+    render: function() {
       return <LoginTestPage />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/SelectableTextTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/SelectableTextTestPage.tsx
@@ -67,7 +67,7 @@ export const title = 'LegacySelectableTextTest';
 export const description = 'Legacy e2e test for selectable Text hit testing';
 export const examples = [
   {
-    render: function (): JSX.Element {
+    render: function () {
       return <SelectableTextTests />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextHitTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextHitTestPage.tsx
@@ -167,7 +167,7 @@ export const title = 'LegacyTextHitTestTest';
 export const description = 'Legacy e2e test for Text hit testing';
 export const examples = [
   {
-    render: function (): JSX.Element {
+    render: function () {
       return <PressableTextTests />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextInputTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextInputTestPage.tsx
@@ -84,7 +84,7 @@ export const title = 'LegacyTextInputTest';
 export const description = 'Legacy e2e test for TextInput';
 export const examples = [
   {
-    render: function (): JSX.Element {
+    render: function () {
       return <TextInputTestPage />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/Popup/PopupExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Popup/PopupExample.windows.tsx
@@ -188,19 +188,19 @@ export const description =
 export const examples = [
   {
     title: 'Popup Anchor to text input w/ light dismiss',
-    render: function (): JSX.Element {
+    render: function () {
       return <AnchoredPopupExample />;
     },
   },
   {
     title: 'Popup centered on screen',
-    render: function (): JSX.Element {
+    render: function () {
       return <PopupPlacementExample />;
     },
   },
   {
     title: 'Popup with Accessibility Customization',
-    render: function (): JSX.Element {
+    render: function () {
       return <PopupAccessibilityExample />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/TransferProperties/TransferPropertiesExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/TransferProperties/TransferPropertiesExample.tsx
@@ -143,13 +143,13 @@ export const description =
 export const examples = [
   {
     title: 'Flow Direction Change',
-    render: function (): JSX.Element {
+    render: function () {
       return <FlowDirectionChange />;
     },
   },
   {
     title: 'zIndex Change',
-    render: function (): JSX.Element {
+    render: function () {
       return <ZIndexChange />;
     },
   },

--- a/packages/@react-native-windows/tester/src/js/examples-win/XAML/XAMLExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/XAML/XAMLExample.tsx
@@ -115,7 +115,7 @@ export const description = 'Usage of react-native-xaml controls';
 export const examples = [
   {
     title: 'react-native-xaml examples',
-    render: function (): JSX.Element {
+    render: function () {
       return <XAMLExamples />;
     },
   },

--- a/vnext/src-win/Libraries/Components/Keyboard/KeyboardExt.tsx
+++ b/vnext/src-win/Libraries/Components/Keyboard/KeyboardExt.tsx
@@ -25,7 +25,7 @@ export const supportKeyboard = <P extends Record<string, any>>(
     IForwardRefProps;
 
   class SupportKeyboard extends React.Component<PropsWithForwardedRef> {
-    public render(): JSX.Element {
+    public render() {
       const {forwardedRef, ...rest} = this.props;
       return (
         <WrappedComponent ref={forwardedRef} {...(rest as unknown as P)} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,20 +114,7 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz#7644147706bb90ff613297d49ed5266bde729f83"
-  integrity sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.25.9"
-    "@babel/helper-member-expression-to-functions" "^7.25.9"
-    "@babel/helper-optimise-call-expression" "^7.25.9"
-    "@babel/helper-replace-supers" "^7.25.9"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
-    semver "^6.3.1"
-
-"@babel/helper-create-class-features-plugin@^7.27.0":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.25.9", "@babel/helper-create-class-features-plugin@^7.27.0":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz#518fad6a307c6a96f44af14912b2c20abe9bfc30"
   integrity sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==
@@ -192,12 +179,7 @@
   dependencies:
     "@babel/types" "^7.25.9"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.18.9", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.26.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz#18580d00c9934117ad719392c4f6585c9333cc35"
-  integrity sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==
-
-"@babel/helper-plugin-utils@^7.27.1":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.18.9", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.26.5", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz#ddb2f876534ff8013e6c2b299bf4d39b3c51d44c"
   integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
@@ -211,16 +193,7 @@
     "@babel/helper-wrap-function" "^7.25.9"
     "@babel/traverse" "^7.25.9"
 
-"@babel/helper-replace-supers@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz#ba447224798c3da3f8713fc272b145e33da6a5c5"
-  integrity sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.25.9"
-    "@babel/helper-optimise-call-expression" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
-
-"@babel/helper-replace-supers@^7.26.5":
+"@babel/helper-replace-supers@^7.25.9", "@babel/helper-replace-supers@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz#6cb04e82ae291dae8e72335dfe438b0725f14c8d"
   integrity sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==
@@ -507,19 +480,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.25.4":
+"@babel/plugin-syntax-typescript@^7.25.4", "@babel/plugin-syntax-typescript@^7.25.9", "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz#5147d29066a793450f220c63fa3a9431b7e6dd18"
   integrity sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
-
-"@babel/plugin-syntax-typescript@^7.25.9", "@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz#67dda2b74da43727cf21d46cf9afef23f4365399"
-  integrity sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
@@ -2809,11 +2775,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prop-types@*":
-  version "15.7.13"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
-  integrity sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==
-
 "@types/prop-types@15.7.1":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
@@ -2840,15 +2801,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.3.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.18.tgz#9b382c4cd32e13e463f97df07c2ee3bbcd26904b"
-  integrity sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^19.0.0":
+"@types/react@*", "@types/react@^19.0.0":
   version "19.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.3.tgz#7867240defc1a3686f151644ac886a7e8e0868f4"
   integrity sha512-UavfHguIjnnuq9O67uXfgy/h3SRJbidAYvNjLceB+2RIKVRBzVsh0QO+Pw6BCSQqFS9xwzKfwstXx0m6AbAREA==
@@ -4035,12 +3988,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bare-events@^2.2.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.5.0.tgz#305b511e262ffd8b9d5616b056464f8e1b3329cc"
-  integrity sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==
-
-bare-events@^2.5.4:
+bare-events@^2.2.0, bare-events@^2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.5.4.tgz#16143d435e1ed9eafd1ab85f12b89b3357a41745"
   integrity sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==
@@ -4149,17 +4097,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
-  version "4.24.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.2.tgz#f5845bc91069dbd55ee89faf9822e1d885d16580"
-  integrity sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==
-  dependencies:
-    caniuse-lite "^1.0.30001669"
-    electron-to-chromium "^1.5.41"
-    node-releases "^2.0.18"
-    update-browserslist-db "^1.1.1"
-
-browserslist@^4.24.3:
+browserslist@^4.24.0, browserslist@^4.24.3:
   version "4.24.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.4.tgz#c6b2865a3f08bcb860a0e827389003b9fe686e4b"
   integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
@@ -4307,11 +4245,6 @@ camelcase@^6.2.0, camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
-
-caniuse-lite@^1.0.30001669:
-  version "1.0.30001680"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz#5380ede637a33b9f9f1fc6045ea99bd142f3da5e"
-  integrity sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==
 
 caniuse-lite@^1.0.30001688:
   version "1.0.30001701"
@@ -5231,11 +5164,6 @@ ejs@^3.1.10:
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
   dependencies:
     jake "^10.8.5"
-
-electron-to-chromium@^1.5.41:
-  version "1.5.56"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.56.tgz#3213f369efc3a41091c3b2c05bc0f406108ac1df"
-  integrity sha512-7lXb9dAvimCFdvUMTyucD4mnIndt/xhRKFAlky0CyFogdnNmdPQNoHI23msF/2V4mpTxMzgMdjK4+YRlFlRQZw==
 
 electron-to-chromium@^1.5.73:
   version "1.5.109"
@@ -9155,11 +9083,6 @@ node-notifier@^9.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-releases@^2.0.18:
-  version "2.0.18"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
-  integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
-
 node-releases@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
@@ -9982,11 +9905,6 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-queue-tick@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142"
-  integrity sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==
 
 queue@6.0.2:
   version "6.0.2"
@@ -10975,18 +10893,7 @@ stream-exhaust@^1.0.1, stream-exhaust@^1.0.2:
   resolved "https://registry.yarnpkg.com/stream-exhaust/-/stream-exhaust-1.0.2.tgz#acdac8da59ef2bc1e17a2c0ccf6c320d120e555d"
   integrity sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==
 
-streamx@^2.15.0:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.20.1.tgz#471c4f8b860f7b696feb83d5b125caab2fdbb93c"
-  integrity sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==
-  dependencies:
-    fast-fifo "^1.3.2"
-    queue-tick "^1.0.1"
-    text-decoder "^1.1.0"
-  optionalDependencies:
-    bare-events "^2.2.0"
-
-streamx@^2.21.0:
+streamx@^2.15.0, streamx@^2.21.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.22.0.tgz#cd7b5e57c95aaef0ff9b2aef7905afa62ec6e4a7"
   integrity sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14726)