### PR TITLE
[Fabric] Implement aria-level, aria-posinset, aria-setsize in TextInput 

### DIFF
--- a/change/react-native-windows-17854356-6c83-40a6-b389-c84b78901335.json
+++ b/change/react-native-windows-17854356-6c83-40a6-b389-c84b78901335.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Implement aria-level, aria-posinset, aria-setsize in Switch",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/index.tsx
+++ b/packages/playground/Samples/index.tsx
@@ -81,6 +81,9 @@ class PopupButton extends React.Component<
         <Switch
           value={this.state.isLightDismissEnabled}
           onValueChange={value => this.setState({isLightDismissEnabled: value})}
+          aria-level={1}
+          aria-posinset={1}
+          aria-setsize={30}
         />
         <Button
           onPress={this._onPress}

--- a/vnext/src-win/Libraries/Components/Switch/Switch.windows.js
+++ b/vnext/src-win/Libraries/Components/Switch/Switch.windows.js
@@ -176,10 +176,16 @@ const Switch: component(
     thumbColor,
     trackColor,
     value,
+    'aria-level': ariaLevel, // Windows
+    'aria-posinset': ariaPosinset, // Windows
+    'aria-setsize': ariaSetsize, // Windows
     ...restProps
   } = props;
   const trackColorForFalse = trackColor?.false;
   const trackColorForTrue = trackColor?.true;
+  const _accessibilityLevel = ariaLevel ?? props.accessibilityLevel; // Windows
+  const _accessibilityPosInSet = ariaPosinset ?? props.accessibilityPosInSet; // Windows
+  const _accessibilitySetSize = ariaSetsize ?? props.accessibilitySetSize; // Windows
 
   const nativeSwitchRef = React.useRef<React.ElementRef<
     typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
@@ -278,6 +284,9 @@ const Switch: component(
         focusable={focusable === undefined ? true : focusable} // [Windows]
         accessible={accessible === undefined ? true : accessible} // [Windows]
         accessibilityRole={props.accessibilityRole ?? 'switch'}
+        accessibilityLevel={_accessibilityLevel} // [Windows]
+        accessibilityPosInSet={_accessibilityPosInSet} // [Windows]
+        accessibilitySetSize={_accessibilitySetSize} // [Windows]
         onChange={handleChange}
         onResponderTerminationRequest={returnsFalse}
         onStartShouldSetResponder={returnsTrue}


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves https://github.com/microsoft/react-native-windows/issues/14734

### What
Add aria-level, aria-posinset and aria-setsize in Switch.windows.js, this file is already overridden.

Call Stack:
```
Switch.windows.js
SwitchComponentView::updateProps
ViewComponentView::updateProps
ComponentView::updateAccessibilityProps
```

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
Playground tested

## Changelog
Should this change be included in the release notes: YES

Add a brief summary of the change to use in the release notes for the next release.
 Implement aria-level, aria-posinset, aria-setsize in TextInput 