### PR TITLE
[CLI] Update CLI Warnings to > 0.79 instead of 0.75

### DIFF
--- a/change/react-native-windows-init-02969c7e-5d96-4cf2-946d-853cd126cfdb.json
+++ b/change/react-native-windows-init-02969c7e-5d96-4cf2-946d-853cd126cfdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[CLI] Update CLI Warnings to > 0.79 instead of 0.75",
+  "packageName": "react-native-windows-init",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -303,7 +303,7 @@ function installReactNativeWindows(
     const newSteps =
       'Please see https://microsoft.github.io/react-native-windows/docs/getting-started for the latest method for adding RNW to your project.';
     if (
-      parsedVersion.minor > 75 ||
+      parsedVersion.minor > 79 ||
       (parsedVersion.minor === 0 &&
         parsedVersion.prerelease.length > 1 &&
         parsedVersion.prerelease[0] === 'canary' &&
@@ -313,13 +313,13 @@ function installReactNativeWindows(
       // Full-stop, you can't use the command anymore.
       throw new CodedError(
         'UnsupportedReactNativeVersion',
-        `react-native-windows-init only supports react-native-windows <= 0.75. ${newSteps}`,
+        `react-native-windows-init only supports react-native-windows <= 0.79. ${newSteps}`,
       );
-    } else if (parsedVersion.minor === 75) {
+    } else if (parsedVersion.minor === 79) {
       // You can use the command for now, but it will be deprecated soon.
       console.warn(
         chalk.yellow(
-          `Warning: react-native-windows-init will be deprecated for RNW > 0.75. ${newSteps}`,
+          `Warning: react-native-windows-init will be deprecated for RNW > 0.79. ${newSteps}`,
         ),
       );
     }


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To build RNW Gallery app with 0.79 preview version using instructions here https://github.com/microsoft/react-native-gallery/wiki/Manual-Validation-Steps-for-RNW-Release
Step 3

Run `npx react-native-windows-init --version 0.79.0-preview.1 --overwrite`. 

### What

Update CLI Warnings to > 0.79 instead of 0.75

## Changelog
Should this change be included in the release notes: NO

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14742)