### PR TITLE
creaternwapp.cmd: Override RN CLI nightly template

### DIFF
--- a/change/react-native-windows-f5824696-b0ed-4c23-a443-5f00a7ac5569.json
+++ b/change/react-native-windows-f5824696-b0ed-4c23-a443-5f00a7ac5569.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "creaternwapp.cmd: Override default RN CLI template when nightly detected",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/creaternwapp.cmd
+++ b/vnext/Scripts/creaternwapp.cmd
@@ -111,8 +111,14 @@ for /f "delims=" %%a in ('npm show react@%R_VERSION% version') do @set R_VERSION
 
 @echo creaternwapp.cmd Creating RNW app "%APP_NAME%" with react@%R_VERSION%, react-native@%RN_VERSION%, and react-native-windows@%RNW_VERSION%
 
-@echo creaternwapp.cmd: Creating base RN app project with: npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% --verbose --skip-install --install-pods false --skip-git-init true
-call npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% --verbose --skip-install --install-pods false --skip-git-init true
+set RNCLI_TEMPLATE=
+if not "x%RN_VERSION:nightly=%"=="x%RN_VERSION%" (
+  @echo creaternwapp.cmd Override @react-native-community/template version
+  set RNCLI_TEMPLATE=--template "@react-native-community/template@^%RN_VERSION:~0,4%.0"
+)
+
+@echo creaternwapp.cmd: Creating base RN app project with: npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% %RNCLI_TEMPLATE% --verbose --skip-install --install-pods false --skip-git-init true
+call npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% %RNCLI_TEMPLATE% --verbose --skip-install --install-pods false --skip-git-init true
 
 if %ERRORLEVEL% neq 0 (
   @echo creaternwapp.cmd: Unable to create base RN app project
@@ -134,7 +140,7 @@ call yarn install
 @echo creaternwapp.cmd: Creating commit to save current state
 if not exist ".git\" call git init .
 call git add .
-call git commit -m "npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% --verbose --skip-install --install-pods false --skip-git-init true"
+call git commit -m "npx --yes @react-native-community/cli@latest init %APP_NAME% --version %RN_VERSION% %RNCLI_TEMPLATE% --verbose --skip-install --install-pods false --skip-git-init true"
 
 if %USE_VERDACCIO% equ 1 (
   @echo creaternwapp.cmd: Setting yarn to use verdaccio at http://localhost:4873


### PR DESCRIPTION
## Description

This PR fixes broken PR checks when creating new RN app projects with `@react-native-community/cli`, by trying to find a better template for the base project than the RN community CLI chooses.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
When the `@react-native-community/cli init` command is told to make a project with **any** RN version that is a nightly, it ignores that version and assumes the user **always** wants the very latest nightly template form the community instead. But there is no guarantee that this latest nightly template works, and it explicitly doesn't support any RN version other than the very latest nightly.

As our main branch only integrates to the nightly versions from the upstream react-native main branch, and by definition we can't integrate ahead of react-native, our main is **always** pointing to an older RN nightly version. As such, this causes all kinds of problems with creating working projects against RNW main, and in particular breaks our PR/CI checks to do so.

### What
This PR tries to fix this by, when targeting nightly versions, we override the template that the community CLI chooses, by instead specifying in advance that we want the latest template version with the same minor version as our version of RN. This way we'll have a better chance of getting a template from at least the same version timeframe as the RN version we want to use.

## Screenshots
N/A

## Testing
Verified the script works now.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14747)