### PR TITLE
Change `init-windows` default new app template to New Architecture

### DIFF
--- a/change/@react-native-windows-cli-d1794f85-8985-4fcd-b5c0-50b289c776d9.json
+++ b/change/@react-native-windows-cli-d1794f85-8985-4fcd-b5c0-50b289c776d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change `init-windows` default new app template to New Architecture",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-bd20914d-b8fe-423d-834a-6caf8cb49b9c.json
+++ b/change/react-native-windows-bd20914d-b8fe-423d-834a-6caf8cb49b9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change `init-windows` default new app template to New Architecture",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -24,7 +24,7 @@ export const initOptions: CommandOption[] = [
   {
     name: '--template [string]',
     description: 'Specify the template to use',
-    default: undefined,
+    default: 'cpp-app',
   },
   {
     name: '--name [string]',

--- a/vnext/templates/cpp-app/template.config.js
+++ b/vnext/templates/cpp-app/template.config.js
@@ -144,8 +144,9 @@ async function postInstall(config = {}, options = {}) {
 module.exports = {
   name: 'React Native Windows Application (New Arch, WinAppSDK, C++)',
   description:
-    "[Preview] A RNW app using RN's New Architecture, built in C++ and targeting WinAppSDK.",
+    "A RNW app using RN's New Architecture, built in C++ and targeting WinAppSDK.",
   preInstall,
   getFileMappings,
   postInstall,
+  isDefault: true,
 };

--- a/vnext/templates/old/generateWrapper.js
+++ b/vnext/templates/old/generateWrapper.js
@@ -13,7 +13,7 @@ function makeGenerateWindowsWrapper(language = 'cpp', isDefault = false) {
   const name = `React Native Windows Application (Old Arch, UWP, ${
     language === 'cs' ? 'C#' : 'C++'
   })`;
-  const description = `A RNW app using RN's Old Architecture, built in ${
+  const description = `[Legacy] A RNW app using RN's Old Architecture, built in ${
     language === 'cs' ? 'C#' : 'C++'
   } and targeting UWP.`;
 

--- a/vnext/templates/old/uwp-cpp-app/template.config.js
+++ b/vnext/templates/old/uwp-cpp-app/template.config.js
@@ -12,4 +12,4 @@
 
 const {makeGenerateWindowsWrapper} = require('../generateWrapper');
 
-module.exports = makeGenerateWindowsWrapper('cpp', true); // TODO: Remove this as the default
+module.exports = makeGenerateWindowsWrapper('cpp');


### PR DESCRIPTION
## Description

This PR changes the default template for `init-windows` to the New Architecture `cpp-app` template.

### Type of Change
- This change requires a documentation update

### Why
Starting in RNW 0.80.0, the New Architecture will be the default for new apps.

Resolves #13935
Resolves #14749 

### What
Switched the default from `old\uwp-cpp-app` to `cpp-app` and updated the descriptions of both.

## Screenshots
N/A

## Testing
Verified the default changes when listing the available templates.

## Changelog
Should this change be included in the release notes: _yes_

Change `init-windows` default new app template to New Architecture
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14750)