### PR TITLE
[0.76] Fix `init-windows` template default not set for telemetry purposes

### DIFF
--- a/change/@react-native-windows-cli-2c1aab12-ed30-48da-ad94-6a45e37c4a3f.json
+++ b/change/@react-native-windows-cli-2c1aab12-ed30-48da-ad94-6a45e37c4a3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.76] Fix `init-windows` template default not set for telemetry purposes",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -24,7 +24,7 @@ export const initOptions: CommandOption[] = [
   {
     name: '--template [string]',
     description: 'Specify the template to use',
-    default: undefined,
+    default: 'old/uwp-cpp-app',
   },
   {
     name: '--name [string]',


### PR DESCRIPTION
## Description

This PR fixes the issue where telemetry reports the value of the template before it's calculated.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The template default, when no option was provided, is calculated after telemetry records the value, so it was always blank in such cases.

Resolves #14749

### What
Updated `initWindowsOptions` to include the current template default.

## Screenshots
N/A

## Testing
Verified the value appears in the debugger.

## Changelog
Should this change be included in the release notes: _yes_

Fix `init-windows` template default not set for telemetry purposes
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14755)