### PR TITLE
Add warning to CLI commands about using the old architecture

### DIFF
--- a/change/@react-native-windows-cli-34ba2de8-d376-4c25-bc3d-fe3c53f1787c.json
+++ b/change/@react-native-windows-cli-34ba2de8-d376-4c25-bc3d-fe3c53f1787c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add warning to CLI commands about using the old architecture",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
@@ -540,10 +540,16 @@ export function getRnwConfig(
 
   const config: Record<string, any> = pkgJson['react-native-windows'] ?? {};
 
+  const info = getRawTemplateInfo(projectFile);
+
+  // inject raw templateInfo for later command use
+  config.projectArch = info.projectArch;
+  config.projectLang = info.projectLang;
+  config.projectType = info.projectType;
+
   // if init-windows is missing (most existing projects), try to auto-calculate it
   config['init-windows'] ??= {};
   if (!config['init-windows'].template) {
-    const info = getRawTemplateInfo(projectFile);
     if (info.projectArch && info.projectLang && info.projectType) {
       config['init-windows'].template = `${
         info.projectArch === 'old' ? 'old/uwp-' : ''

--- a/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
@@ -543,14 +543,22 @@ export function getRnwConfig(
   const info = getRawTemplateInfo(projectFile);
 
   // inject raw templateInfo for later command use
-  config.projectArch = info.projectArch;
-  config.projectLang = info.projectLang;
-  config.projectType = info.projectType;
+  if (info.projectArch) {
+    config.projectArch = info.projectArch;
+  }
+
+  if (info.projectLang) {
+    config.projectLang = info.projectLang;
+  }
+
+  if (info.projectType) {
+    config.projectType = info.projectType;
+  }
 
   // if init-windows is missing (most existing projects), try to auto-calculate it
-  config['init-windows'] ??= {};
-  if (!config['init-windows'].template) {
+  if (!config['init-windows']?.template) {
     if (info.projectArch && info.projectLang && info.projectType) {
+      config['init-windows'] ??= {};
       config['init-windows'].template = `${
         info.projectArch === 'old' ? 'old/uwp-' : ''
       }${info.projectLang}-${info.projectType}`;

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindows.ts
@@ -165,6 +165,13 @@ export class InitWindows {
         `Unable to find template '${this.options.template}'.`,
       );
     }
+
+    if (this.options.template.startsWith('old')) {
+      spinner.warn(
+        `The legacy '${this.options.template}' template targets the React Native Old Architecture, which will eventually be deprecated. See https://microsoft.github.io/react-native-windows/docs/new-architecture for details on switching to the New Architecture.`,
+      );
+    }
+
     const templateConfig = this.templates.get(this.options.template)!;
 
     // Check if there's a passed-in project name and if it's valid

--- a/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
@@ -4,6 +4,8 @@
  * @format
  */
 
+/* eslint-disable complexity */
+
 import fs from '@react-native-windows/fs';
 import path from 'path';
 
@@ -38,7 +40,6 @@ import type {AutoLinkOptions} from '../autolinkWindows/autolinkWindowsOptions';
  * @param value The unsanitized value of the option.
  * @returns The sanitized value of the option.
  */
-// eslint-disable-next-line complexity
 function optionSanitizer(key: keyof RunWindowsOptions, value: any): any {
   // Do not add a default case here.
   // Strings risking PII should just return true if present, false otherwise.
@@ -203,6 +204,13 @@ async function runWindowsInternal(
 
   if (verbose) {
     newInfo('Verbose: ON');
+  }
+
+  // Warn about old architecture projects
+  if (config.project.windows?.rnwConfig?.projectArch === 'old') {
+    newWarn(
+      'This project is using the React Native (for Windows) Old Architecture, which will eventually be deprecated. See https://microsoft.github.io/react-native-windows/docs/new-architecture for details on switching to the New Architecture.',
+    );
   }
 
   // Get the solution file

--- a/packages/@react-native-windows/cli/src/e2etest/__snapshots__/dependencyConfig.test.ts.snap
+++ b/packages/@react-native-windows/cli/src/e2etest/__snapshots__/dependencyConfig.test.ts.snap
@@ -81,6 +81,9 @@ exports[`dependencyConfig - SimpleCSharpLib (Ignore react-native.config.js) 1`] 
     "init-windows": {
       "template": "old/uwp-cs-lib",
     },
+    "projectArch": "old",
+    "projectLang": "cs",
+    "projectType": "lib",
   },
   "solutionFile": "SimpleCSharpLib.sln",
   "sourceDir": "windows",
@@ -116,6 +119,9 @@ exports[`dependencyConfig - SimpleCSharpLib (Use react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cs-lib",
     },
+    "projectArch": "old",
+    "projectLang": "cs",
+    "projectType": "lib",
   },
   "solutionFile": "SimpleCSharpLib.sln",
   "sourceDir": "windows",
@@ -179,6 +185,9 @@ exports[`dependencyConfig - SimpleCppLib (Ignore react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-lib",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "lib",
   },
   "solutionFile": "SimpleCppLib.sln",
   "sourceDir": "windows",
@@ -214,6 +223,9 @@ exports[`dependencyConfig - SimpleCppLib (Use react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-lib",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "lib",
   },
   "solutionFile": "SimpleCppLib.sln",
   "sourceDir": "windows",

--- a/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
+++ b/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
@@ -10,9 +10,7 @@ exports[`projectConfig - MissingProjectFilesApp (Ignore react-native.config.js) 
   "project": {
     "projectFile": "Error: No app project file found, please specify in react-native.config.",
   },
-  "rnwConfig": {
-    "init-windows": {},
-  },
+  "rnwConfig": {},
   "solutionFile": "Error: No app solution file found, please specify in react-native.config.",
   "sourceDir": "windows",
 }
@@ -24,9 +22,7 @@ exports[`projectConfig - MissingProjectFilesApp (Use react-native.config.js) 1`]
   "project": {
     "projectFile": "Error: Project is required but not specified in react-native.config.",
   },
-  "rnwConfig": {
-    "init-windows": {},
-  },
+  "rnwConfig": {},
   "solutionFile": "Error: Solution file is required but not specified in react-native.config.",
   "sourceDir": "windows",
 }
@@ -50,6 +46,9 @@ exports[`projectConfig - SimpleCSharpApp (Ignore react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cs-app",
     },
+    "projectArch": "old",
+    "projectLang": "cs",
+    "projectType": "app",
   },
   "solutionFile": "SimpleCSharpApp.sln",
   "sourceDir": "windows",
@@ -74,6 +73,9 @@ exports[`projectConfig - SimpleCSharpApp (Use react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cs-app",
     },
+    "projectArch": "old",
+    "projectLang": "cs",
+    "projectType": "app",
   },
   "solutionFile": "SimpleCSharpApp.sln",
   "sourceDir": "windows",
@@ -98,6 +100,9 @@ exports[`projectConfig - SimpleCppApp (Ignore react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "SimpleCppApp.sln",
   "sourceDir": "windows",
@@ -122,6 +127,9 @@ exports[`projectConfig - SimpleCppApp (Use react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "SimpleCppApp.sln",
   "sourceDir": "windows",
@@ -146,6 +154,9 @@ exports[`projectConfig - WithExperimentalNuget (Ignore react-native.config.js) 1
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "WithExperimentalNuGet.sln",
   "sourceDir": "windows",
@@ -170,6 +181,9 @@ exports[`projectConfig - WithExperimentalNuget (Use react-native.config.js) 1`] 
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "WithExperimentalNuGet.sln",
   "sourceDir": "windows",
@@ -194,6 +208,9 @@ exports[`projectConfig - WithHermes (Ignore react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "WithHermes.sln",
   "sourceDir": "windows",
@@ -218,6 +235,9 @@ exports[`projectConfig - WithHermes (Use react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "WithHermes.sln",
   "sourceDir": "windows",
@@ -235,9 +255,7 @@ exports[`projectConfig - WithIndirectDependency (Ignore react-native.config.js) 
   "project": {
     "projectFile": "Error: Too many app project files found, please specify in react-native.config.",
   },
-  "rnwConfig": {
-    "init-windows": {},
-  },
+  "rnwConfig": {},
   "solutionFile": "WithIndirectDependency.sln",
   "sourceDir": "windows",
 }
@@ -261,6 +279,9 @@ exports[`projectConfig - WithIndirectDependency (Use react-native.config.js) 1`]
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "WithIndirectDependency.sln",
   "sourceDir": "windows",
@@ -286,6 +307,9 @@ exports[`projectConfig - WithWinUI3 (Ignore react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "WithWinUI3.sln",
   "sourceDir": "windows",
@@ -310,6 +334,9 @@ exports[`projectConfig - WithWinUI3 (Use react-native.config.js) 1`] = `
     "init-windows": {
       "template": "old/uwp-cpp-app",
     },
+    "projectArch": "old",
+    "projectLang": "cpp",
+    "projectType": "app",
   },
   "solutionFile": "WithWinUI3.sln",
   "sourceDir": "windows",


### PR DESCRIPTION
## Description

This PR adds warnings to the `run-windows` and `init-windows` CLI commands to warn about using old architecture projects.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
To warn users that their project is using the old architecture and that they should upgrade to the new architecture, as the old architecture will be deprecated.

Resolves #13936

### What
See above.

## Screenshots
N/A

## Testing
Verified commands show the warning

## Changelog
Should this change be included in the release notes: _yes_

Add warning to CLI commands about using the old architecture
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14757)