### PR TITLE
Force all in-repo projects to build locally with RestoreForceEvaluate

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -269,12 +269,17 @@
                   displayName: Restore NuGet packages
                   # Should be kept in sync with UniversalBuild - template: ../templates/msbuild-sln.yml
                   inputs:
-                    solution: vnext/Microsoft.ReactNative.sln
+                    ${{ if eq(matrix.UseFabric, true) }}:
+                      solution: vnext/Microsoft.ReactNative.NewArch.sln
+                    ${{ else }}:
+                      solution: vnext/Microsoft.ReactNative.sln
                     platform: ${{ matrix.BuildPlatform }}
                     configuration: ${{ matrix.BuildConfiguration }}
                     msbuildArchitecture: x64
                     msbuildArguments:
-                      /t:Restore
+                      /restore
+                      /p:RestoreLockedMode=true
+                      /p:RestoreForceEvaluate=true
 
                 - task: VSTest@2
                   displayName: Run Universal Unit Tests (Native)

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,8 @@ x86/
 bld/
 [Ll]og/
 *.binlog
+*.err
+*.wrn
 
 # Certificates
 *.pfx

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,9 @@
     <MSBuildProjectExtensionsPath Condition="'$(ProjectName)' != ''">$(RootIntDir)\ProjectExtensions\$(ProjectName)\</MSBuildProjectExtensionsPath>
     <MSBuildProjectExtensionsPath Condition="'$(ProjectName)' == ''">$(RootIntDir)\ProjectExtensions\$(MSBuildProjectName)\</MSBuildProjectExtensionsPath>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <RestoreLockedMode Condition="'$(RestoreLockedMode)' == ''">true</RestoreLockedMode>
+    <RestorePackagesWithLockFile Condition="'$(RestorePackagesWithLockFile)' == ''">true</RestorePackagesWithLockFile>
+    <RestoreForceEvaluate Condition="'$(RestoreForceEvaluate)' == ''">true</RestoreForceEvaluate>
   </PropertyGroup>
 
   <!-- User overrides -->

--- a/change/react-native-windows-1c48c39f-0038-40a8-a646-b7f2e2f9aa73.json
+++ b/change/react-native-windows-1c48c39f-0038-40a8-a646-b7f2e2f9aa73.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Force all in-repo projects to build locally with RestoreForceEvaluate",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -7,7 +7,7 @@
     "lint": "rnw-scripts lint",
     "lint:fix": "rnw-scripts lint:fix",
     "watch": "rnw-scripts watch",
-    "windows": "npx @react-native-community/cli run-windows",
+    "windows": "npx @react-native-community/cli run-windows --msbuildprops RestoreForceEvaluate=true",
     "e2etest": "jest",
     "e2etest:updateSnapshots": "jest -u",
     "e2etest:debug": "jest --config ./jest.debug.config.js"

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -74,10 +74,13 @@
 
     <IntermediateOutputPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(IntDir)</IntermediateOutputPath>
     <OutputPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(OutDir)</OutputPath>
+  </PropertyGroup>
 
-    <RestorePackagesWithLockFile Condition="'$(RestorePackagesWithLockFile)' == ''">true</RestorePackagesWithLockFile>
+  <PropertyGroup Condition="'$(BuildingInRnwRepo)' != 'true'">
+    <!-- Consumers of RNW outside of the repo don't need lock files unless they ask for it -->
+    <RestoreLockedMode Condition="'$(RestoreLockedMode)' == ''">false</RestoreLockedMode>
+    <RestorePackagesWithLockFile Condition="'$(RestorePackagesWithLockFile)' == ''">false</RestorePackagesWithLockFile>
     <RestoreForceEvaluate Condition="'$(RestoreForceEvaluate)' == ''">false</RestoreForceEvaluate>
-
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">


### PR DESCRIPTION
## Description

This PR fixes it so every project in the repo, unless explicitly specified, builds locally **with** the nuget lock files and forced evaluation, but ensures external projects build **without** nuget lock files and forced evaluation.

This is primarily to fix `e2e-test-app` failing to build locally.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Fix `e2e-test-app` not building locally with `run-windows`, and prevent our lock file requirements form leaking outside of the repo.

### What
The published `Directory.Build.props` file will disable using lock files by default, but the unpublished, in-repo `Directory.Build.props` file will enable using lock files by default.

Also, since msbuild from the command line ignores the RestoreForceEvaluate specified anyway, which causes `e2e-test-app` (and any C# app) to always fail when it's turned off (and lock mode is on), we add the prop to the default windows command.

## Screenshots
N/A

## Testing
Verified `e2e-test-app` builds locally with `run-windows` and within VS 17.14.

## Changelog
Should this change be included in the release notes: _yes_

Force all in-repo projects to build locally with RestoreForceEvaluate
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14758)