### PR TITLE
[0.78] Disable SBOM in Non-Production ADO Pipelines

### DIFF
--- a/.ado/templates/publish-build-artifacts.yml
+++ b/.ado/templates/publish-build-artifacts.yml
@@ -22,11 +22,6 @@ steps:
       contents: ${{parameters.contents}}
 
   - ${{ if not(parameters.oneESMode) }}:
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: "📒 Generate Manifest: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}"
-      inputs:
-        BuildDropPath: $(Build.StagingDirectory)/NuGet/${{ parameters.artifactName }}/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}
-
     - task: PublishPipelineArtifact@1
       displayName: "Publish Artifact: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}"
       # Do nothing if the artifact was already published. E.g. after rerunning a past successful job attempt

--- a/.ado/variables/shared.yml
+++ b/.ado/variables/shared.yml
@@ -5,9 +5,6 @@ variables:
   runCodesignValidationInjection: false
   skipComponentGovernanceDetection: true
   
-  # SBOM signing only works on microsoft ADO
-  Packaging.EnableSBOMSigning: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
-  
   # Enables `chalk` to show colored output to Azure Pipelines
   FORCE_COLOR: 3
 


### PR DESCRIPTION
This PR backports PR #14775 to RNW 0.78.

## Description

This removes the creation of SBOM manifests in our CI/PR pipelines, as it is no longer possible to create them unsigned.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Our non-production ADO pipelines (CI/PR) do not need to create SBOMS, but we were doing so anyway. But since they didn't have permission to sign the SBOMs, we disabled that and create unsigned ones instead. This no longer works, and so all CI/PR are failing, blocking all codeflow.

Closes #14774

### What
Removed SBOM tasks that ran in CI/PR.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14777)