### PR TITLE
Implement accessibilityLevel test in ScrollView Playground 

### DIFF
--- a/change/react-native-windows-08f8989a-9a55-42c5-9137-1b2474f46644.json
+++ b/change/react-native-windows-08f8989a-9a55-42c5-9137-1b2474f46644.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Implement accessibilityLevel in ScrollView",
-  "packageName": "react-native-windows",
-  "email": "54227869+anupriya13@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}


### PR DESCRIPTION
## Description

### Type of Change

- Test case


### Why
Implement accessibilityLevel in ScrollView 

### What
Implement accessibilityLevel in ScrollView which was missing in JS codebase.
https://github.com/microsoft/react-native-windows/issues/14550

### Screenshots

#### Before

importing scrollview from "react-native" shows error but importing from "react-native-windows" doesn't on js
![image](https://github.com/user-attachments/assets/88470687-79d0-4ee3-952b-7c72b7647e7a)

![image](https://github.com/user-attachments/assets/c0c400a0-fdaf-4914-b053-118cd354411b)

#### After
![image](https://github.com/user-attachments/assets/091f14c9-f759-49ab-b916-5116d45fe021)

![image](https://github.com/user-attachments/assets/f61e6609-396b-4812-9387-2a237fccc6ff)

![image](https://github.com/user-attachments/assets/89349ac7-114a-49a7-92ba-82879fc25a93)

## Changelog
Should this change be included in the release notes: NO

