### PR TITLE
[Fabric] Implement snapToStart, snapToEnd, snapToOffsets property for ScrollView

### DIFF
--- a/change/react-native-windows-aa754bc8-86a7-4d0f-975d-ea69252b5b32.json
+++ b/change/react-native-windows-aa754bc8-86a7-4d0f-975d-ea69252b5b32.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add e2e test cases for snapToStart property in ScrollView fabric implementation",
+  "packageName": "react-native-windows",
+  "email": "198982749+Copilot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -120,6 +120,9 @@ namespace Microsoft.ReactNative.Composition.Experimental
     void SetMaximumZoomScale(Single maximumZoomScale);
     void SetMinimumZoomScale(Single minimumZoomScale);
     Boolean Horizontal;
+    void SnapToStart(Boolean snapToStart);
+    void SnapToEnd(Boolean snapToEnd);
+    void SnapToOffsets(Windows.Foundation.Collections.IVectorView<Single> offsets);
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -805,6 +805,23 @@ void ScrollViewComponentView::updateProps(
   if (oldViewProps.zoomScale != newViewProps.zoomScale) {
     m_scrollVisual.Scale({newViewProps.zoomScale, newViewProps.zoomScale, newViewProps.zoomScale});
   }
+
+  if (!oldProps || oldViewProps.snapToStart != newViewProps.snapToStart) {
+    m_scrollVisual.SnapToStart(newViewProps.snapToStart);
+  }
+
+  if (!oldProps || oldViewProps.snapToOffsets != newViewProps.snapToOffsets) {
+    // Convert from std::vector<facebook::react::Float> to winrt::IVectorView<float>
+    const auto snapToOffsets = winrt::single_threaded_vector<float>();
+    for (const auto &offset : newViewProps.snapToOffsets) {
+      snapToOffsets.Append(static_cast<float>(offset));
+    }
+    m_scrollVisual.SnapToOffsets(snapToOffsets.GetView());
+  }
+
+  if (!oldProps || oldViewProps.snapToEnd != newViewProps.snapToEnd) {
+    m_scrollVisual.SnapToEnd(newViewProps.snapToEnd);
+  }
 }
 
 void ScrollViewComponentView::updateState(


### PR DESCRIPTION
## Description

### Type of Change

- New feature (non-breaking change which adds functionality)

### Why
[Fabric] Implement snapToStart, snapToEnd, snapToOffsets property for ScrollView

Resolves [Add Relevant Issue Here]

### What
[Fabric] Implement snapToStart, snapToEnd, snapToOffsets property for ScrollView

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
to-do

## Changelog
Should this change be included in the release notes: YES 
Implemented snapToStart, snapToEnd, snapToOffsets property for ScrollView in Fabric