### PR TITLE
Remove .. usage in relative include

### DIFF
--- a/change/react-native-windows-cc8b0e86-24d1-43aa-aa15-6acabf669ade.json
+++ b/change/react-native-windows-cc8b0e86-24d1-43aa-aa15-6acabf669ade.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove .. usage in relative include",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.h
@@ -5,7 +5,7 @@
 #ifndef MICROSOFT_REACTNATIVE_JSI_JSIAPI
 #define MICROSOFT_REACTNATIVE_JSI_JSIAPI
 
-#include "../ReactContext.h"
+#include <ReactContext.h>
 #include "JsiAbiApi.h"
 #include "ReactPromise.h"
 


### PR DESCRIPTION
## Description
In some projects usage of `..` within relative include paths is disallowed to prevent files from being included from outside the project directory.  

Removing a use of `..` in a relative include path to allow the file to be usable in such projects.
