### PR TITLE
Fix/template pch include dirs

### DIFF
--- a/change/react-native-windows-41760bd2-4285-44fd-b37d-01df6f5082e2.json
+++ b/change/react-native-windows-41760bd2-4285-44fd-b37d-01df6f5082e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(vnext-template): add additional include dirs for submodules",
+  "packageName": "react-native-windows",
+  "email": "fcalise@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-app/windows/MyApp/MyApp.vcxproj
+++ b/vnext/templates/cpp-app/windows/MyApp/MyApp.vcxproj
@@ -75,6 +75,10 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>
+        $(MSBuildThisFileDirectory);
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shell32.lib;user32.lib;windowsapp.lib;%(AdditionalDependenices)</AdditionalDependencies>


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
The current default New Arch template shows an error if you create a Turbo Module in a subdirectory, calling out that it is unable to find `pch.h`.

The following compile (and runs) but show an error in the Errors List
- `#include "pch.h"`
- `#include <pch.h>`

The following removes the error about not being able to open the source file, does not compile and warns you that you didn't import the precompiled header
- `#include ../../MyProject/pch.h`

### What
Adds additional include directories for the precompiled header file.

## Screenshots
| | |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/4cbf8e5e-1245-4c45-9e25-766fd460905c) | ![image](https://github.com/user-attachments/assets/647dc814-1ddb-4086-b7e8-4166ce4c892e) |


## Testing
Manual testing, the error went away after adding this to my vcxproj. Additional Discord discussion [here](https://discord.com/channels/514829729862516747/1384618317754663114/1384917240595484803).

## Changelog
Should this change be included in the release notes: no