### PR TITLE
[Fabric] Implement autoFocus property for TextInput for fabric 

### DIFF
--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -281,6 +281,20 @@ export default class Bootstrap extends React.Component<{}, any> {
               placeholder="Focus and then click outside"
               onEndEditing={this.handleEndEditing}
             />
+            <TextInput
+              style={[styles.input, {borderColor: 'green', borderWidth: 2}]}
+              placeholder={
+                'autoFocus: true - This input will be focused automatically'
+              }
+              autoFocus={true}
+            />
+            <TextInput
+              style={[styles.input, {borderColor: 'red', borderWidth: 2}]}
+              placeholder={
+                'autoFocus: false - This input will NOT be focused automatically'
+              }
+              autoFocus={false}
+            />
 
             <KeyboardAvoidingView
               style={styles.container}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1371,6 +1371,13 @@ void WindowsTextInputComponentView::onMounted() noexcept {
     m_propBits |= TXTBIT_CHARFORMATCHANGE;
   }
   InternalFinalize();
+
+  // Handle autoFocus property - focus the component when mounted if autoFocus is true
+  if (windowsTextInputProps().autoFocus) {
+    if (auto root = rootComponentView()) {
+      root->TrySetFocusedComponent(*get_strong(), winrt::Microsoft::ReactNative::FocusNavigationDirection::None);
+    }
+  }
 }
 
 std::optional<std::string> WindowsTextInputComponentView::getAccessiblityValue() noexcept {


### PR DESCRIPTION
## Description
Implement autoFocus property for TextInput for fabric 
### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Implement the autoFocus property for the fabric implementation of TextInput.
This property was available in RNW Paper via TextInputViewManager.
See https://reactnative.dev/docs/textinput#autofocus for details.

Resolves [[Add Relevant Issue Here](https://github.com/microsoft/react-native-windows/issues/13121)]

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

## Changelog
yes o

Add a brief summary of the change to use in the release notes for the next release.
Implement autoFocus property for TextInput for fabric 