### PR TITLE
fix(new-arch): metro warning for Flyout/Popup

### DIFF
--- a/change/react-native-windows-435e1359-4961-4938-9b95-12d1e464146f.json
+++ b/change/react-native-windows-435e1359-4961-4938-9b95-12d1e464146f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix(new-arch): add deprecation warning for Flyout/Popup",
+  "packageName": "react-native-windows",
+  "email": "fcalise@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src-win/Libraries/Components/Flyout/Flyout.js
+++ b/vnext/src-win/Libraries/Components/Flyout/Flyout.js
@@ -66,6 +66,8 @@ type State = $ReadOnly<{
   targetRef?: React.ReactNode,
 }>;
 
+const isFabric = global.nativeFabricUIManager;
+
 /**
  * Renders a flyout component.
  *
@@ -93,6 +95,12 @@ export class Flyout extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
+
+    if (__DEV__ && isFabric) {
+      console.warn(
+        '`Flyout` is deprecated and not supported in the New Architecture. Use the new `Modal` component instead.',
+      );
+    }
   }
 
   render(): React.Node {

--- a/vnext/src-win/Libraries/Components/Flyout/Flyout.js
+++ b/vnext/src-win/Libraries/Components/Flyout/Flyout.js
@@ -10,6 +10,8 @@ import FlyoutNativeComponent from './FlyoutNativeComponent';
 import * as React from 'react';
 import {findNodeHandle, StyleSheet} from 'react-native';
 
+const warnOnce = require('../../Utilities/warnOnce').default;
+
 type Placement =
   | 'top'
   | 'bottom'
@@ -97,7 +99,8 @@ export class Flyout extends React.Component<Props, State> {
     super(props);
 
     if (__DEV__ && isFabric) {
-      console.warn(
+      warnOnce(
+        'flyout-new-arch-deprecated',
         '`Flyout` is deprecated and not supported in the New Architecture. Use the new `Modal` component instead.',
       );
     }

--- a/vnext/src-win/Libraries/Components/Popup/Popup.js
+++ b/vnext/src-win/Libraries/Components/Popup/Popup.js
@@ -49,6 +49,8 @@ type State = $ReadOnly<{|
   targetRef?: React.ReactNode,
 |}>;
 
+const isFabric = global.nativeFabricUIManager;
+
 /**
  * Renders a popup component.
  *
@@ -75,6 +77,12 @@ export class Popup extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {target: undefined, targetRef: null};
+
+    if (__DEV__ && isFabric) {
+      console.warn(
+        '`Popup` is deprecated and not supported in the New Architecture. Use the new `Modal` component instead.',
+      );
+    }
   }
 
   render(): React.Node {

--- a/vnext/src-win/Libraries/Components/Popup/Popup.js
+++ b/vnext/src-win/Libraries/Components/Popup/Popup.js
@@ -11,6 +11,8 @@ import type {ViewProps} from '../View/ViewPropTypes';
 import {findNodeHandle} from '../../ReactNative/RendererProxy';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 
+const warnOnce = require('../../Utilities/warnOnce').default;
+
 const styles = StyleSheet.create({
   rctPopup: {
     position: 'absolute',
@@ -79,7 +81,8 @@ export class Popup extends React.Component<Props, State> {
     this.state = {target: undefined, targetRef: null};
 
     if (__DEV__ && isFabric) {
-      console.warn(
+      warnOnce(
+        'popup-new-arch-deprecated',
         '`Popup` is deprecated and not supported in the New Architecture. Use the new `Modal` component instead.',
       );
     }


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
While building an app in the New Architecture template, if you use either `<Flyout />` or `<Popup />` you'll be met with the unsupported Fabric view red box. This error is displayed from RN core.

Additionally, we can display a Metro warning to make the error more clear to the user - that they should be migrating to `<Modal />`

Resolves #14671 

### What
1. Detects if we're running Fabric via `global.nativeFabricUIManager`
2. Outputs a warning via `console.warn` in the contructors of `Flyout` and `Popup`

## Screenshots
| Collapsed Warning | Expanded Warning |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/f0dd37d0-3bc3-45f7-ae6b-e96b9a8cabf1) | ![image](https://github.com/user-attachments/assets/da6c5197-1e25-4ae1-9c5a-3d77b351ca9c) |


## Testing
Manually tested by editing `node_modules\react-native-windows\Libraries\Components\Flyout\Flyout.js`

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14817)