### PR TITLE
[Fabric] Implement snapToAlignment property for ScrollView 

### DIFF
--- a/change/react-native-windows-ae44eda2-ce08-4405-916b-db6f08ee6786.json
+++ b/change/react-native-windows-ae44eda2-ce08-4405-916b-db6f08ee6786.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement snapToAlignment support for Fabric ScrollView - interface and prop handling",
+  "packageName": "react-native-windows",
+  "email": "198982749+Copilot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -31,6 +31,13 @@ namespace Microsoft.ReactNative.Composition.Experimental
     SwitchThumb,
   };
 
+  enum SnapAlignment
+  {
+    Start,
+    Center,
+    End,
+  };
+
   [webhosthidden]
   [uuid("172def51-9e1a-4e3c-841a-e5a470065acc")] // uuid needed for empty interfaces
   [version(0)]
@@ -120,7 +127,7 @@ namespace Microsoft.ReactNative.Composition.Experimental
     void SetMaximumZoomScale(Single maximumZoomScale);
     void SetMinimumZoomScale(Single minimumZoomScale);
     Boolean Horizontal;
-    void SetSnapPoints(Boolean snapToStart, Boolean snapToEnd, Windows.Foundation.Collections.IVectorView<Single> offsets);
+    void SetSnapPoints(Boolean snapToStart, Boolean snapToEnd, Windows.Foundation.Collections.IVectorView<Single> offsets, SnapAlignment snapToAlignment);
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1107,12 +1107,12 @@ struct CompScrollerVisual : winrt::implements<
 
     // Adjust snap positions based on alignment
     const float viewportSize = m_horizontal ? visualSize.x : visualSize.y;
-    if (m_snapToAlignment == winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Center) {
+    if (m_snapToAlignment == SnapAlignment::Center) {
       // For center alignment, offset snap positions by half the viewport size
       for (auto &position : snapPositions) {
         position = std::max(0.0f, position - viewportSize / 2.0f);
       }
-    } else if (m_snapToAlignment == winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::End) {
+    } else if (m_snapToAlignment == SnapAlignment::End) {
       // For end alignment, offset snap positions by the full viewport size
       for (auto &position : snapPositions) {
         position = std::max(0.0f, position - viewportSize);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -27,6 +27,8 @@
 
 namespace Microsoft::ReactNative::Composition::Experimental {
 
+using namespace winrt::Microsoft::ReactNative::Composition::Experimental;
+
 template <typename TSpriteVisual>
 struct CompositionTypeTraits {};
 
@@ -872,7 +874,7 @@ struct CompScrollerVisual : winrt::implements<
       bool snapToStart,
       bool snapToEnd,
       winrt::Windows::Foundation::Collections::IVectorView<float> const &offsets,
-      winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment snapToAlignment) noexcept {
+      SnapAlignment snapToAlignment) noexcept {
     m_snapToStart = snapToStart;
     m_snapToEnd = snapToEnd;
     m_snapToAlignment = snapToAlignment;
@@ -1245,8 +1247,7 @@ struct CompScrollerVisual : winrt::implements<
   bool m_snapToStart{true};
   bool m_snapToEnd{true};
   std::vector<float> m_snapToOffsets;
-  winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment m_snapToAlignment{
-      winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Start};
+  SnapAlignment m_snapToAlignment{SnapAlignment::Start};
   bool m_inertia{false};
   bool m_custom{false};
   winrt::Windows::Foundation::Numerics::float3 m_targetPosition;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -815,9 +815,8 @@ void ScrollViewComponentView::updateProps(
     }
 
     // When snapToInterval is set, snapToAlignment will define the relationship of the snapping to the scroll view.
-    auto snapAlignment = newViewProps.snapToInterval > 0.0f
-        ? convertSnapToAlignment(newViewProps.snapToAlignment)
-        : winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Center;
+    auto snapAlignment = newViewProps.snapToInterval > 0.0f ? convertSnapToAlignment(newViewProps.snapToAlignment)
+                                                            : SnapAlignment::Center;
 
     m_scrollVisual.SetSnapPoints(
         newViewProps.snapToStart, newViewProps.snapToEnd, snapToOffsets.GetView(), snapAlignment);
@@ -1444,16 +1443,16 @@ void ScrollViewComponentView::updateDecelerationRate(float value) noexcept {
   m_scrollVisual.SetDecelerationRate({value, value, value});
 }
 
-winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment ScrollViewComponentView::convertSnapToAlignment(
+SnapAlignment ScrollViewComponentView::convertSnapToAlignment(
     facebook::react::ScrollViewSnapToAlignment alignment) noexcept {
   switch (alignment) {
     case facebook::react::ScrollViewSnapToAlignment::Center:
-      return winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Center;
+      return SnapAlignment::Center;
     case facebook::react::ScrollViewSnapToAlignment::End:
-      return winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::End;
+      return SnapAlignment::End;
     case facebook::react::ScrollViewSnapToAlignment::Start:
     default:
-      return winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Start;
+      return SnapAlignment::Start;
   }
 }
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -814,7 +814,10 @@ void ScrollViewComponentView::updateProps(
       snapToOffsets.Append(static_cast<float>(offset));
     }
 
-    auto snapAlignment = convertSnapToAlignment(newViewProps.snapToAlignment);
+    // When snapToInterval is set, snapToAlignment will define the relationship of the snapping to the scroll view.
+    auto snapAlignment = newViewProps.snapToInterval > 0.0f
+        ? convertSnapToAlignment(newViewProps.snapToAlignment)
+        : winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Center;
 
     m_scrollVisual.SetSnapPoints(
         newViewProps.snapToStart, newViewProps.snapToEnd, snapToOffsets.GetView(), snapAlignment);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -807,12 +807,17 @@ void ScrollViewComponentView::updateProps(
   }
 
   if (oldViewProps.snapToStart != newViewProps.snapToStart || oldViewProps.snapToEnd != newViewProps.snapToEnd ||
-      oldViewProps.snapToOffsets != newViewProps.snapToOffsets) {
+      oldViewProps.snapToOffsets != newViewProps.snapToOffsets ||
+      oldViewProps.snapToAlignment != newViewProps.snapToAlignment) {
     const auto snapToOffsets = winrt::single_threaded_vector<float>();
     for (const auto &offset : newViewProps.snapToOffsets) {
       snapToOffsets.Append(static_cast<float>(offset));
     }
-    m_scrollVisual.SetSnapPoints(newViewProps.snapToStart, newViewProps.snapToEnd, snapToOffsets.GetView());
+
+    auto snapAlignment = convertSnapToAlignment(newViewProps.snapToAlignment);
+
+    m_scrollVisual.SetSnapPoints(
+        newViewProps.snapToStart, newViewProps.snapToEnd, snapToOffsets.GetView(), snapAlignment);
   }
 }
 
@@ -1434,5 +1439,18 @@ void ScrollViewComponentView::updateShowsVerticalScrollIndicator(bool value) noe
 
 void ScrollViewComponentView::updateDecelerationRate(float value) noexcept {
   m_scrollVisual.SetDecelerationRate({value, value, value});
+}
+
+winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment ScrollViewComponentView::convertSnapToAlignment(
+    facebook::react::ScrollViewSnapToAlignment alignment) noexcept {
+  switch (alignment) {
+    case facebook::react::ScrollViewSnapToAlignment::Center:
+      return winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Center;
+    case facebook::react::ScrollViewSnapToAlignment::End:
+      return winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::End;
+    case facebook::react::ScrollViewSnapToAlignment::Start:
+    default:
+      return winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment::Start;
+  }
 }
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -816,19 +816,14 @@ void ScrollViewComponentView::updateProps(
     m_scrollVisual.Scale({newViewProps.zoomScale, newViewProps.zoomScale, newViewProps.zoomScale});
   }
 
-  if (oldViewProps.snapToStart != newViewProps.snapToStart ||
-      oldViewProps.snapToEnd != newViewProps.snapToEnd ||
+  if (oldViewProps.snapToStart != newViewProps.snapToStart || oldViewProps.snapToEnd != newViewProps.snapToEnd ||
       oldViewProps.snapToOffsets != newViewProps.snapToOffsets) {
-    if (newViewProps.snapToInterval > 0 &&
-        oldViewProps.snapToInterval != newViewProps.snapToInterval) {
+    if (oldViewProps.snapToInterval != newViewProps.snapToInterval) {
       updateSnapPoints();
     } else {
       const auto snapToOffsets = CreateSnapToOffsets(newViewProps.snapToOffsets);
       m_scrollVisual.SetSnapPoints(
-          newViewProps.snapToStart,
-          newViewProps.snapToEnd,
-          snapToOffsets.GetView(),
-          SnapAlignment::Center);
+          newViewProps.snapToStart, newViewProps.snapToEnd, snapToOffsets.GetView(), SnapAlignment::Center);
     }
   }
 }
@@ -1468,7 +1463,7 @@ SnapAlignment ScrollViewComponentView::convertSnapToAlignment(
       return SnapAlignment::Start;
   }
 }
-  
+
 void ScrollViewComponentView::updateSnapPoints() noexcept {
   const auto &viewProps = *std::static_pointer_cast<const facebook::react::ScrollViewProps>(this->viewProps());
   const auto snapToOffsets = CreateSnapToOffsets(viewProps.snapToOffsets);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -1468,8 +1468,8 @@ void ScrollViewComponentView::updateSnapPoints() noexcept {
   const auto &viewProps = *std::static_pointer_cast<const facebook::react::ScrollViewProps>(this->viewProps());
   const auto snapToOffsets = CreateSnapToOffsets(viewProps.snapToOffsets);
   // Typically used in combination with snapToAlignment and decelerationRate="fast"
-  const auto snapAlignment = SnapAlignment::Center;
-  const auto decelerationRate = viewProps.decelerationRate;
+  auto snapAlignment = SnapAlignment::Center;
+  auto decelerationRate = viewProps.decelerationRate;
 
   // snapToOffsets has priority over snapToInterval (matches React Native behavior)
   if (viewProps.snapToInterval > 0 && decelerationRate >= 0.99) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -134,6 +134,8 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       winrt::Microsoft::ReactNative::Composition::Experimental::IScrollPositionChangedArgs const &args) noexcept;
   void updateShowsHorizontalScrollIndicator(bool value) noexcept;
   void updateShowsVerticalScrollIndicator(bool value) noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment convertSnapToAlignment(
+      facebook::react::ScrollViewSnapToAlignment alignment) noexcept;
 
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual m_scrollVisual{nullptr};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -18,6 +18,8 @@
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
+using namespace Microsoft::ReactNative::Composition::Experimental;
+
 struct ScrollBarComponent;
 
 struct ScrollViewComponentView : ScrollViewComponentViewT<ScrollViewComponentView, ViewComponentView> {
@@ -134,8 +136,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       winrt::Microsoft::ReactNative::Composition::Experimental::IScrollPositionChangedArgs const &args) noexcept;
   void updateShowsHorizontalScrollIndicator(bool value) noexcept;
   void updateShowsVerticalScrollIndicator(bool value) noexcept;
-  winrt::Microsoft::ReactNative::Composition::Experimental::SnapAlignment convertSnapToAlignment(
-      facebook::react::ScrollViewSnapToAlignment alignment) noexcept;
+  SnapAlignment convertSnapToAlignment(facebook::react::ScrollViewSnapToAlignment alignment) noexcept;
 
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual m_scrollVisual{nullptr};


### PR DESCRIPTION
## Description

### Type of Change

- New feature (non-breaking change which adds functionality)

### Why
Implement snapToAlignment property for ScrollView in Fabric

Resolves #13148 

### What
Implement snapToAlignment property for ScrollView in Fabric
<img width="640" alt="image" src="https://github.com/user-attachments/assets/2b6d0d17-e682-4916-87cc-f3706f29b591" />
https://reactnative.dev/docs/scrollview#snaptoalignment

Refer IOS implementation https://github.com/facebook/react-native/blob/618279508159191f2b11c0b20446f91e82a27abf/packages/react-native/React/Views/ScrollView/RCTScrollView.m#L833

## Background
The `snapToAlignment` property was available in RNW Paper via ScrollViewManager but missing from the Fabric implementation, causing a parity gap between the two architectures.

We came up with this implementation to ensure that snap points align correctly within the viewport depending on the desired alignment. Since snap positions are relative to the start edge by default, we subtract half the viewport size for center alignment or the full viewport size for end alignment. This way, when scrolling settles on a snap point, it appears at the right position in the visible area.

More context:

What is a snap point?
When the user scrolls or flicks the content, instead of stopping anywhere, the scroller will settle on the closest snap point, making the scrolling feel natural and intentional.

This is what m_snapToAlignment controls:

Start: snap position aligns to start of viewport
Center: snap position aligns to center of viewport
End: snap position aligns to end of viewport

## Screenshots

https://github.com/user-attachments/assets/2ceb9681-20c1-4fb3-9231-ead486a95bcf

## Testing

Tested in playground and e2etestappfabric already added

## Changes

### Core Implementation
- **Extended SetSnapPoints interface** in `CompositionSwitcher.idl` to accept `snapToAlignment` parameter
- **Added snapToAlignment handling** in `ScrollViewComponentView.cpp` with proper enum conversion from React Native to Windows types


## Changelog
Should this change be included in the release notes: YES

Add a brief summary of the change to use in the release notes for the next release.
Implement snapToAlignment property for ScrollView in Fabric
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14841)