### PR TITLE
Add accessibilityValue support to Button component (#14903)

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/Button/ButtonExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Button/ButtonExample.windows.js
@@ -222,7 +222,11 @@ exports.examples = [
                 accessibilityPosInSet={1}
                 accessibilitySetSize={1}
                 accessibilityLiveRegion="assertive"
-                accessibilityValue={{Text: 'Submit Application'}}
+                accessibilityValue={{text: 'Submit Application'}}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={75}
+                aria-valuetext="75 percent complete"
               />
             );
           }}

--- a/vnext/src-win/Libraries/Components/Button.windows.js
+++ b/vnext/src-win/Libraries/Components/Button.windows.js
@@ -16,6 +16,7 @@ import type {
   AccessibilityActionEvent,
   AccessibilityActionInfo,
   AccessibilityState,
+  AccessibilityValue,
 } from './View/ViewAccessibility';
 
 import StyleSheet, {type ColorValue} from '../StyleSheet/StyleSheet';
@@ -154,6 +155,7 @@ export type ButtonProps = $ReadOnly<{
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
   onAccessibilityTap?: ?() => void, // Windows
   accessibilityState?: ?AccessibilityState,
+  accessibilityValue?: ?AccessibilityValue,
 
   /**
    * alias for accessibilityState
@@ -168,6 +170,15 @@ export type ButtonProps = $ReadOnly<{
   'aria-readonly'?: ?boolean, // Windows
   'aria-multiselectable'?: ?boolean, // Windows
   'aria-required'?: ?boolean, // Windows
+
+  /**
+   * alias for accessibilityValue
+   * It represents textual description of a component's value, or for range-based components, such as sliders and progress bars.
+   */
+  'aria-valuemax'?: ?AccessibilityValue['max'],
+  'aria-valuemin'?: ?AccessibilityValue['min'],
+  'aria-valuenow'?: ?AccessibilityValue['now'],
+  'aria-valuetext'?: ?AccessibilityValue['text'],
 
   /**
    * [Android] Controlling if a view fires accessibility events and if it is reported to accessibility services.
@@ -308,6 +319,7 @@ const Button: component(
   const {
     accessibilityLabel,
     accessibilityState,
+    accessibilityValue,
     'aria-busy': ariaBusy,
     'aria-checked': ariaChecked,
     'aria-disabled': ariaDisabled,
@@ -317,6 +329,10 @@ const Button: component(
     'aria-readonly': ariaReadOnly, // Windows
     'aria-multiselectable': ariaMultiselectable, // Windows
     'aria-required': ariaRequired, // Windows
+    'aria-valuemax': ariaValueMax,
+    'aria-valuemin': ariaValueMin,
+    'aria-valuenow': ariaValueNow,
+    'aria-valuetext': ariaValueText,
     importantForAccessibility,
     color,
     onPress,
@@ -366,6 +382,22 @@ const Button: component(
       ? {..._accessibilityState, disabled}
       : _accessibilityState;
 
+  let _accessibilityValue;
+  if (
+    accessibilityValue != null ||
+    ariaValueMax != null ||
+    ariaValueMin != null ||
+    ariaValueNow != null ||
+    ariaValueText != null
+  ) {
+    _accessibilityValue = {
+      max: ariaValueMax ?? accessibilityValue?.max,
+      min: ariaValueMin ?? accessibilityValue?.min,
+      now: ariaValueNow ?? accessibilityValue?.now,
+      text: ariaValueText ?? accessibilityValue?.text,
+    };
+  }
+
   if (disabled) {
     buttonStyles.push(styles.buttonDisabled);
     textStyles.push(styles.textDisabled);
@@ -393,6 +425,7 @@ const Button: component(
         accessibilityLanguage={accessibilityLanguage}
         accessibilityRole="button"
         accessibilityState={_accessibilityState}
+        accessibilityValue={_accessibilityValue}
         onAccessibilityTap={onAccessibilityTap} // Windows
         importantForAccessibility={_importantForAccessibility}
         hasTVPreferredFocus={hasTVPreferredFocus}
@@ -495,6 +528,7 @@ const Button: component(
         accessibilityLanguage={accessibilityLanguage}
         accessibilityRole="button"
         accessibilityState={_accessibilityState}
+        accessibilityValue={_accessibilityValue}
         importantForAccessibility={_importantForAccessibility}
         hasTVPreferredFocus={hasTVPreferredFocus}
         nextFocusDown={nextFocusDown}


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
This PR implements support for accessibilityValue prop in the React Native Windows Button component, enabling proper propagation of accessibility values from JavaScript to the native C++ layer.

Resolves #14902 

### What
The Button component in Button.windows.js was missing support for the accessibilityValue prop and related aria-value* props, which prevented accessibility values from being passed through to the underlying TouchableHighlight component. This was identified in the existing ButtonExample where accessibilityValue={{Text: 'Submit Application'}} was being used but not actually supported by the component.

## Screenshots
Before

After

## Testing
Tested in Playground

## Changelog
Should this change be included in the release notes: NO

Add a brief summary of the change to use in the release notes for the next release.