### PR TITLE
0.79-stable upgrade tar-fs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,12 @@
     "**/webdriverio/**/puppeteer-core/ws": "^8.17.1",
     "**/detox/ws": "^5.2.4",
     "xml2js": "^0.5.0",
-    "z-schema": "^5.0.2"
+    "z-schema": "^5.0.2",
+    "tar-fs": "^3.0.9"
   },
   "resolutions.justification": {
-    "z-schema": "CVE-2021-3765 in validator. z-schema is used by rush which is a dependency of lage so should not be executed in this repo"
+    "z-schema": "CVE-2021-3765 in validator. z-schema is used by rush which is a dependency of lage so should not be executed in this repo",
+    "tar-fs": "CVE-2025-48387 - Security vulnerability fix by upgrading tar-fs from 3.0.8 to 3.0.9"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,11 +4465,6 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chownr@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
-  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
-
 chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
@@ -9104,11 +9099,6 @@ mitt@3.0.1:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
-mkdirp-classic@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
-
 "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
@@ -11297,20 +11287,10 @@ table-layout@^1.0.2:
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
 
-tar-fs@^2.0.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.3.tgz#fb3b8843a26b6f13a08e606f7922875eb1fbbf92"
-  integrity sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==
-  dependencies:
-    chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
-    pump "^3.0.0"
-    tar-stream "^2.1.4"
-
-tar-fs@^3.0.6:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.9.tgz#d570793c6370d7078926c41fa422891566a0b617"
-  integrity sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==
+tar-fs@^2.0.0, tar-fs@^3.0.6, tar-fs@^3.0.9:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.0.tgz#4675e2254d81410e609d91581a762608de999d25"
+  integrity sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
## Description

This PR addresses a security vulnerability (https://github.com/advisories/GHSA-8cj5-5rvv-wf4v) by upgrading the tar-fs package from version 3.0.8 to 3.0.9 across the entire dependency tree.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
The repository had multiple versions of tar-fs installed:

tar-fs@^3.0.6 (resolving to 3.0.9) - used by newer dependencies like @puppeteer/browsers
tar-fs@^2.0.0 (resolving to 2.1.3) - used by older dependencies like puppeteer-core@5.5.0
The older version (2.1.3) contained the security vulnerability that needed to be addressed.

## Screenshots
<img width="1165" height="1304" alt="Screenshot 2025-07-14 135514" src="https://github.com/user-attachments/assets/de62f459-6236-4f65-b877-bdf5cbcc1c9e" />

Added a yarn resolution to force all instances of tar-fs to use version ^3.0.9:
```
{
  "resolutions": {
    "tar-fs": "^3.0.9"
  },
  "resolutions.justification": {
    "tar-fs": "CVE-2025-48387 - Security vulnerability fix by upgrading tar-fs from 3.0.8 to 3.0.9"
  }
}
```

## Testing
✅ yarn install completes successfully
✅ yarn build passes without errors
✅ Verified all tar-fs instances use version 3.1.0
✅ Confirmed removal of the vulnerable version
After this change yarn why tar-fs 
yarn why v1.22.22
[1/4] Why do we have the module "tar-fs"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> **Found "tar-fs@3.1.0"**

## Changelog
Maybe included in Release Log

Security vulnerability https://github.com/advisories/GHSA-8cj5-5rvv-wf4v is now resolved