### PR TITLE
Upgrading tar-fs version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11266,9 +11266,9 @@ tar-fs@^2.0.0:
     tar-stream "^2.1.4"
 
 tar-fs@^3.0.6:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.9.tgz#d570793c6370d7078926c41fa422891566a0b617"
-  integrity sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.0.tgz#4675e2254d81410e609d91581a762608de999d25"
+  integrity sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
## Description

This PR addresses a security vulnerability as a part of component governance (https://github.com/advisories/GHSA-8cj5-5rvv-wf4v) by upgrading the tar-fs package from version 3.0.8 to 3.0.9 across the entire dependency tree.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [https://github.com/advisories/GHSA-8cj5-5rvv-wf4v]

### What
As a part of component governance, The repository had multiple versions of tar-fs installed:

tar-fs@^3.0.6 (resolving to 3.0.9) - used by newer dependencies like @puppeteer/browsers
tar-fs@^2.0.0 (resolving to 2.1.3) - used by older dependencies like puppeteer-core@5.5.0
The older version (2.1.3) contained the security vulnerability that needed to be addressed.

## Screenshots
<img width="1165" height="1304" alt="Screenshot 2025-07-14 135514" src="https://github.com/user-attachments/assets/ce07fd42-14b1-4df9-884c-69461aac625c" />

## Testing
✅ yarn install completes successfully
✅ yarn build passes without errors
✅ Verified all tar-fs instances use version 3.1.0
✅ Confirmed removal of the vulnerable version
After this change yarn why tar-fs
yarn why v1.22.22
[1/4] Why do we have the module "tar-fs"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "tar-fs@3.1.0"


## Changelog
Should this change be included in the release notes: yes

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14940)