### PR TITLE
[0.79] Bump tar-fs from 3.0.8 to 3.1.0 for component governance

### DIFF
--- a/change/react-native-windows-10692328-3799-41d8-8663-4965fdd044fb.json
+++ b/change/react-native-windows-10692328-3799-41d8-8663-4965fdd044fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "updating tar-fs to 3.0.9",
+  "packageName": "react-native-windows",
+  "email": "protikbiswas100@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11123,9 +11123,9 @@ table-layout@^1.0.2:
     wordwrapjs "^4.0.0"
 
 tar-fs@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.2.tgz#425f154f3404cb16cb8ff6e671d45ab2ed9596c5"
-  integrity sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.3.tgz#fb3b8843a26b6f13a08e606f7922875eb1fbbf92"
+  integrity sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -11133,9 +11133,9 @@ tar-fs@^2.0.0:
     tar-stream "^2.1.4"
 
 tar-fs@^3.0.6:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.8.tgz#8f62012537d5ff89252d01e48690dc4ebed33ab7"
-  integrity sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.0.tgz#4675e2254d81410e609d91581a762608de999d25"
+  integrity sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
Updated the following packages:
* 'tar-fs [CVE-2024-12905](https://github.com/advisories/GHSA-8cj5-5rvv-wf4v)

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To resolve Component Governance alerts.

### What
(https://github.com/advisories/GHSA-8cj5-5rvv-wf4v)

## Screenshots
<img width="1258" height="361" alt="Screenshot 2025-07-22 134015" src="https://github.com/user-attachments/assets/68419ecd-b409-44b7-95cd-b50d47b8136d" />


## Testing
Local build

## Changelog

Should this change be included in the release notes: yes
Add a brief summary of the change to use in the release notes for the next release.
