### PR TITLE
[Fabric] Implementation of scrollEvent Handling and scrollEnabled,OnScroll prop for TextInput

### DIFF
--- a/change/react-native-windows-b24bafa9-f8e5-4f4b-801d-86e84ba9a69c.json
+++ b/change/react-native-windows-b24bafa9-f8e5-4f4b-801d-86e84ba9a69c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Implementation of scrollEvent Handling and OnScroll prop for TextInput",
+  "packageName": "react-native-windows",
+  "email": "kvineeth@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-b24bafa9-f8e5-4f4b-801d-86e84ba9a69c.json
+++ b/change/react-native-windows-b24bafa9-f8e5-4f4b-801d-86e84ba9a69c.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "[Fabric] Implementation of scrollEvent Handling and OnScroll prop for TextInput",
+  "comment": "[Fabric] Implementation of scrollEvent Handling and scrollEnabled,OnScroll prop for TextInput",
   "packageName": "react-native-windows",
   "email": "kvineeth@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -486,6 +486,13 @@ const examples: Array<RNTesterModuleExample> = [
           <ExampleTextInput
             autoCorrect={true}
             multiline={true}
+            onScroll={event => {
+              console.log(
+                `onScroll event: ${JSON.stringify(
+                  event.nativeEvent.contentOffset,
+                )}`,
+              );
+            }}
             style={[
               styles.multiline,
               {color: 'blue'},

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -80443,6 +80443,7 @@ exports[`snapshotAllPages TextInput 32`] = `
   <TextInput
     autoCorrect={true}
     multiline={true}
+    onScroll={[Function]}
     style={
       [
         {

--- a/packages/playground/Samples/textinput.tsx
+++ b/packages/playground/Samples/textinput.tsx
@@ -302,6 +302,22 @@ export default class Bootstrap extends React.Component<{}, any> {
               }
               autoFocus={false}
             />
+            <TextInput
+              style={[
+                styles.input,
+                {height: 50, borderColor: '#bd1cddff', borderWidth: 2},
+              ]}
+              multiline={true}
+              placeholder="onScroll..."
+              scrollEnabled={true}
+              onScroll={event => {
+                Alert.alert(
+                  `onScroll event: ${JSON.stringify(
+                    event.nativeEvent.contentOffset,
+                  )}`,
+                );
+              }}
+            />
 
             <KeyboardAvoidingView
               style={styles.container}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -818,7 +818,7 @@ void WindowsTextInputComponentView::OnPointerWheelChanged(
 
     auto delta = static_cast<float>(ppp.MouseWheelDelta());
 
-    if (m_textServices  && !ppp.IsHorizontalMouseWheel()) {
+    if (m_textServices && !ppp.IsHorizontalMouseWheel()) {
       if (delta > 0) {
         m_textServices->TxSendMessage(WM_VSCROLL, SB_LINEUP, 0, nullptr);
       } else {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -859,8 +859,6 @@ void WindowsTextInputComponentView::OnKeyDown(
       args.Handled(true);
     }
   }
-  // Emit the onScroll event
-  EmitOnScrollEvent();
   Super::OnKeyDown(args);
 }
 
@@ -890,8 +888,6 @@ void WindowsTextInputComponentView::OnKeyUp(
       args.Handled(true);
     }
   }
-  // Emit the onScroll event
-  EmitOnScrollEvent();
   Super::OnKeyUp(args);
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -818,7 +818,7 @@ void WindowsTextInputComponentView::OnPointerWheelChanged(
 
     auto delta = static_cast<float>(ppp.MouseWheelDelta());
 
-    if (!ppp.IsHorizontalMouseWheel()) {
+    if (m_textServices  && !ppp.IsHorizontalMouseWheel()) {
       if (delta > 0) {
         m_textServices->TxSendMessage(WM_VSCROLL, SB_LINEUP, 0, nullptr);
       } else {
@@ -1351,19 +1351,19 @@ void WindowsTextInputComponentView::OnTextUpdated() noexcept {
 }
 
 void WindowsTextInputComponentView::EmitOnScrollEvent() noexcept {
-  if (windowsTextInputProps().scrollEnabled) {
-    if (m_eventEmitter && !m_comingFromJS) {
-      LONG lMin, lMax, lxPos, lyPos, lPage;
-      BOOL fEnabled;
-      m_textServices->TxGetHScroll(&lMin, &lMax, &lxPos, &lPage, &fEnabled);
-      m_textServices->TxGetVScroll(&lMin, &lMax, &lyPos, &lPage, &fEnabled);
-      facebook::react::Point offset;
-      offset.x = static_cast<float>(lxPos);
-      offset.y = static_cast<float>(lyPos);
-      auto emitter = std::static_pointer_cast<const facebook::react::WindowsTextInputEventEmitter>(m_eventEmitter);
-      emitter->onScroll(offset);
-    }
+  if (!windowsTextInputProps().scrollEnabled || !m_eventEmitter || m_comingFromJS) {
+    return;
   }
+  LONG hMin, hMax, hPos, hPage;
+  LONG vMin, vMax, vPos, vPage;
+  BOOL hEnabled, vEnabled;
+  m_textServices->TxGetHScroll(&hMin, &hMax, &hPos, &hPage, &hEnabled);
+  m_textServices->TxGetVScroll(&vMin, &vMax, &vPos, &vPage, &vEnabled);
+  facebook::react::Point offset;
+  offset.x = static_cast<float>(hPos);
+  offset.y = static_cast<float>(vPos);
+  auto emitter = std::static_pointer_cast<const facebook::react::WindowsTextInputEventEmitter>(m_eventEmitter);
+  emitter->onScroll(offset);
 }
 
 void WindowsTextInputComponentView::OnSelectionChanged(LONG start, LONG end) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -813,7 +813,7 @@ void WindowsTextInputComponentView::OnPointerMoved(
 
 void WindowsTextInputComponentView::OnPointerWheelChanged(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  if (windowsTextInputProps().scrollEnabled) {
+  if (windowsTextInputProps().scrollEnabled && windowsTextInputProps().multiline) {
     auto ppp = args.GetCurrentPoint(-1).Properties();
 
     auto delta = static_cast<float>(ppp.MouseWheelDelta());

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -89,7 +89,7 @@ struct WindowsTextInputComponentView
     ~DrawBlock();
     WindowsTextInputComponentView &m_view;
   };
-  winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual m_scrollVisual{nullptr};
+
   facebook::react::AttributedString getAttributedString() const;
   void ensureDrawingSurface() noexcept;
   void DrawText() noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -60,6 +60,8 @@ struct WindowsTextInputComponentView
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void OnPointerMoved(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
+  void OnPointerWheelChanged(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
 
   void OnKeyDown(const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept override;
   void OnKeyUp(const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept override;
@@ -87,7 +89,7 @@ struct WindowsTextInputComponentView
     ~DrawBlock();
     WindowsTextInputComponentView &m_view;
   };
-
+  winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual m_scrollVisual{nullptr};
   facebook::react::AttributedString getAttributedString() const;
   void ensureDrawingSurface() noexcept;
   void DrawText() noexcept;
@@ -97,6 +99,7 @@ struct WindowsTextInputComponentView
   void UpdateParaFormat() noexcept;
   void UpdateText(const std::string &str) noexcept;
   void OnTextUpdated() noexcept;
+  void EmitOnScrollEvent() noexcept;
   void OnSelectionChanged(LONG start, LONG end) noexcept;
   std::pair<float, float> GetContentSize() const noexcept;
   std::string GetTextFromRichEdit() const noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.cpp
@@ -109,7 +109,7 @@ void WindowsTextInputEventEmitter::onPressOut(GestureResponderEvent event) const
   });
 }
 
-void WindowsTextInputEventEmitter::onScroll(facebook::react::Point &offset) const {
+void WindowsTextInputEventEmitter::onScroll(facebook::react::Point offset) const {
   dispatchEvent("textInputScroll", [offset = std::move(offset)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.cpp
@@ -109,4 +109,17 @@ void WindowsTextInputEventEmitter::onPressOut(GestureResponderEvent event) const
   });
 }
 
+void WindowsTextInputEventEmitter::onScroll(facebook::react::Point &offset) const {
+  dispatchEvent("textInputScroll", [offset = std::move(offset)](jsi::Runtime &runtime) {
+    auto payload = jsi::Object(runtime);
+    {
+      auto contentOffsetObj = jsi::Object(runtime);
+      contentOffsetObj.setProperty(runtime, "x", offset.x);
+      contentOffsetObj.setProperty(runtime, "y", offset.y);
+      payload.setProperty(runtime, "contentOffset", contentOffsetObj);
+    }
+    return payload;
+  });
+}
+
 } // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.h
@@ -55,6 +55,7 @@ class WindowsTextInputEventEmitter : public ViewEventEmitter {
   void onPressIn(GestureResponderEvent event) const override;
   void onEndEditing(OnEndEditing value) const;
   void onPressOut(GestureResponderEvent event) const override;
+  void onScroll(facebook::react::Point &offset) const;
 };
 
 } // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.h
@@ -55,7 +55,7 @@ class WindowsTextInputEventEmitter : public ViewEventEmitter {
   void onPressIn(GestureResponderEvent event) const override;
   void onEndEditing(OnEndEditing value) const;
   void onPressOut(GestureResponderEvent event) const override;
-  void onScroll(facebook::react::Point &offset) const;
+  void onScroll(facebook::react::Point offset) const;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Added support for the scrollEnabled, OnScroll  prop for the TextInput component.

Resolves #13129 , #13130

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
i)Implemented ScrollEVent Handling for TexInput.
ii)Implemented onScroll Props's Event Emitter

## Screenshots
Used the IOS implementation here i.e 
i)If scrollEnabled prop is set to false means , onScroll event won't fire.
ii)If ScrollEnabled set to true means, we can use the keyboard to move up , but onScroll event won't be triggered.

https://github.com/user-attachments/assets/6e15a0ba-dbac-441c-9bd5-c220a2511462



## Testing
Tested In playground.

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _yes_

Add a brief summary of the change to use in the release notes for the next release.

Added support for the scrollEnabled,OnScroll event for the TextInput component.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14946)