### PR TITLE
TextInput should capture mouse on mouse down

### DIFF
--- a/change/react-native-windows-47643b4d-f7e0-4d08-9fa1-f3612b5a39db.json
+++ b/change/react-native-windows-47643b4d-f7e0-4d08-9fa1-f3612b5a39db.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "TextInput should capture mouse on mouse down",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -811,7 +811,7 @@ struct CompScrollerVisual : winrt::implements<
           m_horizontal ? TTypeRedirects::InteractionSourceMode::Disabled
                        : TTypeRedirects::InteractionSourceMode::EnabledWithInertia);
       m_visualInteractionSource.ManipulationRedirectionMode(
-          TTypeRedirects::VisualInteractionSourceRedirectionMode::CapableTouchpadAndPointerWheel);
+          TTypeRedirects::VisualInteractionSourceRedirectionMode::CapableTouchpadOnly);
     } else {
       m_visualInteractionSource.PositionXSourceMode(TTypeRedirects::InteractionSourceMode::Disabled);
       m_visualInteractionSource.PositionYSourceMode(TTypeRedirects::InteractionSourceMode::Disabled);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -16,6 +16,7 @@
 #include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.h>
+#include "../Composition.Input.h"
 #include "../CompositionHelpers.h"
 #include "../RootComponentView.h"
 #include "JSValueReader.h"
@@ -213,15 +214,13 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
 
   //@cmember Get mouse capture
   void TxSetCapture(BOOL fCapture) override {
-    // assert(false);
-    // TODO capture?
-    /*
+    auto mousePointer = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::Pointer>(winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse, 1 /* 1 is Mouse PointerId*/);
+
     if (fCapture) {
-      ::SetCapture(m_hwndHost);
+      m_outer->CapturePointer(mousePointer);
     } else {
-      ::ReleaseCapture();
+      m_outer->ReleasePointerCapture(mousePointer);
     }
-    */
   }
 
   //@cmember Set the focus to the text window

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -214,7 +214,8 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
 
   //@cmember Get mouse capture
   void TxSetCapture(BOOL fCapture) override {
-    auto mousePointer = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::Pointer>(winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse, 1 /* 1 is Mouse PointerId*/);
+    auto mousePointer = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::Pointer>(
+        winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse, 1 /* 1 is Mouse PointerId*/);
 
     if (fCapture) {
       m_outer->CapturePointer(mousePointer);


### PR DESCRIPTION
## Description
Implement `TxSetCapture` which allows RichEdit to capture the mouse input, so that the user can continue to select text if the mouse leaves the bounds of richedit during the mouse drag gesture.

I also switched scrollview's VisualInteractionSourceRedirectionMode to not redirect scrollwheel input to the compositor, which was stealing it away from other components -causing scrolling not to work.

### Why
Resolves #14974

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/14983)