### PR TITLE
Added UIA Event Triggers for accessibilityAnnotation Property Changes

### DIFF
--- a/change/@react-native-windows-cli-55399dd7-6f33-4e76-82c7-1832ffab3efa.json
+++ b/change/@react-native-windows-cli-55399dd7-6f33-4e76-82c7-1832ffab3efa.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Revert \"Change `init-windows` default new app template to New Architecture (#…\"",
-  "packageName": "@react-native-windows/cli",
-  "email": "54227869+anupriya13@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@rnw-scripts-generate-release-notes-d4a4f9cb-19ee-4dac-a467-95b8a8365643.json
+++ b/change/@rnw-scripts-generate-release-notes-d4a4f9cb-19ee-4dac-a467-95b8a8365643.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Update ReadMe for Release Notes Generation Script",
-  "packageName": "@rnw-scripts/generate-release-notes",
-  "email": "54227869+anupriya13@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-a7eded58-5a2a-479b-b48e-19ebcd5e6e2b.json
+++ b/change/react-native-windows-a7eded58-5a2a-479b-b48e-19ebcd5e6e2b.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Revert \"Change `init-windows` default new app template to New Architecture (#…\"",
-  "packageName": "react-native-windows",
-  "email": "54227869+anupriya13@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-ceab7d9f-344b-44bf-aa55-ba1d9b9bdcba.json
+++ b/change/react-native-windows-ceab7d9f-344b-44bf-aa55-ba1d9b9bdcba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add UIA Event Triggers for accessibilityAnnotation Property Changes",
+  "packageName": "react-native-windows",
+  "email": "gsaran252000@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -46,12 +46,13 @@ CompositionDynamicAutomationProvider::CompositionDynamicAutomationProvider(
     AddSelectionItemsToContainer(this);
   }
 
-  if (strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::WindowsTextInputComponentView>() ||
-      strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ParagraphComponentView>()) {
-    m_textProvider = winrt::make<CompositionTextProvider>(
-                         strongView.as<winrt::Microsoft::ReactNative::Composition::ComponentView>(), this)
-                         .try_as<ITextProvider2>();
-  }
+  // if (strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::WindowsTextInputComponentView>()
+  // ||
+  //     strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ParagraphComponentView>()) {
+  //   m_textProvider = winrt::make<CompositionTextProvider>(
+  //                        strongView.as<winrt::Microsoft::ReactNative::Composition::ComponentView>(), this)
+  //                        .try_as<ITextProvider2>();
+  // }
 
   if (strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ViewComponentView>()) {
     m_annotationProvider = winrt::make<CompositionAnnotationProvider>(
@@ -294,16 +295,18 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPatternProvider(PATTE
     AddRef();
   }
 
-  if (patternId == UIA_TextPatternId &&
-      (strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::WindowsTextInputComponentView>() ||
-       strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ParagraphComponentView>())) {
-    m_textProvider.as<IUnknown>().copy_to(pRetVal);
-  }
+  // if (patternId == UIA_TextPatternId &&
+  //     (strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::WindowsTextInputComponentView>()
+  //     ||
+  //      strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ParagraphComponentView>())) {
+  //   m_textProvider.as<IUnknown>().copy_to(pRetVal);
+  // }
 
-  if (patternId == UIA_TextPattern2Id &&
-      strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::WindowsTextInputComponentView>()) {
-    m_textProvider.as<IUnknown>().copy_to(pRetVal);
-  }
+  // if (patternId == UIA_TextPattern2Id &&
+  //     strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::WindowsTextInputComponentView>())
+  //     {
+  //   m_textProvider.as<IUnknown>().copy_to(pRetVal);
+  // }
   if (patternId == UIA_AnnotationPatternId &&
       strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ViewComponentView>() &&
       accessibilityAnnotationHasValue(props->accessibilityAnnotation)) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -834,42 +834,26 @@ void ComponentView::updateAccessibilityProps(
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_AnnotationAnnotationTypeIdPropertyId,
-      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->typeID.empty()
-          ? oldViewProps.accessibilityAnnotation->typeID
-          : std::string(),
-      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->typeID.empty()
-          ? newViewProps.accessibilityAnnotation->typeID
-          : std::string());
+      oldViewProps.accessibilityAnnotation->typeID,
+      newViewProps.accessibilityAnnotation->typeID);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_AnnotationAnnotationTypeNamePropertyId,
-      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->typeName.empty()
-          ? oldViewProps.accessibilityAnnotation->typeName
-          : std::string(),
-      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->typeName.empty()
-          ? newViewProps.accessibilityAnnotation->typeName
-          : std::string());
+      oldViewProps.accessibilityAnnotation->typeName,
+      newViewProps.accessibilityAnnotation->typeName);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_AnnotationAuthorPropertyId,
-      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->author.empty()
-          ? oldViewProps.accessibilityAnnotation->author
-          : std::string(),
-      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->author.empty()
-          ? newViewProps.accessibilityAnnotation->author
-          : std::string());
+      oldViewProps.accessibilityAnnotation->author,
+      newViewProps.accessibilityAnnotation->author);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_AnnotationDateTimePropertyId,
-      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->dateTime.empty()
-          ? oldViewProps.accessibilityAnnotation->dateTime
-          : std::string(),
-      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->dateTime.empty()
-          ? newViewProps.accessibilityAnnotation->dateTime
-          : std::string());
+      oldViewProps.accessibilityAnnotation->dateTime,
+      newViewProps.accessibilityAnnotation->dateTime);
 
   if ((oldViewProps.accessibilityState.has_value() && oldViewProps.accessibilityState->selected.has_value()) !=
       ((newViewProps.accessibilityState.has_value() && newViewProps.accessibilityState->selected.has_value()))) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -831,6 +831,46 @@ void ComponentView::updateAccessibilityProps(
       oldViewProps.accessibilityValue.text,
       newViewProps.accessibilityValue.text);
 
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      EnsureUiaProvider(),
+      UIA_AnnotationAnnotationTypeIdPropertyId,
+      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->typeID.empty()
+          ? oldViewProps.accessibilityAnnotation->typeID
+          : std::string(),
+      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->typeID.empty()
+          ? newViewProps.accessibilityAnnotation->typeID
+          : std::string());
+
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      EnsureUiaProvider(),
+      UIA_AnnotationAnnotationTypeNamePropertyId,
+      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->typeName.empty()
+          ? oldViewProps.accessibilityAnnotation->typeName
+          : std::string(),
+      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->typeName.empty()
+          ? newViewProps.accessibilityAnnotation->typeName
+          : std::string());
+
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      EnsureUiaProvider(),
+      UIA_AnnotationAuthorPropertyId,
+      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->author.empty()
+          ? oldViewProps.accessibilityAnnotation->author
+          : std::string(),
+      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->author.empty()
+          ? newViewProps.accessibilityAnnotation->author
+          : std::string());
+
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      EnsureUiaProvider(),
+      UIA_AnnotationDateTimePropertyId,
+      oldViewProps.accessibilityAnnotation && !oldViewProps.accessibilityAnnotation->dateTime.empty()
+          ? oldViewProps.accessibilityAnnotation->dateTime
+          : std::string(),
+      newViewProps.accessibilityAnnotation && !newViewProps.accessibilityAnnotation->dateTime.empty()
+          ? newViewProps.accessibilityAnnotation->dateTime
+          : std::string());
+
   if ((oldViewProps.accessibilityState.has_value() && oldViewProps.accessibilityState->selected.has_value()) !=
       ((newViewProps.accessibilityState.has_value() && newViewProps.accessibilityState->selected.has_value()))) {
     auto compProvider =


### PR DESCRIPTION
## Description
The accessibilityAnnotation property was introduced in RNW. However, we did not implement logic to raise a UIA change event when its values are updated.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The accessibilityAnnotation property was introduced in RNW. However, we did not implement logic to raise a UIA change event when its values are updated.

Resolves [#14999]

### What
Added events for the below properties.
UIA_AnnotationAnnotationTypeIdPropertyId
UIA_AnnotationAnnotationTypeNamePropertyId
UIA_AnnotationAuthorPropertyId
UIA_AnnotationDateTimePropertyId

## Screenshots
Developed in mac, Could not able to test.

## Testing
Developed in mac, Could not able to test.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15000)