### PR TITLE
Cherrypick - [BugFix] Open Init windows telemetry not capturing the true default template  (#15011)

### DIFF
--- a/change/@react-native-windows-cli-82554c64-39d4-4d16-9e5e-8bafdb95812b.json
+++ b/change/@react-native-windows-cli-82554c64-39d4-4d16-9e5e-8bafdb95812b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[BugFix] Open Init windows telemetry not capturing the true default template",
+  "packageName": "@react-native-windows/cli",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -24,7 +24,7 @@ export const initOptions: CommandOption[] = [
   {
     name: '--template [string]',
     description: 'Specify the template to use',
-    default: undefined,
+    default: 'old/uwp-cpp-app',
   },
   {
     name: '--name [string]',


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

When not specifying a template when calling init-windows, the default is used, but the telemetry records before that selection and therefore doesn't know that the default was selected.

Resolves #14750 

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

Expect to see that the default is the default template


## Screenshots
Add any relevant screen captures here from before or after your changes. 
N/A

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.
N/A

## Changelog
Should this change be included in the release notes: _no_

Add a brief summary of the change to use in the release notes for the next release.
