### PR TITLE
[ Fix ] : Paper crash occurring in SetLayoutPropsRecursive due to a null pointer dereference

### DIFF
--- a/change/react-native-windows-98dd2231-24dd-452f-8057-4234da3a5c05.json
+++ b/change/react-native-windows-98dd2231-24dd-452f-8057-4234da3a5c05.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Null pointer checks and validation in SetLayoutPropsRecursive to prevent crashes when shadow nodes are invalid or deleted",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -935,7 +935,7 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
     return;
   }
 
-  auto* shadowNodePtr = m_host->FindShadowNodeForTag(tag);
+  auto *shadowNodePtr = m_host->FindShadowNodeForTag(tag);
   if (!shadowNodePtr) {
     return;
   }
@@ -968,7 +968,7 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
     float height = YGNodeLayoutGetHeight(yogaNode);
     auto view = shadowNode.GetView();
     auto pViewManager = shadowNode.GetViewManager();
-    
+
     if (pViewManager) {
       pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
       if (shadowNode.m_onLayoutRegistered) {

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -931,11 +931,28 @@ void NativeUIManager::ApplyLayout(int64_t tag, float width, float height) {
 }
 
 void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
-  ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
+  if (!m_host) {
+    return;
+  }
+
+  auto* shadowNodePtr = m_host->FindShadowNodeForTag(tag);
+  if (!shadowNodePtr) {
+    return;
+  }
+
+  ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(*shadowNodePtr);
   auto *pViewManager = shadowNode.GetViewManager();
+  if (!pViewManager) {
+    return;
+  }
+
   if (!pViewManager->IsNativeControlWithSelfLayout()) {
-    for (const auto child : shadowNode.m_children) {
-      SetLayoutPropsRecursive(child);
+    // copy of children if collection is modified during iteration
+    auto children = shadowNode.m_children;
+    for (const auto child : children) {
+      if (child != InvalidTag && m_host->FindShadowNodeForTag(child)) {
+        SetLayoutPropsRecursive(child);
+      }
     }
   }
 
@@ -951,18 +968,21 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
     float height = YGNodeLayoutGetHeight(yogaNode);
     auto view = shadowNode.GetView();
     auto pViewManager = shadowNode.GetViewManager();
-    pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
-    if (shadowNode.m_onLayoutRegistered) {
-      const auto hasLayoutChanged = !YogaFloatEquals(left, shadowNode.m_layout.Left) ||
-          !YogaFloatEquals(top, shadowNode.m_layout.Top) || !YogaFloatEquals(width, shadowNode.m_layout.Width) ||
-          !YogaFloatEquals(height, shadowNode.m_layout.Height);
-      if (hasLayoutChanged) {
-        React::JSValueObject layout{{"x", left}, {"y", top}, {"height", height}, {"width", width}};
-        React::JSValueObject eventData{{"target", tag}, {"layout", std::move(layout)}};
-        pViewManager->DispatchCoalescingEvent(tag, L"topLayout", MakeJSValueWriter(std::move(eventData)));
+    
+    if (pViewManager) {
+      pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
+      if (shadowNode.m_onLayoutRegistered) {
+        const auto hasLayoutChanged = !YogaFloatEquals(left, shadowNode.m_layout.Left) ||
+            !YogaFloatEquals(top, shadowNode.m_layout.Top) || !YogaFloatEquals(width, shadowNode.m_layout.Width) ||
+            !YogaFloatEquals(height, shadowNode.m_layout.Height);
+        if (hasLayoutChanged) {
+          React::JSValueObject layout{{"x", left}, {"y", top}, {"height", height}, {"width", width}};
+          React::JSValueObject eventData{{"target", tag}, {"layout", std::move(layout)}};
+          pViewManager->DispatchCoalescingEvent(tag, L"topLayout", MakeJSValueWriter(std::move(eventData)));
+        }
       }
+      shadowNode.m_layout = {left, top, width, height};
     }
-    shadowNode.m_layout = {left, top, width, height};
   }
 }
 


### PR DESCRIPTION
## Description
 SetLayoutPropsRecursive crash happens when accessing a shadow node that has been deleted or is invalid.
### Type of Change

- Bug fix (non-breaking change which fixes an issue)


### Why
crash happens when accessing a shadow node that has been deleted or is invalid

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-windows/issues/14950

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_

Add a brief summary of the change to use in the release notes for the next release.
