### PR TITLE
[Fabric] Raising UIA Event if Toggle State Changes in Switch Component

### DIFF
--- a/change/react-native-windows-bcf77be5-d1cd-4b1a-9756-3de4607890e5.json
+++ b/change/react-native-windows-bcf77be5-d1cd-4b1a-9756-3de4607890e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Raising UIA Event if Toggle State Changes in Switch Component",
+  "packageName": "react-native-windows",
+  "email": "kvineeth@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -8,8 +8,8 @@
 #include <AutoDraw.h>
 #include <Fabric/AbiViewProps.h>
 #include "CompositionDynamicAutomationProvider.h"
-#include "UiaHelpers.h"
 #include "RootComponentView.h"
+#include "UiaHelpers.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
@@ -330,8 +330,7 @@ bool SwitchComponentView::toggle() noexcept {
         EnsureUiaProvider(),
         UIA_ToggleToggleStatePropertyId,
         m_localToggleState ? ToggleState_Off : ToggleState_On,
-        m_localToggleState ? ToggleState_On : ToggleState_Off
-        );
+        m_localToggleState ? ToggleState_On : ToggleState_Off);
   }
   return true;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -81,12 +81,14 @@ void SwitchComponentView::updateProps(
     m_visualUpdateRequired = true;
   }
 
-  if (UiaClientsAreListening()) {
-    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-        EnsureUiaProvider(),
-        UIA_ToggleToggleStatePropertyId,
-        oldViewProps.value ? ToggleState_On : ToggleState_Off,
-        newViewProps.value ? ToggleState_On : ToggleState_Off);
+  if (oldViewProps.value != newViewProps.value) {
+    if (UiaClientsAreListening()) {
+      winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+          EnsureUiaProvider(),
+          UIA_ToggleToggleStatePropertyId,
+          oldViewProps.value ? ToggleState_On : ToggleState_Off,
+          newViewProps.value ? ToggleState_On : ToggleState_Off);
+    }
   }
 
   Super::updateProps(props, oldProps);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -67,6 +67,7 @@ struct SwitchComponentView : SwitchComponentViewT<SwitchComponentView, ViewCompo
   void updateVisuals() noexcept;
 
   bool m_hovered{false};
+  bool m_localToggleState{false}; // Add this to track immediate toggle state
   bool m_pressed{false};
   bool m_supressAnimationForNextFrame{false};
   bool m_visualUpdateRequired{true};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -67,7 +67,6 @@ struct SwitchComponentView : SwitchComponentViewT<SwitchComponentView, ViewCompo
   void updateVisuals() noexcept;
 
   bool m_hovered{false};
-  bool m_localToggleState{false}; // Add this to track immediate toggle state
   bool m_pressed{false};
   bool m_supressAnimationForNextFrame{false};
   bool m_visualUpdateRequired{true};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -166,6 +166,15 @@ void UpdateUiaProperty(winrt::IInspectable provider, PROPERTYID propId, bool old
   UiaRaiseAutomationPropertyChangedEvent(spProviderSimple.get(), propId, CComVariant(oldValue), CComVariant(newValue));
 }
 
+void UpdateUiaProperty(winrt::IInspectable provider, PROPERTYID propId, int oldValue, int newValue) noexcept {
+  auto spProviderSimple = provider.try_as<IRawElementProviderSimple>();
+
+  if (spProviderSimple == nullptr || oldValue == newValue || !WasUiaPropertyAdvised(spProviderSimple, propId))
+    return;
+
+  UiaRaiseAutomationPropertyChangedEvent(spProviderSimple.get(), propId, CComVariant(oldValue), CComVariant(newValue));
+}
+
 void UpdateUiaProperty(
     winrt::IInspectable provider,
     PROPERTYID propId,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
@@ -32,6 +32,12 @@ void UpdateUiaProperty(
 void UpdateUiaProperty(
     winrt::Windows::Foundation::IInspectable provider,
     PROPERTYID propId,
+    int oldValue,
+    int newValue) noexcept;
+
+void UpdateUiaProperty(
+    winrt::Windows::Foundation::IInspectable provider,
+    PROPERTYID propId,
     const std::string &oldValue,
     const std::string &newValue) noexcept;
 


### PR DESCRIPTION
## Description
Changes made to raise UIA Changed Event if toggle state changes.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Changing toggle doesn't notify the UIA Clients.

Resolves [#14608]

### What
Changes made to notify UIA Clients, if toggle state changes

## Screenshots

https://github.com/user-attachments/assets/2aa253ca-bd16-48c7-bc27-c55b7cb4cc04



## Testing
Tested in Playground.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15023)