### PR TITLE
Remove unused ITextProvider2

### DIFF
--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionTextProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionTextProvider.cpp
@@ -99,17 +99,5 @@ HRESULT __stdcall CompositionTextProvider::RangeFromPoint(UiaPoint point, ITextR
   m_textRangeProvider.copy_to(pRetVal);
   return S_OK;
 }
-HRESULT __stdcall CompositionTextProvider::GetCaretRange(BOOL *isActive, ITextRangeProvider **pRetVal) {
-  // no-op
-  *pRetVal = nullptr;
-  return S_OK;
-}
 
-HRESULT __stdcall CompositionTextProvider::RangeFromAnnotation(
-    IRawElementProviderSimple *annotationElement,
-    ITextRangeProvider **pRetVal) {
-  // no-op
-  *pRetVal = nullptr;
-  return S_OK;
-}
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionTextProvider.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionTextProvider.h
@@ -9,7 +9,7 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-class CompositionTextProvider : public winrt::implements<CompositionTextProvider, ITextProvider, ITextProvider2> {
+class CompositionTextProvider : public winrt::implements<CompositionTextProvider, ITextProvider> {
  public:
   CompositionTextProvider(
       const winrt::Microsoft::ReactNative::Composition::ComponentView &componentView,
@@ -23,12 +23,6 @@ class CompositionTextProvider : public winrt::implements<CompositionTextProvider
   virtual HRESULT __stdcall RangeFromChild(IRawElementProviderSimple *childElement, ITextRangeProvider **pRetVal)
       override;
   virtual HRESULT __stdcall RangeFromPoint(UiaPoint point, ITextRangeProvider **pRetVal) override;
-
-  // inherited via ITextProvider2
-  virtual HRESULT __stdcall GetCaretRange(BOOL *isActive, ITextRangeProvider **pRetVal) override;
-  virtual HRESULT __stdcall RangeFromAnnotation(
-      IRawElementProviderSimple *annotationElement,
-      ITextRangeProvider **pRetVal) override;
 
   void EnsureTextRangeProvider();
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
The narrator focus doesn't shift on textinput when the keyboard focus shifts onto textinput.

Resolves https://github.com/microsoft/react-native-gallery/issues/619


### What
1. Identified that ITextProvider2 returns ITextRangeProvider with an incomplete implementation which is interfering with the narrator focus.
2. Temporarily Remove references to ITextProvider2 as it is not being used for any purpose.

## Screenshots
<img width="1830" height="1088" alt="image" src="https://github.com/user-attachments/assets/cb18fcf4-ec27-4c11-bf13-f171934ec41c" /> 

## Testing
Used a simple example to verify if narrator focus shifts onto textinput

`
import React from 'react';
import { View, TextInput, StyleSheet, AppRegistry } from 'react-native';

const AccessibilityTestScreen = () => {
  return (
    <View style={styles.container} accessible={true}>
      <TextInput
        style={styles.input}
        accessibilityLabel="Username"
        accessible={true}
      />
     <TextInput
        style={styles.input}
        accessibilityLabel="Username2"
        accessible={true}
      />
    </View>
  );
};

AppRegistry.registerComponent('Bootstrap', () => AccessibilityTestScreen);
`

## Changelog
Should this change be included in the release notes: _indicate yes or no_

Add a brief summary of the change to use in the release notes for the next release.
