### PR TITLE
[Fabric] Added UIA Event Triggers for accessibilityAnnotation Property Changes

### DIFF
--- a/change/react-native-windows-8aaaff79-a2a7-4bd6-af5f-ecee696abe44.json
+++ b/change/react-native-windows-8aaaff79-a2a7-4bd6-af5f-ecee696abe44.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "wrapped to single call - UpdateUIAPropertiesForAnnotation",
-  "packageName": "react-native-windows",
-  "email": "gsaran252000@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-8aaaff79-a2a7-4bd6-af5f-ecee696abe44.json
+++ b/change/react-native-windows-8aaaff79-a2a7-4bd6-af5f-ecee696abe44.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "wrapped to single call - UpdateUIAPropertiesForAnnotation",
+  "packageName": "react-native-windows",
+  "email": "gsaran252000@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-a648cb52-86ff-47b1-b2be-04d168a7f110.json
+++ b/change/react-native-windows-a648cb52-86ff-47b1-b2be-04d168a7f110.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Added UIA Event Triggers for accessibilityAnnotation Property Changes",
+  "packageName": "react-native-windows",
+  "email": "gsaran252000@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -831,32 +831,9 @@ void ComponentView::updateAccessibilityProps(
       oldViewProps.accessibilityValue.text,
       newViewProps.accessibilityValue.text);
 
-  // Handle annotation properties with null checks
-  if (oldViewProps.accessibilityAnnotation.has_value() && newViewProps.accessibilityAnnotation.has_value()) {
-    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
-        EnsureUiaProvider(),
-        UIA_AnnotationAnnotationTypeIdPropertyId,
-        oldViewProps.accessibilityAnnotation->typeID,
-        newViewProps.accessibilityAnnotation->typeID);
-
-    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
-        EnsureUiaProvider(),
-        UIA_AnnotationAnnotationTypeNamePropertyId,
-        oldViewProps.accessibilityAnnotation->typeName,
-        newViewProps.accessibilityAnnotation->typeName);
-
-    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
-        EnsureUiaProvider(),
-        UIA_AnnotationAuthorPropertyId,
-        oldViewProps.accessibilityAnnotation->author,
-        newViewProps.accessibilityAnnotation->author);
-
-    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
-        EnsureUiaProvider(),
-        UIA_AnnotationDateTimePropertyId,
-        oldViewProps.accessibilityAnnotation->dateTime,
-        newViewProps.accessibilityAnnotation->dateTime);
-  }
+  // Handle annotation properties with single call
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaPropertiesForAnnotation(
+      EnsureUiaProvider(), oldViewProps.accessibilityAnnotation, newViewProps.accessibilityAnnotation);
 
   if ((oldViewProps.accessibilityState.has_value() && oldViewProps.accessibilityState->selected.has_value()) !=
       ((newViewProps.accessibilityState.has_value() && newViewProps.accessibilityState->selected.has_value()))) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -831,6 +831,33 @@ void ComponentView::updateAccessibilityProps(
       oldViewProps.accessibilityValue.text,
       newViewProps.accessibilityValue.text);
 
+  // Handle annotation properties with null checks
+  if (oldViewProps.accessibilityAnnotation.has_value() && newViewProps.accessibilityAnnotation.has_value()) {
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
+        EnsureUiaProvider(),
+        UIA_AnnotationAnnotationTypeIdPropertyId,
+        oldViewProps.accessibilityAnnotation->typeID,
+        newViewProps.accessibilityAnnotation->typeID);
+
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
+        EnsureUiaProvider(),
+        UIA_AnnotationAnnotationTypeNamePropertyId,
+        oldViewProps.accessibilityAnnotation->typeName,
+        newViewProps.accessibilityAnnotation->typeName);
+
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
+        EnsureUiaProvider(),
+        UIA_AnnotationAuthorPropertyId,
+        oldViewProps.accessibilityAnnotation->author,
+        newViewProps.accessibilityAnnotation->author);
+
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaAnnotationProperty(
+        EnsureUiaProvider(),
+        UIA_AnnotationDateTimePropertyId,
+        oldViewProps.accessibilityAnnotation->dateTime,
+        newViewProps.accessibilityAnnotation->dateTime);
+  }
+
   if ((oldViewProps.accessibilityState.has_value() && oldViewProps.accessibilityState->selected.has_value()) !=
       ((newViewProps.accessibilityState.has_value() && newViewProps.accessibilityState->selected.has_value()))) {
     auto compProvider =

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -212,13 +212,9 @@ void UpdateUiaPropertiesForAnnotation(
     winrt::IInspectable provider,
     const std::optional<facebook::react::AccessibilityAnnotation> &oldAnnotation,
     const std::optional<facebook::react::AccessibilityAnnotation> &newAnnotation) noexcept {
-  // Only update if both annotations have values
-  if (!oldAnnotation.has_value() || !newAnnotation.has_value()) {
-    return;
-  }
-
-  const auto &old_annotation = oldAnnotation.value();
-  const auto &new_annotation = newAnnotation.value();
+  // if no value fall back to a default value.
+  const auto &old_annotation = oldAnnotation.value_or(facebook::react::AccessibilityAnnotation());
+  const auto &new_annotation = newAnnotation.value_or(facebook::react::AccessibilityAnnotation());
 
   // Update all annotation properties
   UpdateUiaProperty(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -175,6 +175,15 @@ void UpdateUiaProperty(winrt::IInspectable provider, PROPERTYID propId, int oldV
   UiaRaiseAutomationPropertyChangedEvent(spProviderSimple.get(), propId, CComVariant(oldValue), CComVariant(newValue));
 }
 
+void UpdateUiaProperty(winrt::IInspectable provider, PROPERTYID propId, long oldValue, long newValue) noexcept {
+  auto spProviderSimple = provider.try_as<IRawElementProviderSimple>();
+
+  if (spProviderSimple == nullptr || oldValue == newValue || !WasUiaPropertyAdvised(spProviderSimple, propId))
+    return;
+
+  UiaRaiseAutomationPropertyChangedEvent(spProviderSimple.get(), propId, CComVariant(oldValue), CComVariant(newValue));
+}
+
 void UpdateUiaProperty(
     winrt::IInspectable provider,
     PROPERTYID propId,
@@ -242,17 +251,18 @@ void UpdateUiaPropertiesForAnnotation(
   const auto &new_annotation = newAnnotation.value();
 
   // Update all annotation properties
-  UpdateUiaPropertyForAnnotation(
-      provider, UIA_AnnotationAnnotationTypeIdPropertyId, old_annotation.typeID, new_annotation.typeID);
+  UpdateUiaProperty(
+      provider,
+      UIA_AnnotationAnnotationTypeIdPropertyId,
+      GetAnnotationTypeId(old_annotation.typeID),
+      GetAnnotationTypeId(new_annotation.typeID));
 
-  UpdateUiaPropertyForAnnotation(
+  UpdateUiaProperty(
       provider, UIA_AnnotationAnnotationTypeNamePropertyId, old_annotation.typeName, new_annotation.typeName);
 
-  UpdateUiaPropertyForAnnotation(
-      provider, UIA_AnnotationAuthorPropertyId, old_annotation.author, new_annotation.author);
+  UpdateUiaProperty(provider, UIA_AnnotationAuthorPropertyId, old_annotation.author, new_annotation.author);
 
-  UpdateUiaPropertyForAnnotation(
-      provider, UIA_AnnotationDateTimePropertyId, old_annotation.dateTime, new_annotation.dateTime);
+  UpdateUiaProperty(provider, UIA_AnnotationDateTimePropertyId, old_annotation.dateTime, new_annotation.dateTime);
 }
 
 long GetLiveSetting(const std::string &liveRegion) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -208,36 +208,6 @@ void UpdateUiaProperty(
   UpdateUiaProperty(provider, propId, oldData, newData);
 }
 
-void UpdateUiaPropertyForAnnotation(
-    winrt::IInspectable provider,
-    PROPERTYID propId,
-    const std::string &oldValue,
-    const std::string &newValue) noexcept {
-  std::string oldData = oldValue.empty() ? "" : oldValue;
-  std::string newData = newValue.empty() ? "" : newValue;
-
-  auto spProviderSimple = provider.try_as<IRawElementProviderSimple>();
-
-  if (spProviderSimple == nullptr || !WasUiaPropertyAdvised(spProviderSimple, propId))
-    return;
-
-  if (oldData == newData)
-    return;
-
-  // For annotation type ID property, convert string type IDs to annotation type constants
-  if (propId == UIA_AnnotationAnnotationTypeIdPropertyId) {
-    long oldAnnotationTypeId = GetAnnotationTypeId(oldData);
-    long newAnnotationTypeId = GetAnnotationTypeId(newData);
-
-    UiaRaiseAutomationPropertyChangedEvent(
-        spProviderSimple.get(), propId, CComVariant(oldAnnotationTypeId), CComVariant(newAnnotationTypeId));
-  } else {
-    // For other annotation properties, use string comparison
-    UiaRaiseAutomationPropertyChangedEvent(
-        spProviderSimple.get(), propId, CComVariant(oldData.c_str()), CComVariant(newData.c_str()));
-  }
-}
-
 void UpdateUiaPropertiesForAnnotation(
     winrt::IInspectable provider,
     const std::optional<facebook::react::AccessibilityAnnotation> &oldAnnotation,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.cpp
@@ -199,7 +199,7 @@ void UpdateUiaProperty(
   UpdateUiaProperty(provider, propId, oldData, newData);
 }
 
-void UpdateUiaAnnotationProperty(
+void UpdateUiaPropertyForAnnotation(
     winrt::IInspectable provider,
     PROPERTYID propId,
     const std::string &oldValue,
@@ -227,6 +227,32 @@ void UpdateUiaAnnotationProperty(
     UiaRaiseAutomationPropertyChangedEvent(
         spProviderSimple.get(), propId, CComVariant(oldData.c_str()), CComVariant(newData.c_str()));
   }
+}
+
+void UpdateUiaPropertiesForAnnotation(
+    winrt::IInspectable provider,
+    const std::optional<facebook::react::AccessibilityAnnotation> &oldAnnotation,
+    const std::optional<facebook::react::AccessibilityAnnotation> &newAnnotation) noexcept {
+  // Only update if both annotations have values
+  if (!oldAnnotation.has_value() || !newAnnotation.has_value()) {
+    return;
+  }
+
+  const auto &old_annotation = oldAnnotation.value();
+  const auto &new_annotation = newAnnotation.value();
+
+  // Update all annotation properties
+  UpdateUiaPropertyForAnnotation(
+      provider, UIA_AnnotationAnnotationTypeIdPropertyId, old_annotation.typeID, new_annotation.typeID);
+
+  UpdateUiaPropertyForAnnotation(
+      provider, UIA_AnnotationAnnotationTypeNamePropertyId, old_annotation.typeName, new_annotation.typeName);
+
+  UpdateUiaPropertyForAnnotation(
+      provider, UIA_AnnotationAuthorPropertyId, old_annotation.author, new_annotation.author);
+
+  UpdateUiaPropertyForAnnotation(
+      provider, UIA_AnnotationDateTimePropertyId, old_annotation.dateTime, new_annotation.dateTime);
 }
 
 long GetLiveSetting(const std::string &liveRegion) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
@@ -47,12 +47,6 @@ void UpdateUiaProperty(
     const std::optional<std::string> &oldValue,
     const std::optional<std::string> &newValue) noexcept;
 
-void UpdateUiaPropertyForAnnotation(
-    winrt::Windows::Foundation::IInspectable provider,
-    PROPERTYID propId,
-    const std::string &oldTypeId,
-    const std::string &newTypeId) noexcept;
-
 void UpdateUiaPropertiesForAnnotation(
     winrt::Windows::Foundation::IInspectable provider,
     const std::optional<facebook::react::AccessibilityAnnotation> &oldAnnotation,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
@@ -47,11 +47,16 @@ void UpdateUiaProperty(
     const std::optional<std::string> &oldValue,
     const std::optional<std::string> &newValue) noexcept;
 
-void UpdateUiaAnnotationProperty(
+void UpdateUiaPropertyForAnnotation(
     winrt::Windows::Foundation::IInspectable provider,
     PROPERTYID propId,
     const std::string &oldTypeId,
     const std::string &newTypeId) noexcept;
+
+void UpdateUiaPropertiesForAnnotation(
+    winrt::Windows::Foundation::IInspectable provider,
+    const std::optional<facebook::react::AccessibilityAnnotation> &oldAnnotation,
+    const std::optional<facebook::react::AccessibilityAnnotation> &newAnnotation) noexcept;
 
 long GetLiveSetting(const std::string &liveRegion) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
@@ -38,6 +38,12 @@ void UpdateUiaProperty(
 void UpdateUiaProperty(
     winrt::Windows::Foundation::IInspectable provider,
     PROPERTYID propId,
+    long oldValue,
+    long newValue) noexcept;
+
+void UpdateUiaProperty(
+    winrt::Windows::Foundation::IInspectable provider,
+    PROPERTYID propId,
     const std::string &oldValue,
     const std::string &newValue) noexcept;
 
@@ -46,6 +52,7 @@ void UpdateUiaProperty(
     PROPERTYID propId,
     const std::optional<std::string> &oldValue,
     const std::optional<std::string> &newValue) noexcept;
+
 
 void UpdateUiaPropertiesForAnnotation(
     winrt::Windows::Foundation::IInspectable provider,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
@@ -47,6 +47,12 @@ void UpdateUiaProperty(
     const std::optional<std::string> &oldValue,
     const std::optional<std::string> &newValue) noexcept;
 
+void UpdateUiaAnnotationProperty(
+    winrt::Windows::Foundation::IInspectable provider,
+    PROPERTYID propId,
+    const std::string &oldTypeId,
+    const std::string &newTypeId) noexcept;
+
 long GetLiveSetting(const std::string &liveRegion) noexcept;
 
 long GetAnnotationTypeId(const std::string &annotationType) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UiaHelpers.h
@@ -53,7 +53,6 @@ void UpdateUiaProperty(
     const std::optional<std::string> &oldValue,
     const std::optional<std::string> &newValue) noexcept;
 
-
 void UpdateUiaPropertiesForAnnotation(
     winrt::Windows::Foundation::IInspectable provider,
     const std::optional<facebook::react::AccessibilityAnnotation> &oldAnnotation,


### PR DESCRIPTION
## Description
The accessibilityAnnotation property was introduced in RNW. However, we did not implement logic to raise a UIA change event when its values are updated.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The accessibilityAnnotation property was introduced in RNW. However, we did not implement logic to raise a UIA change event when its values are updated.

Resolves [#14999]

### What
Added events for the below properties.
UIA_AnnotationAnnotationTypeIdPropertyId
UIA_AnnotationAnnotationTypeNamePropertyId
UIA_AnnotationAuthorPropertyId
UIA_AnnotationDateTimePropertyId

## Screenshots
Developed in mac, Could not able to test.

## Testing
Developed in mac, Could not able to test.

### Changelog
Should this change be included in the release notes: yes

Add a brief summary of the change to use in the release notes for the next release.
Added UIA update event for change in annotation properties.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15039)