### PR TITLE
Add reply count prop to AccessibilityAnnotationInfo

### DIFF
--- a/change/@office-iss-react-native-win32-4719dc73-e282-43b7-b81e-73f7be41577c.json
+++ b/change/@office-iss-react-native-win32-4719dc73-e282-43b7-b81e-73f7be41577c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add reply count prop to AccessibilityAnnotationInfo",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "mmaring@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src-win/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/@office-iss/react-native-win32/src-win/Libraries/Components/View/ViewAccessibility.d.ts
@@ -417,6 +417,7 @@ export type AccessibilityAnnotationInfo = Readonly<{
   author?: string;
   dateTime?: string;
   target?: string;
+  replyCount?: number;
 }>;
 
 // [Win32]


### PR DESCRIPTION
Add reply count prop to AccessibilityAnnotationInfo, which is used to indicate the number of replies to annotation (i.e. children in the view heiarchy that also use AccessibilityAnnotationInfo).
