### PR TITLE
[Cherry-pick] Update CLI to show static warning for old architecture in run-windows and interactive prompt for init-windows 

### DIFF
--- a/change/@react-native-windows-cli-df0889c3-e18b-4f66-82ef-3b55c9294c4b.json
+++ b/change/@react-native-windows-cli-df0889c3-e18b-4f66-82ef-3b55c9294c4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update CLI to show static warning for old architecture in run-windows and interactive prompt for init-windows (#15029)",
+  "packageName": "@react-native-windows/cli",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-2e2f5bfc-794a-42c2-8ec0-fccb4e6e19cf.json
+++ b/change/@react-native-windows-telemetry-2e2f5bfc-794a-42c2-8ec0-fccb4e6e19cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update CLI to show static warning for old architecture in run-windows and interactive prompt for init-windows (#15029)",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/commands/initWindows/initWindowsOptions.ts
@@ -14,6 +14,7 @@ export interface InitOptions {
   overwrite?: boolean;
   telemetry?: boolean;
   list?: boolean;
+  prompt?: boolean;
 }
 
 export const initOptions: CommandOption[] = [
@@ -51,5 +52,9 @@ export const initOptions: CommandOption[] = [
     name: '--list',
     description:
       'Shows a list with all available templates with their descriptions.',
+  },
+  {
+    name: '--no-prompt',
+    description: 'Skip any interactive prompts and use default choices.',
   },
 ];

--- a/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/commands/runWindows/runWindows.ts
@@ -33,6 +33,7 @@ import type {RunWindowsOptions} from './runWindowsOptions';
 import {runWindowsOptions} from './runWindowsOptions';
 import {autolinkWindowsInternal} from '../autolinkWindows/autolinkWindows';
 import type {AutoLinkOptions} from '../autolinkWindows/autolinkWindowsOptions';
+import {showOldArchitectureWarning} from '../../utils/oldArchWarning';
 
 /**
  * Sanitizes the given option for telemetry.
@@ -208,9 +209,7 @@ async function runWindowsInternal(
 
   // Warn about old architecture projects
   if (config.project.windows?.rnwConfig?.projectArch === 'old') {
-    newWarn(
-      'This project is using the React Native (for Windows) Old Architecture, which will eventually be deprecated. See https://microsoft.github.io/react-native-windows/docs/new-architecture for details on switching to the New Architecture.',
-    );
+    showOldArchitectureWarning();
   }
 
   // Get the solution file

--- a/packages/@react-native-windows/cli/src/e2etest/architecturePrompt.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/architecturePrompt.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {promptForArchitectureChoice} from '../utils/architecturePrompt';
+
+// Mock prompts module
+jest.mock('prompts', () => {
+  return jest.fn();
+});
+
+import prompts from 'prompts';
+const mockPrompts = prompts as jest.MockedFunction<typeof prompts>;
+
+describe('architecturePrompt', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns true when user chooses Y', async () => {
+    mockPrompts.mockResolvedValue({choice: 'y'});
+
+    const result = await promptForArchitectureChoice();
+
+    expect(result.shouldContinueWithOldArch).toBe(true);
+    expect(result.userCancelled).toBe(false);
+  });
+
+  test('returns true when user chooses Y (uppercase)', async () => {
+    mockPrompts.mockResolvedValue({choice: 'Y'});
+
+    const result = await promptForArchitectureChoice();
+
+    expect(result.shouldContinueWithOldArch).toBe(true);
+    expect(result.userCancelled).toBe(false);
+  });
+
+  test('returns false when user chooses N', async () => {
+    mockPrompts.mockResolvedValue({choice: 'n'});
+
+    const result = await promptForArchitectureChoice();
+
+    expect(result.shouldContinueWithOldArch).toBe(false);
+    expect(result.userCancelled).toBe(false);
+  });
+
+  test('returns false when user chooses N (uppercase)', async () => {
+    mockPrompts.mockResolvedValue({choice: 'N'});
+
+    const result = await promptForArchitectureChoice();
+
+    expect(result.shouldContinueWithOldArch).toBe(false);
+    expect(result.userCancelled).toBe(false);
+  });
+
+  test('returns true with userCancelled when user cancels with no input', async () => {
+    mockPrompts.mockResolvedValue({});
+
+    const result = await promptForArchitectureChoice();
+
+    expect(result.shouldContinueWithOldArch).toBe(true);
+    expect(result.userCancelled).toBe(true);
+  });
+
+  test('returns true with userCancelled when prompts throws cancellation error', async () => {
+    mockPrompts.mockRejectedValue(new Error('User cancelled'));
+
+    const result = await promptForArchitectureChoice();
+
+    expect(result.shouldContinueWithOldArch).toBe(true);
+    expect(result.userCancelled).toBe(true);
+  });
+
+  test('returns true and not cancelled on other errors', async () => {
+    mockPrompts.mockRejectedValue(new Error('Some other error'));
+
+    const result = await promptForArchitectureChoice();
+
+    expect(result.shouldContinueWithOldArch).toBe(true);
+    expect(result.userCancelled).toBe(false);
+  });
+});

--- a/packages/@react-native-windows/cli/src/e2etest/initWindows.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/initWindows.test.ts
@@ -26,6 +26,7 @@ function validateOptionName(
     case 'overwrite':
     case 'telemetry':
     case 'list':
+    case 'prompt':
       return true;
   }
   throw new Error(
@@ -55,6 +56,7 @@ test('initOptions - validate options', () => {
 
     // Validate all command options are present in InitOptions
     const optionName = commanderNameToOptionName(commandOption.name);
+
     expect(
       validateOptionName(commandOption.name, optionName as keyof InitOptions),
     ).toBe(true);

--- a/packages/@react-native-windows/cli/src/utils/architecturePrompt.ts
+++ b/packages/@react-native-windows/cli/src/utils/architecturePrompt.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import prompts from 'prompts';
+import chalk from 'chalk';
+export interface ArchitecturePromptResult {
+  shouldContinueWithOldArch: boolean;
+  userCancelled: boolean;
+}
+
+export async function promptForArchitectureChoice(): Promise<ArchitecturePromptResult> {
+  try {
+    const response = await prompts(
+      {
+        type: 'text',
+        name: 'choice',
+        message: 'Would you like to continue using the Old Architecture? (Y/N)',
+        validate: (value: string) => {
+          const normalized = value.trim().toLowerCase();
+          if (normalized === 'y' || normalized === 'n') {
+            return true;
+          }
+          return "Invalid input. Please enter 'Y' for Yes or 'N' for No.";
+        },
+      },
+      {
+        onCancel: () => {
+          throw new Error('User cancelled');
+        },
+      },
+    );
+
+    if (!response.choice) {
+      return {shouldContinueWithOldArch: true, userCancelled: true};
+    }
+
+    const normalizedChoice = response.choice.trim().toLowerCase();
+    if (normalizedChoice === 'y') {
+      console.log(
+        chalk.yellow(
+          'Proceeding with Old Architecture. You can migrate later using our migration guide: https://microsoft.github.io/react-native-windows/docs/new-architecture',
+        ),
+      );
+      return {shouldContinueWithOldArch: true, userCancelled: false};
+    } else {
+      console.log(
+        chalk.green(
+          'Great choice! Setting up the project with New Architecture support.',
+        ),
+      );
+      return {shouldContinueWithOldArch: false, userCancelled: false};
+    }
+  } catch (error) {
+    if ((error as Error).message === 'User cancelled') {
+      return {shouldContinueWithOldArch: true, userCancelled: true};
+    }
+    console.log(
+      chalk.yellow(
+        'Proceeding with Old Architecture. You can migrate later using our migration guide: https://microsoft.github.io/react-native-windows/docs/new-architecture',
+      ),
+    );
+    return {shouldContinueWithOldArch: true, userCancelled: false};
+  }
+}

--- a/packages/@react-native-windows/cli/src/utils/oldArchWarning.ts
+++ b/packages/@react-native-windows/cli/src/utils/oldArchWarning.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import chalk from 'chalk';
+
+/**
+ * Displays a warning message about the Old Architecture template.
+ */
+export function showOldArchitectureWarning(): void {
+  console.log(
+    chalk.yellow(
+      `⚠️ This project is using the React Native (for Windows) Old Architecture. The old architecture will begin to be removed starting with react-native-windows@0.82.0.`,
+    ),
+  );
+  console.log();
+  console.log(
+    chalk.cyan(
+      '💡 It is strongly recommended to move to the new architecture as soon as possible to take advantage of improved performance, long-term support, and modern capabilities.',
+    ),
+  );
+  console.log();
+  console.log(
+    chalk.blue(
+      '🔗 Learn more: https://microsoft.github.io/react-native-windows/docs/new-architecture',
+    ),
+  );
+  console.log();
+}

--- a/packages/@react-native-windows/cli/src/utils/telemetryHelpers.ts
+++ b/packages/@react-native-windows/cli/src/utils/telemetryHelpers.ts
@@ -151,6 +151,8 @@ export async function startTelemetrySession(
 export async function endTelemetrySession(
   error?: Error,
   getExtraProps?: () => Promise<Record<string, any>>,
+  finalOptions?: Record<string, any>,
+  optionSanitizer?: (opts: Record<string, any>) => Record<string, any>,
 ) {
   if (!Telemetry.isEnabled()) {
     // Bail early so don't waste time here
@@ -166,8 +168,13 @@ export async function endTelemetrySession(
       error instanceof CodedError ? (error as CodedError).type : 'Unknown';
   }
 
-  Telemetry.endCommand(
-    endInfo,
-    getExtraProps ? await getExtraProps() : undefined,
-  );
+  // Get extra properties
+  const extraProps = getExtraProps ? await getExtraProps() : undefined;
+
+  // Sanitize and attach finalOptions if provided
+  if (finalOptions && optionSanitizer) {
+    endInfo.finalOptions = optionSanitizer(finalOptions);
+  }
+
+  Telemetry.endCommand(endInfo, extraProps);
 }

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -28,6 +28,7 @@ export interface CommandStartInfo {
 
 export interface CommandEndInfo {
   resultCode: errorUtils.CodedErrorType;
+  finalOptions?: Record<string, any>;
 }
 
 interface CommandInfo {

--- a/packages/@react-native-windows/tester/src/js/examples-win/DisplayNone/DisplayNoneExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/DisplayNone/DisplayNoneExample.windows.tsx
@@ -32,7 +32,12 @@ export class DisplayNoneExample extends React.Component<{}> {
               testID="textbox-container"
               style={{display: this.state.displayNone ? 'none' : 'flex'}}>
               <TextInput
-                style={{height: 40, borderColor: 'gray', borderWidth: 1}}
+                style={{
+                  height: 40,
+                  borderColor: 'gray',
+                  backgroundColor: 'white',
+                  borderWidth: 1,
+                }}
                 onChangeText={text => this._handleChangeText(text)}
                 value={this.state.textState}
               />

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -11743,6 +11743,7 @@ exports[`snapshotAllPages Display:none Style 1`] = `
                 onChangeText={[Function]}
                 style={
                   {
+                    "backgroundColor": "white",
                     "borderColor": "gray",
                     "borderWidth": 1,
                     "height": 40,

--- a/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
@@ -21,7 +21,7 @@ exports[`DisplayNoneTest DisplayNoneDisabledTest 1`] = `
   "XamlType": "Microsoft.ReactNative.ViewPanel",
   "children": [
     {
-      "Background": "#B3FFFFFF",
+      "Background": "#FFFFFFFF",
       "BorderBrush": "#FF808080",
       "BorderThickness": "1,1,1,1",
       "Clip": null,
@@ -57,7 +57,7 @@ exports[`DisplayNoneTest DisplayNoneDisabledTest 1`] = `
           "XamlType": "Windows.UI.Xaml.Controls.Grid",
           "children": [
             {
-              "Background": "#80F9F9F9",
+              "Background": "#FFFFFFFF",
               "BorderBrush": "#FF808080",
               "BorderThickness": "1,1,1,1",
               "Clip": null,
@@ -224,7 +224,7 @@ exports[`DisplayNoneTest DisplayNoneEnabledTest 1`] = `
   "XamlType": "Microsoft.ReactNative.ViewPanel",
   "children": [
     {
-      "Background": "#B3FFFFFF",
+      "Background": "#FFFFFFFF",
       "BorderBrush": "#FF808080",
       "BorderThickness": "1,1,1,1",
       "Clip": null,
@@ -260,7 +260,7 @@ exports[`DisplayNoneTest DisplayNoneEnabledTest 1`] = `
           "XamlType": "Windows.UI.Xaml.Controls.Grid",
           "children": [
             {
-              "Background": "#B3FFFFFF",
+              "Background": "#FFFFFFFF",
               "BorderBrush": "#FF808080",
               "BorderThickness": "1,1,1,1",
               "Clip": null,

--- a/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
@@ -57,7 +57,7 @@ exports[`DisplayNoneTest DisplayNoneDisabledTest 1`] = `
           "XamlType": "Windows.UI.Xaml.Controls.Grid",
           "children": [
             {
-              "Background": "#B3FFFFFF",
+              "Background": "#80F9F9F9",
               "BorderBrush": "#FF808080",
               "BorderThickness": "1,1,1,1",
               "Clip": null,


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves #15027

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

Adds a yes/no prompt in init-windows and if user wants new arch then will switch to that instead.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

### init-windows with No

<img width="853" height="227" alt="image" src="https://github.com/user-attachments/assets/a7507eab-2dfd-4014-86ff-371c49874f78" />

### init-windows with Yes

<img width="852" height="247" alt="image" src="https://github.com/user-attachments/assets/17044f8f-50d8-4bd6-ae7c-d6bc3d10017c" />

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

Tested locally

https://github.com/user-attachments/assets/42c4e53a-afaf-4f82-80d3-ef523af182de


Other Cases:
### 1. old/uwp-cpp-app

<img width="862" height="209" alt="image" src="https://github.com/user-attachments/assets/a9ebd71d-e63e-4ea6-a102-7bc4bd7221ac" />

### 2. old/uwp-cs-app

<img width="851" height="236" alt="image" src="https://github.com/user-attachments/assets/386f7c97-4ec9-4461-9822-baed07aa9998" />

### 3. cpp-app
<img width="853" height="137" alt="image" src="https://github.com/user-attachments/assets/bb831f32-4718-4ed3-a213-804bb9803ed1" />

### 4. cpp-lib
<img width="851" height="135" alt="image" src="https://github.com/user-attachments/assets/b68f5c4e-ba2e-4cfe-a655-0c5a8e00340e" />

### 5. --no-prompt
<img width="860" height="212" alt="image" src="https://github.com/user-attachments/assets/5d32264a-7ede-49fd-aa2b-b3f2b0b10ba5" />

## Changelog
Should this change be included in the release notes: _yes_

Add a brief summary of the change to use in the release notes for the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15070)