### PR TITLE
[Bug Fix] Deadlock in ReactRootView::ReactViewHost

### DIFF
--- a/change/react-native-windows-e5144fa3-1937-45ca-afee-6bcba8b3e0fe.json
+++ b/change/react-native-windows-e5144fa3-1937-45ca-afee-6bcba8b3e0fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Bug Fix] Deadlock in ReactRootView::ReactViewHost",
+  "packageName": "react-native-windows",
+  "email": "54227869+anupriya13@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -418,8 +418,8 @@ void ReactRootView::ReactViewHost(Mso::React::IReactViewHost *viewHost) noexcept
   }
 
   if (m_reactViewHost) {
-    UninitRootView();
     m_reactViewHost->DetachViewInstance();
+    UninitRootView();
   }
 
   m_reactViewHost = viewHost;


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

To fix deadlock issue

Resolves #15109

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

`ReactInstanceWin::DetachRootView `calls `runOnQueueSync`, which posts work to the UI queue while the UI thread itself is already blocked waiting on `ManualResetEvent::Wait`. Debugging confirmed `callbackFinished` was still `unsignaled` and both `ReactRootView::m_uiQueue` and `ReactInstanceWin::m_uiMessageQueue` point to the same UI dispatcher. This creates a classic deadlock: the UI thread is waiting for work that requires the UI thread to run. The root cause is the synchronous detach ordering in teardown.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

## Changelog
Should this change be included in the release notes: _no_

Add a brief summary of the change to use in the release notes for the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15110)