### PR TITLE
[0.74] Add reply count prop to AccessibilityAnnotationInfo (#15055)

### DIFF
--- a/change/@office-iss-react-native-win32-4719dc73-e282-43b7-b81e-73f7be41577c.json
+++ b/change/@office-iss-react-native-win32-4719dc73-e282-43b7-b81e-73f7be41577c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add reply count prop to AccessibilityAnnotationInfo",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "mmaring@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src-win/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/@office-iss/react-native-win32/src-win/Libraries/Components/View/ViewAccessibility.d.ts
@@ -402,6 +402,7 @@ export type AccessibilityAnnotationInfo = Readonly<{
   author?: string;
   dateTime?: string;
   target?: string;
+  replyCount?: number;
 }>;
 
 // [Win32]


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
This PR backports to #15055 to RNW 0.74.

Original description:
Screen reader consumers of react native UI using AccessibilityAnnotationInfo are trying to determine how many replies to a post with AccessibilityAnnotationInfo also have AccessibilityAnnotationInfo attached to them. This requires some hacky logic on the screen reader side to determine, so it was requested that we expose this through a new property similar to how the author/datetime of the post is already exposed.

### What
This PR adds a reply count prop to AccessibilityAnnotationInfo, which is used to indicate the number of replies to a particular post/annotation (i.e. children in the view heiarchy that also use AccessibilityAnnotationInfo).

## Testing
No impact to this repository, as AccessibilityAnnotationInfo is only defined here, but it not used.

## Changelog
Should this change be included in the release notes: yes

Add a brief summary of the change to use in the release notes for the next release.
Add reply count prop to AccessibilityAnnotationInfo
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15138)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15140)