### PR TITLE
Update telemetry test to use localId instead of deviceId for consistency

### DIFF
--- a/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
@@ -365,6 +365,11 @@ function verifyTestCommandTelemetryProcessor(
       // Verify basics
       const commonProperties = properties!.common;
       expect(commonProperties.commandName).toBe('test-command');
+      // Verify LocalId
+      const expectedLocalId = TelemetryTest.getCommonProperty('deviceId');
+      expect(envelope.ext?.device?.localId).toBeDefined();
+      expect(envelope.ext?.device?.localId).toBe(expectedLocalId);
+      expect(commonProperties.localId).toBe(expectedLocalId); // Only if you know it's set in the event, not in static commonProperties
 
       // Verify versions info
       const versions = properties!.versions;

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -369,7 +369,7 @@ export class Telemetry {
     // Populate Part A extensions
     telemetryItem.ext = {};
     telemetryItem.ext.device = {
-      id: Telemetry.commonProperties.deviceId,
+      localId: Telemetry.commonProperties.deviceId,
       deviceClass: Telemetry.commonProperties.deviceClass,
     };
     telemetryItem.ext.os = {
@@ -394,6 +394,7 @@ export class Telemetry {
         isCliTest: Telemetry.commonProperties.isTest,
         sessionId: Telemetry.commonProperties.sessionId,
         commandName: Telemetry.commonProperties.commandName,
+        localId: Telemetry.commonProperties.deviceId,
       },
       // Set project and versions props, belonging to Part B.
       project: Telemetry.projectProp,


### PR DESCRIPTION
## Description
Changed telemetry test property key from `deviceId` to `localId` to align with telemetry transmission naming conventions.
- In telemetry envelopes, the device identifier is transmitted as `localId` (in `envelope.ext.device.localId`)
- Using `localId` as the property key creates consistency between storage and transmission naming
### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Kusto database queries are not showing deviceId field in telemetry data
Resolves [Add Relevant Issue Here]

### What
Changed telemetry test property key from `deviceId` to `localId` to align with telemetry transmission naming conventions.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
<img width="1407" height="834" alt="image" src="https://github.com/user-attachments/assets/5c9ea095-73c5-4820-aaf2-3dc2d212432d" />

## Changelog
Should this change be included in the release notes: no

Add a brief summary of the change to use in the release notes for the next release.
