### PR TITLE
[0.80][Fabric] Fix UIA Clipped Property for Modal Component

### DIFF
--- a/change/react-native-windows-aca77b5b-e0c0-4051-bb1d-70c3e69bec86.json
+++ b/change/react-native-windows-aca77b5b-e0c0-4051-bb1d-70c3e69bec86.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fixing Clipped Property for Modal Component",
+  "packageName": "react-native-windows",
+  "email": "kvineeth@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -561,7 +561,29 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
     }
     case UIA_IsOffscreenPropertyId: {
       pRetVal->vt = VT_BOOL;
-      pRetVal->boolVal = (compositionView->getClipState() == ClipState::FullyClipped) ? VARIANT_TRUE : VARIANT_FALSE;
+
+      // Special handling for modal content - check if component is in a popup/modal window
+      bool isOffscreen = true;
+      auto clipState = compositionView->getClipState();
+
+      if (clipState != ClipState::FullyClipped) {
+        isOffscreen = false;
+      } else {
+        // Component appears clipped, but check if it's modal content
+        // Modal content may appear clipped due to lack of parent relationships
+        // but should still be considered visible if it's in its own window
+        if (auto hwnd = compositionView->GetHwndForParenting()) {
+          // Check if this window is visible and not minimized
+          if (IsWindowVisible(hwnd) && !IsIconic(hwnd)) {
+            isOffscreen = false; // Window is visible, so content is not offscreen
+          }
+        } else {
+          // If we can't get window info, fall back to clip state
+          isOffscreen = true;
+        }
+      }
+
+      pRetVal->boolVal = isOffscreen ? VARIANT_TRUE : VARIANT_FALSE;
       break;
     }
     case UIA_HelpTextPropertyId: {


### PR DESCRIPTION
# Description
Fixing UIA Clipping property for Modal Component.
Cherry-pick cc9d7a0

## Type of Change
Bug fix

## Why
Will fix the UIA clipping state of Modal Component.
Resolves [microsoft/react-native-gallery/issues/650]

# Screenshots
<img width="1570" height="1208" alt="image" src="https://github.com/user-attachments/assets/a5f5dd97-b2ee-44e7-ab6e-f05d69074e69" />

# Changelog
Should this change be included in the release notes: _yes_

UIA Clipping property for Modal Component is fixed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15184)