### PR TITLE
Fix for heading level for accessibility

### DIFF
--- a/change/react-native-windows-48182af8-4e3f-46a5-a980-f041f56ff6ce.json
+++ b/change/react-native-windows-48182af8-4e3f-46a5-a980-f041f56ff6ce.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Fixing heading level for accessibility",
+  "type": "prerelease",
+  "packageName": "react-native-windows",
+  "email": "protikbiswas100@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -8,6 +8,7 @@
 #include <Fabric/Composition/SwitchComponentView.h>
 #include <Fabric/Composition/TextInput/WindowsTextInputComponentView.h>
 #include <Unicode.h>
+#include <react/renderer/components/view/HostPlatformViewProps.h>
 #include <winrt/Microsoft.UI.Content.h>
 #include "RootComponentView.h"
 #include "UiaHelpers.h"
@@ -484,6 +485,9 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
   if (props == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;
 
+  // Cast to HostPlatformViewProps to access Windows-specific properties like accessibilityLevel
+  auto hostProps = std::static_pointer_cast<const facebook::react::HostPlatformViewProps>(baseView->props());
+
   auto compositionView = strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
   if (compositionView == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;
@@ -597,17 +601,17 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
     }
     case UIA_PositionInSetPropertyId: {
       pRetVal->vt = VT_I4;
-      pRetVal->lVal = props->accessibilityPosInSet;
+      pRetVal->lVal = hostProps ? hostProps->accessibilityPosInSet : 0;
       break;
     }
     case UIA_SizeOfSetPropertyId: {
       pRetVal->vt = VT_I4;
-      pRetVal->lVal = props->accessibilitySetSize;
+      pRetVal->lVal = hostProps ? hostProps->accessibilitySetSize : 0;
       break;
     }
     case UIA_LiveSettingPropertyId: {
       pRetVal->vt = VT_I4;
-      pRetVal->lVal = GetLiveSetting(props->accessibilityLiveRegion);
+      pRetVal->lVal = GetLiveSetting(hostProps ? hostProps->accessibilityLiveRegion : "none");
       break;
     }
     case UIA_ItemStatusPropertyId: {
@@ -619,24 +623,27 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
     }
     case UIA_LevelPropertyId: {
       pRetVal->vt = VT_I4;
-      pRetVal->lVal = props->accessibilityLevel;
+      pRetVal->lVal = hostProps ? hostProps->accessibilityLevel : 0;
       break;
     }
     case UIA_AccessKeyPropertyId: {
       pRetVal->vt = VT_BSTR;
-      auto accessKey = ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityAccessKey.value_or(""));
+      auto accessKey =
+          ::Microsoft::Common::Unicode::Utf8ToUtf16(hostProps ? hostProps->accessibilityAccessKey.value_or("") : "");
       pRetVal->bstrVal = SysAllocString(accessKey.c_str());
       break;
     }
     case UIA_ItemTypePropertyId: {
       pRetVal->vt = VT_BSTR;
-      auto itemtype = ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityItemType.value_or(""));
+      auto itemtype =
+          ::Microsoft::Common::Unicode::Utf8ToUtf16(hostProps ? hostProps->accessibilityItemType.value_or("") : "");
       pRetVal->bstrVal = SysAllocString(itemtype.c_str());
       break;
     }
     case UIA_FullDescriptionPropertyId: {
       pRetVal->vt = VT_BSTR;
-      auto desc = ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityDescription.value_or(""));
+      auto desc =
+          ::Microsoft::Common::Unicode::Utf8ToUtf16(hostProps ? hostProps->accessibilityDescription.value_or("") : "");
       pRetVal->bstrVal = SysAllocString(desc.c_str());
       break;
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -481,12 +481,13 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
   if (baseView == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;
 
-  auto props = std::static_pointer_cast<const facebook::react::ViewProps>(baseView->props());
+  // Try to cast to HostPlatformViewProps first for Windows-specific properties
+  auto hostProps = std::dynamic_pointer_cast<const facebook::react::HostPlatformViewProps>(baseView->props());
+
+  // If that fails, fall back to ViewProps for basic accessibility properties
+  auto props = hostProps ? hostProps : std::static_pointer_cast<const facebook::react::ViewProps>(baseView->props());
   if (props == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;
-
-  // Cast to HostPlatformViewProps to access Windows-specific properties like accessibilityLevel
-  auto hostProps = std::static_pointer_cast<const facebook::react::HostPlatformViewProps>(baseView->props());
 
   auto compositionView = strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
   if (compositionView == nullptr)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -486,7 +486,11 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
     return UIA_E_ELEMENTNOTAVAILABLE;
 
   // Cast to HostPlatformViewProps to access Windows-specific properties like accessibilityLevel
-  auto hostProps = std::static_pointer_cast<const facebook::react::HostPlatformViewProps>(baseView->props());
+  auto hostProps = std::dynamic_pointer_cast<const facebook::react::HostPlatformViewProps>(baseView->props());
+  if (hostProps == nullptr) {
+    // If hostProps is needed later, handle the null case appropriately.
+    // For now, we just proceed; add error handling if hostProps is dereferenced below.
+  }
 
   auto compositionView = strongView.try_as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
   if (compositionView == nullptr)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -16,6 +16,7 @@
 #include <Utils/ValueUtils.h>
 #include <Views/FrameworkElementTransferProperties.h>
 #include <atlcomcli.h>
+#include <react/renderer/components/view/HostPlatformViewProps.h>
 #include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.UI.Composition.h>
@@ -747,6 +748,10 @@ void ComponentView::updateAccessibilityProps(
   if (!UiaClientsAreListening())
     return;
 
+  // Cast to HostPlatformViewProps to access Windows-specific properties
+  auto oldHostProps = static_cast<const facebook::react::HostPlatformViewProps *>(&oldViewProps);
+  auto newHostProps = static_cast<const facebook::react::HostPlatformViewProps *>(&newViewProps);
+
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(), UIA_IsKeyboardFocusablePropertyId, oldViewProps.focusable, newViewProps.focusable);
 
@@ -789,41 +794,41 @@ void ComponentView::updateAccessibilityProps(
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_PositionInSetPropertyId,
-      oldViewProps.accessibilityPosInSet,
-      newViewProps.accessibilityPosInSet);
+      oldHostProps->accessibilityPosInSet,
+      newHostProps->accessibilityPosInSet);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_SizeOfSetPropertyId,
-      oldViewProps.accessibilitySetSize,
-      newViewProps.accessibilitySetSize);
+      oldHostProps->accessibilitySetSize,
+      newHostProps->accessibilitySetSize);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_LiveSettingPropertyId,
-      oldViewProps.accessibilityLiveRegion,
-      newViewProps.accessibilityLiveRegion);
+      oldHostProps->accessibilityLiveRegion,
+      newHostProps->accessibilityLiveRegion);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(), UIA_LevelPropertyId, oldViewProps.accessibilityLevel, newViewProps.accessibilityLevel);
+      EnsureUiaProvider(), UIA_LevelPropertyId, oldHostProps->accessibilityLevel, newHostProps->accessibilityLevel);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_AccessKeyPropertyId,
-      oldViewProps.accessibilityAccessKey,
-      newViewProps.accessibilityAccessKey);
+      oldHostProps->accessibilityAccessKey,
+      newHostProps->accessibilityAccessKey);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_ItemTypePropertyId,
-      oldViewProps.accessibilityItemType,
-      newViewProps.accessibilityItemType);
+      oldHostProps->accessibilityItemType,
+      newHostProps->accessibilityItemType);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_FullDescriptionPropertyId,
-      oldViewProps.accessibilityDescription,
-      newViewProps.accessibilityDescription);
+      oldHostProps->accessibilityDescription,
+      newHostProps->accessibilityDescription);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
@@ -833,7 +838,7 @@ void ComponentView::updateAccessibilityProps(
 
   // Handle annotation properties with single call
   winrt::Microsoft::ReactNative::implementation::UpdateUiaPropertiesForAnnotation(
-      EnsureUiaProvider(), oldViewProps.accessibilityAnnotation, newViewProps.accessibilityAnnotation);
+      EnsureUiaProvider(), oldHostProps->accessibilityAnnotation, newHostProps->accessibilityAnnotation);
 
   // Handle expand/collapse state changes
   if (oldViewProps.accessibilityState.has_value() != newViewProps.accessibilityState.has_value() ||

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -748,9 +748,9 @@ void ComponentView::updateAccessibilityProps(
   if (!UiaClientsAreListening())
     return;
 
-  // Cast to HostPlatformViewProps to access Windows-specific properties
-  auto oldHostProps = static_cast<const facebook::react::HostPlatformViewProps *>(&oldViewProps);
-  auto newHostProps = static_cast<const facebook::react::HostPlatformViewProps *>(&newViewProps);
+  // Try to safely cast to HostPlatformViewProps to access Windows-specific properties
+  auto oldHostProps = dynamic_cast<const facebook::react::HostPlatformViewProps *>(&oldViewProps);
+  auto newHostProps = dynamic_cast<const facebook::react::HostPlatformViewProps *>(&newViewProps);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(), UIA_IsKeyboardFocusablePropertyId, oldViewProps.focusable, newViewProps.focusable);
@@ -791,54 +791,57 @@ void ComponentView::updateAccessibilityProps(
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(), UIA_HelpTextPropertyId, oldViewProps.accessibilityHint, newViewProps.accessibilityHint);
 
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(),
-      UIA_PositionInSetPropertyId,
-      oldHostProps->accessibilityPosInSet,
-      newHostProps->accessibilityPosInSet);
+  // Only update Windows-specific properties if we have HostPlatformViewProps
+  if (oldHostProps && newHostProps) {
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+        EnsureUiaProvider(),
+        UIA_PositionInSetPropertyId,
+        oldHostProps->accessibilityPosInSet,
+        newHostProps->accessibilityPosInSet);
 
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(),
-      UIA_SizeOfSetPropertyId,
-      oldHostProps->accessibilitySetSize,
-      newHostProps->accessibilitySetSize);
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+        EnsureUiaProvider(),
+        UIA_SizeOfSetPropertyId,
+        oldHostProps->accessibilitySetSize,
+        newHostProps->accessibilitySetSize);
 
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(),
-      UIA_LiveSettingPropertyId,
-      oldHostProps->accessibilityLiveRegion,
-      newHostProps->accessibilityLiveRegion);
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+        EnsureUiaProvider(),
+        UIA_LiveSettingPropertyId,
+        oldHostProps->accessibilityLiveRegion,
+        newHostProps->accessibilityLiveRegion);
 
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(), UIA_LevelPropertyId, oldHostProps->accessibilityLevel, newHostProps->accessibilityLevel);
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+        EnsureUiaProvider(), UIA_LevelPropertyId, oldHostProps->accessibilityLevel, newHostProps->accessibilityLevel);
 
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(),
-      UIA_AccessKeyPropertyId,
-      oldHostProps->accessibilityAccessKey,
-      newHostProps->accessibilityAccessKey);
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+        EnsureUiaProvider(),
+        UIA_AccessKeyPropertyId,
+        oldHostProps->accessibilityAccessKey,
+        newHostProps->accessibilityAccessKey);
 
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(),
-      UIA_ItemTypePropertyId,
-      oldHostProps->accessibilityItemType,
-      newHostProps->accessibilityItemType);
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+        EnsureUiaProvider(),
+        UIA_ItemTypePropertyId,
+        oldHostProps->accessibilityItemType,
+        newHostProps->accessibilityItemType);
 
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      EnsureUiaProvider(),
-      UIA_FullDescriptionPropertyId,
-      oldHostProps->accessibilityDescription,
-      newHostProps->accessibilityDescription);
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+        EnsureUiaProvider(),
+        UIA_FullDescriptionPropertyId,
+        oldHostProps->accessibilityDescription,
+        newHostProps->accessibilityDescription);
+
+    // Handle annotation properties with single call
+    winrt::Microsoft::ReactNative::implementation::UpdateUiaPropertiesForAnnotation(
+        EnsureUiaProvider(), oldHostProps->accessibilityAnnotation, newHostProps->accessibilityAnnotation);
+  }
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(),
       UIA_ValueValuePropertyId,
       oldViewProps.accessibilityValue.text,
       newViewProps.accessibilityValue.text);
-
-  // Handle annotation properties with single call
-  winrt::Microsoft::ReactNative::implementation::UpdateUiaPropertiesForAnnotation(
-      EnsureUiaProvider(), oldHostProps->accessibilityAnnotation, newHostProps->accessibilityAnnotation);
 
   // Handle expand/collapse state changes
   if (oldViewProps.accessibilityState.has_value() != newViewProps.accessibilityState.has_value() ||

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -749,8 +749,12 @@ void ComponentView::updateAccessibilityProps(
     return;
 
   // Cast to HostPlatformViewProps to access Windows-specific properties
-  auto oldHostProps = static_cast<const facebook::react::HostPlatformViewProps *>(&oldViewProps);
-  auto newHostProps = static_cast<const facebook::react::HostPlatformViewProps *>(&newViewProps);
+  auto oldHostProps = dynamic_cast<const facebook::react::HostPlatformViewProps *>(&oldViewProps);
+  auto newHostProps = dynamic_cast<const facebook::react::HostPlatformViewProps *>(&newViewProps);
+  if (!oldHostProps || !newHostProps) {
+    // The cast failed; cannot safely access HostPlatformViewProps-specific members.
+    return;
+  }
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       EnsureUiaProvider(), UIA_IsKeyboardFocusablePropertyId, oldViewProps.focusable, newViewProps.focusable);


### PR DESCRIPTION
## Description
The issue was that accessibilityLevel prop was not working properly in React Native Windows Fabric architecture. While the prop was defined in TypeScript and JavaScript, and the UIA (UI Automation) infrastructure existed, there was a casting problem in the native layer.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Fixes
https://github.com/microsoft/react-native-gallery/issues/699

### Why
heading level for accessibility is not defined 


### What
CompositionDynamicAutomationProvider.cpp and CompositionViewComponentView.cpp were incorrectly casting props to the base facebook::react::ViewProps class instead of the Windows-specific facebook::react::HostPlatformViewProps class where the accessibilityLevel property is actually defined.

## Testing
yarn install && yarn build passed

Tested view component in playground app

https://github.com/user-attachments/assets/3b4af3d6-d79f-489b-91cc-a24a26cdb461



## Changelog
Should this change be included in the release notes: yes 

Add a brief summary of the change to use in the release notes for the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15193)