### PR TITLE
[0.80] Bump screenshot-desktop from 1.15.1 to 1.15.2 for component governance

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10203,9 +10203,9 @@ scheduler@^0.25.0:
   integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==
 
 screenshot-desktop@^1.12.2:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/screenshot-desktop/-/screenshot-desktop-1.15.1.tgz#3fa91d25557daf5022d9add82acc8a2b20f0bc2e"
-  integrity sha512-4j9bDZSFnkRqH53bAw5W+ZhdGKiTUcUDohO6NZjL6QSC/6AXbhUqJ9YXygjHrYcSOUD4IcLty6uQ1ES7PSsomg==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/screenshot-desktop/-/screenshot-desktop-1.15.2.tgz#21489e1b4ac779659460cf65dc8db6f84023f30d"
+  integrity sha512-/uf8xhq3n/Ym7oOKT4XF1uLAYP9njABB9zMw7kkOaDVr8XOO1HBQsNJXT8lUvzD26Uj8IYkwQX46UMZG4Y/dIQ==
   dependencies:
     temp "^0.9.4"
 


### PR DESCRIPTION
## Description
Upgraded the following packages
screenshot-desktop from 1.15.1 to 1.15.2
### Type of Change
- Bug fix (non-breaking change which fixes an issue)
### Why
When user-controlled input is passed into the format option of the screenshot function, it is interpolated into a shell command without sanitization.The issue has been patched in version 1.15.2.All users are strongly recommended to upgrade to 1.15.2 or later
Resolves #15187 

### What

Updated the yarn.lock to point to the new versions.

Steps to upgrade:

Delete the older version from yarn.lock file
Execute yarn command so it can fetch the new versions.

## Screenshots
<img width="796" height="326" alt="image" src="https://github.com/user-attachments/assets/ab53937e-6fc2-4e7b-b07b-bc7a1124dd00" />

## Changelog
Should this change be included in the release notes: no_


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15197)