### PR TITLE
[0.79] Bump  tar-fs from 3.0.9 to 3.1.1 &  2.1.3 to 2.1.4 for component governance

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11123,9 +11123,9 @@ table-layout@^1.0.2:
     wordwrapjs "^4.0.0"
 
 tar-fs@^2.0.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.3.tgz#fb3b8843a26b6f13a08e606f7922875eb1fbbf92"
-  integrity sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.4.tgz#800824dbf4ef06ded9afea4acafe71c67c76b930"
+  integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -11133,9 +11133,9 @@ tar-fs@^2.0.0:
     tar-stream "^2.1.4"
 
 tar-fs@^3.0.6:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.0.tgz#4675e2254d81410e609d91581a762608de999d25"
-  integrity sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
+  integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
## Description
Upgraded following packages
tar-fs from 3.0.9 to 3.1.1 
tar-fs from  2.1.3 to 2.1.4 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Upgraded to tar-fs to fix security vulnerabilities

Resolves #15200 

### What
Updated the yarn.lock to point to the new versions.

Steps to upgrade:

Delete the older version from yarn.lock file
Execute yarn command so it can fetch the new versions.

## Screenshots
<img width="1315" height="356" alt="image" src="https://github.com/user-attachments/assets/8b62e9cf-d80c-44fe-82a4-b55b34ff6abb" />

## Changelog
Should this change be included in the release notes: _indicate :no_


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15199)