### PR TITLE
[0.78] Upgrade to dotnet 8

### DIFF
--- a/.ado/image/rnw-img-vs2022-node18.json
+++ b/.ado/image/rnw-img-vs2022-node18.json
@@ -61,6 +61,12 @@
             "parameters": {
                 "DotNetCoreVersion": "6.0.403"
             }
+        },
+        {
+            "name": "windows-dotnetcore-sdk",
+            "parameters": {
+                "DotNetCoreVersion": "8.0.413"
+            }
         }
     ]
 }

--- a/change/@react-native-windows-cli-8af3b340-b959-4154-9057-6ec040e82150.json
+++ b/change/@react-native-windows-cli-8af3b340-b959-4154-9057-6ec040e82150.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "upgrade to dotnet8",
+  "packageName": "@react-native-windows/cli",
+  "email": "10109130+sharath2727@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-87037c9a-0b79-4a87-a88a-d99aa9e181c3.json
+++ b/change/react-native-windows-87037c9a-0b79-4a87-a88a-d99aa9e181c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "upgrade to dotnet8",
+  "packageName": "react-native-windows",
+  "email": "10109130+sharath2727@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/healthCheck/healthCheckList.ts
+++ b/packages/@react-native-windows/cli/src/commands/healthCheck/healthCheckList.ts
@@ -14,5 +14,5 @@ export const HealthCheckList = [
   [true, 'VSUWP', 'Visual Studio 2022 (>= 17.11.0) & req. components'],
   [true, 'Node', 'Node.js (LTS, >= 18.18)'],
   [true, 'Yarn', 'Yarn'],
-  [true, 'DotNetCore', '.NET SDK (LTS, = 6.0)'],
+  [true, 'DotNetCore', '.NET SDK (LTS, = 8.0)'],
 ];

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net8.0": {
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[3.1.2, )",
@@ -1610,7 +1610,7 @@
         }
       }
     },
-    "net6.0/win-x64": {
+    "net8.0/win-x64": {
       "Microsoft.Win32.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Debug.pubxml
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Debug.pubxml
@@ -6,7 +6,7 @@
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Debug</Configuration>
     <Platform>x64</Platform>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PublishDir>$(OutDir)publish</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Release.pubxml
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Release.pubxml
@@ -6,7 +6,7 @@
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PublishDir>$(OutDir)publish</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net8.0": {
       "Humanizer": {
         "type": "Direct",
         "requested": "[2.14.1, )",
@@ -1507,7 +1507,7 @@
         }
       }
     },
-    "net6.0/win-x64": {
+    "net8.0/win-x64": {
       "Microsoft.Win32.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2350,7 +2350,7 @@
         }
       }
     },
-    "net6.0/win-x86": {
+    "net8.0/win-x86": {
       "Microsoft.Win32.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -88,9 +88,9 @@ $wingetver = "1.7.11261";
 $vsver = "17.11.0";
 
 # The exact .NET SDK version to check for
-$dotnetver = "6.0";
+$dotnetver = "8.0";
 # Version name of the winget package
-$wingetDotNetVer = "6";
+$wingetDotNetVer = "8";
 
 $v = [System.Environment]::OSVersion.Version;
 if ($env:Agent_BuildDirectory) {


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
PR Pipelines are blocked as .NET6 is no longer supported.

Resolves https://github.com/microsoft/react-native-windows/issues/15149

### What
Updated individual projects to net8.0 framework
Ensured all the nuget packages are installed from the pipeline
Ensured net8 artifact is installed on the VM.

## Testing
All tests are passing on Pipeline

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15203)