### PR TITLE
Fix INVALID_PARAMETER crash in ThreadPoolSchedulerWin::Post by adding null handle checks

### DIFF
--- a/change/react-native-windows-fb6d576d-7feb-4fe6-8d4d-0fb028f8a011.json
+++ b/change/react-native-windows-fb6d576d-7feb-4fe6-8d4d-0fb028f8a011.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix for watson",
+  "packageName": "react-native-windows",
+  "email": "hmalothu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/src/dispatchQueue/threadPoolScheduler_win.cpp
+++ b/vnext/Mso/src/dispatchQueue/threadPoolScheduler_win.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <utility>
 #include <stdexcept> // For std::runtime_error
+#include <utility>
 #include "dispatchQueue/dispatchQueue.h"
 #include "queueService.h"
 
@@ -97,7 +97,7 @@ std::vector<std::shared_ptr<TP_WORK>> ThreadPoolSchedulerWin::s_trackedThreadPoo
 ThreadPoolSchedulerWin::ThreadPoolSchedulerWin(uint32_t maxThreads)
     : m_maxThreads{maxThreads == 0 ? MaxConcurrentThreads : maxThreads} {
   // Create thread pool work
-  TP_WORK* tpWork = ::CreateThreadpoolWork(WorkCallback, this, nullptr);
+  TP_WORK *tpWork = ::CreateThreadpoolWork(WorkCallback, this, nullptr);
 
   // Throw immediately if creation failed
   if (!tpWork) {

--- a/vnext/Mso/src/dispatchQueue/threadPoolScheduler_win.cpp
+++ b/vnext/Mso/src/dispatchQueue/threadPoolScheduler_win.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include <utility>
+#include <stdexcept> // For std::runtime_error
 #include "dispatchQueue/dispatchQueue.h"
 #include "queueService.h"
 
@@ -14,7 +15,7 @@ struct ThreadPoolWorkDeleter {
 };
 
 struct ThreadPoolSchedulerWin : Mso::UnknownObject<IDispatchQueueScheduler> {
-  ThreadPoolSchedulerWin(uint32_t maxThreads) noexcept;
+  ThreadPoolSchedulerWin(uint32_t maxThreads);
   ~ThreadPoolSchedulerWin() noexcept override;
 
   static void __stdcall WorkCallback(
@@ -93,9 +94,17 @@ std::mutex ThreadPoolSchedulerWin::s_threadPoolWorkMutex;
 bool ThreadPoolSchedulerWin::s_enableThreadPoolWorkTracking{false};
 std::vector<std::shared_ptr<TP_WORK>> ThreadPoolSchedulerWin::s_trackedThreadPoolWork;
 
-ThreadPoolSchedulerWin::ThreadPoolSchedulerWin(uint32_t maxThreads) noexcept
-    : m_threadPoolWork{::CreateThreadpoolWork(WorkCallback, this, nullptr), ThreadPoolWorkDeleter{}},
-      m_maxThreads{maxThreads == 0 ? MaxConcurrentThreads : maxThreads} {
+ThreadPoolSchedulerWin::ThreadPoolSchedulerWin(uint32_t maxThreads)
+    : m_maxThreads{maxThreads == 0 ? MaxConcurrentThreads : maxThreads} {
+  // Create thread pool work
+  TP_WORK* tpWork = ::CreateThreadpoolWork(WorkCallback, this, nullptr);
+
+  // Throw immediately if creation failed
+  if (!tpWork) {
+    throw std::runtime_error("Failed to create thread pool work");
+  }
+
+  m_threadPoolWork = std::shared_ptr<TP_WORK>(tpWork, ThreadPoolWorkDeleter{});
   TrackThreadPoolWork(m_threadPoolWork);
 }
 


### PR DESCRIPTION
## Description
Fix for an watson bug in the ThreadPoolSchedulerWin constructor where the error handling logic for thread pool creation was improperly implemented.
### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Fixed an issue in `ThreadPoolSchedulerWin` constructor where the error handling condition was incorrectly implemented. 
.
Resolves #15099 

### What
Updated the ThreadPoolSchedulerWin constructor to properly detect thread pool creation failures and throw an exception when necessary.
**https://github.com/microsoft/react-native-windows/pull/15150#issuecomment-3371716814--This conversation highlights how the change was implemented**

## Testing
all builds and apps are successfully running

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate  no_

Add a brief summary of the change to use in the release notes for the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15209)