### PR TITLE
[Fix] JSI RuntimeData test compilation errors with UUID namespace and override specifiers

### DIFF
--- a/change/react-native-windows-0f849b5f-40cc-4647-829d-3358479ea031.json
+++ b/change/react-native-windows-0f849b5f-40cc-4647-829d-3358479ea031.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fixed testcli.cpp tests related setruntimedataimpl and getruntimedataimpl",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/jsi/jsi/test/testlib.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/jsi/jsi/test/testlib.cpp
@@ -1767,11 +1767,11 @@ TEST_P(JSITest, SetRuntimeData) {
   };
 
   RD rd1 = RD(rt);
-  facebook::jsi::UUID uuid1{0xe67ab3d6, 0x09a0, 0x11f0, 0xa641, 0x325096b39f47};
+  facebook::jsi::UUID uuid1{0xe67ab3d6u, 0x09a0u, 0x11f0u, 0xa641u, 0x325096b39f47ull};
   auto str = std::make_shared<std::string>("hello world");
   rd1.setRuntimeData(uuid1, str);
 
-  facebook::jsi::UUID uuid2{0xa12f99fc, 0x09a2, 0x11f0, 0x84de, 0x325096b39f47};
+  facebook::jsi::UUID uuid2{0xa12f99fcu, 0x09a2u, 0x11f0u, 0x84deu, 0x325096b39f47ull};
   auto obj1 = std::make_shared<Object>(rd1);
   rd1.setRuntimeData(uuid2, obj1);
 
@@ -1792,7 +1792,7 @@ TEST_P(JSITest, SetRuntimeData) {
 
   auto rt2 = factory();
   RD* rd2 = new RD(*rt2);
-  facebook::jsi::UUID uuid3{0x16f55892, 0x1034, 0x11f0, 0x8f65, 0x325096b39f47};
+  facebook::jsi::UUID uuid3{0x16f55892u, 0x1034u, 0x11f0u, 0x8f65u, 0x325096b39f47ull};
   auto obj2 = std::make_shared<Object>(*rd2);
   rd2->setRuntimeData(uuid3, obj2);
 
@@ -1823,7 +1823,7 @@ TEST_P(JSITest, SetRuntimeData) {
   // clean up the custom data.
   auto rt3 = factory();
   RD* rd3 = new RD(*rt3);
-  UUID uuid4{0xa5682986, 0x1edc, 0x11f0, 0xa4fa, 0x325096b39f47};
+  facebook::jsi::UUID uuid4{0xa5682986u, 0x1edcu, 0x11f0u, 0xa4fau, 0x325096b39f47ull};
   rd3->global()
       .getPropertyAsObject(*rd3, "Object")
       .setProperty(*rd3, "defineProperty", Value(false));
@@ -1844,13 +1844,13 @@ TEST_P(JSITest, CastInterface) {
    public:
     explicit RD(Runtime& rt) : RuntimeDecorator(rt) {}
 
-    ICast* castInterface(const UUID& interfaceUuid) override {
+    ICast* castInterface(const facebook::jsi::UUID& interfaceUuid) override {
       return Runtime::castInterface(interfaceUuid);
     }
   };
 
   RD rd = RD(rt);
-  auto randomUuid = UUID{0xf2cd96cf, 0x455e, 0x42d9, 0x850a, 0x13e2cde59b8b};
+  auto randomUuid = facebook::jsi::UUID{0xf2cd96cfu, 0x455eu, 0x42d9u, 0x850au, 0x13e2cde59b8bull};
   auto ptr = rd.castInterface(randomUuid);
 
   EXPECT_EQ(ptr, nullptr);

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/jsi/jsi/test/testlib.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/jsi/jsi/test/testlib.cpp
@@ -1758,11 +1758,11 @@ TEST_P(JSITest, SetRuntimeData) {
         const facebook::jsi::UUID& uuid,
         const void* data,
         void (*deleter)(const void* data)) override {
-      RuntimeDecorator::setRuntimeDataImpl(uuid, data, deleter);
+      Runtime::setRuntimeDataImpl(uuid, data, deleter);
     }
 
     const void* getRuntimeDataImpl(const facebook::jsi::UUID& uuid) override {
-      return RuntimeDecorator::getRuntimeDataImpl(uuid);
+      return Runtime::getRuntimeDataImpl(uuid);
     }
   };
 

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/jsi/jsi/test/testlib.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/jsi/jsi/test/testlib.cpp
@@ -1658,10 +1658,7 @@ TEST_P(JSITest, CreateFromUtf16Test) {
   auto cp = eval("loneSurrogate.charCodeAt(0)").getNumber();
   EXPECT_EQ(cp, 55357); // 0xD83D in decimal
 }
-Windows] */
 
-/*
-[Windows 
 TEST_P(JSITest, GetStringDataTest) {
   // This Runtime Decorator is used to test the default getStringData
   // implementation for VMs that do not provide their own implementation
@@ -1752,31 +1749,29 @@ TEST_P(JSITest, ObjectCreateWithPrototype) {
 }
 Windows] */
 
-/* [Windows #15134 Uncomment this and solve the JSI TEST issues
-
 TEST_P(JSITest, SetRuntimeData) {
   class RD : public RuntimeDecorator<Runtime, Runtime> {
    public:
     explicit RD(Runtime& rt) : RuntimeDecorator(rt) {}
 
     void setRuntimeDataImpl(
-        const UUID& uuid,
+        const facebook::jsi::UUID& uuid,
         const void* data,
         void (*deleter)(const void* data)) override {
-      Runtime::setRuntimeDataImpl(uuid, data, deleter);
+      RuntimeDecorator::setRuntimeDataImpl(uuid, data, deleter);
     }
 
-    const void* getRuntimeDataImpl(const UUID& uuid) override {
-      return Runtime::getRuntimeDataImpl(uuid);
+    const void* getRuntimeDataImpl(const facebook::jsi::UUID& uuid) override {
+      return RuntimeDecorator::getRuntimeDataImpl(uuid);
     }
   };
 
   RD rd1 = RD(rt);
-  UUID uuid1{0xe67ab3d6, 0x09a0, 0x11f0, 0xa641, 0x325096b39f47};
+  facebook::jsi::UUID uuid1{0xe67ab3d6, 0x09a0, 0x11f0, 0xa641, 0x325096b39f47};
   auto str = std::make_shared<std::string>("hello world");
   rd1.setRuntimeData(uuid1, str);
 
-  UUID uuid2{0xa12f99fc, 0x09a2, 0x11f0, 0x84de, 0x325096b39f47};
+  facebook::jsi::UUID uuid2{0xa12f99fc, 0x09a2, 0x11f0, 0x84de, 0x325096b39f47};
   auto obj1 = std::make_shared<Object>(rd1);
   rd1.setRuntimeData(uuid2, obj1);
 
@@ -1797,7 +1792,7 @@ TEST_P(JSITest, SetRuntimeData) {
 
   auto rt2 = factory();
   RD* rd2 = new RD(*rt2);
-  UUID uuid3{0x16f55892, 0x1034, 0x11f0, 0x8f65, 0x325096b39f47};
+  facebook::jsi::UUID uuid3{0x16f55892, 0x1034, 0x11f0, 0x8f65, 0x325096b39f47};
   auto obj2 = std::make_shared<Object>(*rd2);
   rd2->setRuntimeData(uuid3, obj2);
 
@@ -1860,7 +1855,6 @@ TEST_P(JSITest, CastInterface) {
 
   EXPECT_EQ(ptr, nullptr);
 }
-  Windows] */
 
 INSTANTIATE_TEST_CASE_P(
     Runtimes,


### PR DESCRIPTION
## Description
Fixes C++ compilation errors in the JSI SetRuntimeData [ JSI : 20 ] test that were causing build failures.


ref for source code :
https://github.com/microsoft/hermes-windows/blob/main/API/jsi/jsi/jsi.cpp#L469
https://github.com/microsoft/hermes-windows/blob/main/API/jsi/jsi/jsi.cpp#L512


### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
commented in integration ref : https://github.com/microsoft/react-native-windows/pull/14991 , hence enabling was important to maintain code sanity .

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-windows/issues/15134
### What
Fixed UUID namespace and possible data loss in type conversion


## Changelog
Should this change be included in the release notes: no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15210)