### PR TITLE
Add cherry-pick workflow in Github Action

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,31 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for the React Native Windows repository.
+
+## Available Workflows
+
+### Cherry-pick Commit to Branch
+
+**File:** `cherry-pick-commit.yml`
+
+Cherry-picks a specific commit into a target branch.
+
+**Usage:**
+
+1. Go to the Actions tab in the GitHub repository
+2. Select "Cherry-pick Commit to Branch" workflow
+3. Click "Run workflow"
+4. Enter the required inputs:
+   - **Commit SHA or ID**: The full commit hash or short SHA of the commit to cherry-pick
+   - **Target branch name**: The branch where you want to cherry-pick the commit
+
+**Example:**
+
+- Commit ID: `d1a95351e5203a6c0651cf73885cd7ea99e7d2b9`
+- Target branch: `0.79-stable`
+
+**Notes:**
+
+- The workflow will fail if there are merge conflicts during cherry-pick
+- If conflicts occur, you'll need to resolve them manually
+- The commit will be pushed directly to the target branch after successful cherry-pick

--- a/.github/workflows/cherry-pick-commit.yml
+++ b/.github/workflows/cherry-pick-commit.yml
@@ -1,0 +1,79 @@
+---
+name: Cherry-pick Commit to Branch
+
+'on':
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit SHA or ID to cherry-pick'
+        required: true
+        type: string
+      target_branch:
+        description: 'Target branch name to cherry-pick into'
+        required: true
+        type: string
+
+jobs:
+  cherry-pick:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install -y gh
+
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Clone repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          gh repo clone "${{ github.repository }}" repo
+          cd repo
+          git fetch origin
+
+      - name: Configure Git
+        working-directory: ./repo
+        run: |
+          git config user.name "React-Native-Windows Bot"
+          git config user.email "53619745+rnbot@users.noreply.github.com"
+
+      - name: Checkout target branch
+        working-directory: ./repo
+        run: |
+          git checkout "${{ github.event.inputs.target_branch }}"
+          git pull origin "${{ github.event.inputs.target_branch }}"
+
+      - name: Cherry-pick commit
+        working-directory: ./repo
+        run: |
+          COMMIT_ID="${{ github.event.inputs.commit_id }}"
+          TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+
+          echo "🍒 Cherry-picking commit $COMMIT_ID into branch $TARGET_BRANCH"
+
+          if git cherry-pick "$COMMIT_ID"; then
+            echo "✅ Cherry-pick successful"
+          else
+            echo "❌ Cherry-pick failed with conflicts"
+            echo "Conflict details:"
+            git status
+            exit 1
+          fi
+
+      - name: Push changes
+        working-directory: ./repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMIT_ID="${{ github.event.inputs.commit_id }}"
+          TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+
+          echo "📤 Pushing cherry-picked commit to $TARGET_BRANCH"
+          REPO_URL="https://x-access-token:${GH_TOKEN}@github.com"
+          REPO_URL="${REPO_URL}/${{ github.repository }}.git"
+          git push "$REPO_URL" "$TARGET_BRANCH"
+          echo "✅ Successfully cherry-picked $COMMIT_ID to $TARGET_BRANCH"


### PR DESCRIPTION
## Description
Cherry-picks a specific commit into a target branch.

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
This change introduces a GitHub Actions workflow to automate cherry-picking commits from one branch to another. It simplifies manual effort and reduces the risk of human error during repetitive cherry-pick operations.

### What
1. Go to the Actions tab in the GitHub repository
2. Select "Cherry-pick Commit to Branch" workflow
3. Click "Run workflow"
4. Enter the required inputs:
   - **Commit SHA or ID**: The full commit hash or short SHA of the commit to cherry-pick
   - **Target branch name**: The branch where you want to cherry-pick the commit

## Screenshots

https://github.com/user-attachments/assets/12bbcb0c-defe-44f8-bb74-a896088c64bc


Should this change be included in the release notes: _no_

Add a brief summary of the change to use in the release notes for the next release.

Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15226)