### PR TITLE
cherry-pick-commit with permissions

### DIFF
--- a/.github/workflows/cherry-pick-commit.yml
+++ b/.github/workflows/cherry-pick-commit.yml
@@ -13,6 +13,10 @@ name: Cherry-pick Commit to Branch
         required: true
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   cherry-pick:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Add permissions for writing to contents and pull requests.

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
This change introduces a GitHub Actions workflow to automate cherry-picking commits from one branch to another. It simplifies manual effort and reduces the risk of human error during repetitive cherry-pick operations.

### What
1. Go to the Actions tab in the GitHub repository
2. Select "Cherry-pick Commit to Branch" workflow
3. Click "Run workflow"
4. Enter the required inputs:
   - **Commit SHA or ID**: The full commit hash or short SHA of the commit to cherry-pick
   - **Target branch name**: The branch where you want to cherry-pick the commit

## Screenshots

https://github.com/user-attachments/assets/12bbcb0c-defe-44f8-bb74-a896088c64bc


Should this change be included in the release notes: _no_

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15235)