### PR TITLE
Revert "Update telemetry test to use localId instead of deviceId for consistency"

### DIFF
--- a/change/@react-native-windows-telemetry-db0f2c4f-871c-4759-b316-69e2494c8ab3.json
+++ b/change/@react-native-windows-telemetry-db0f2c4f-871c-4759-b316-69e2494c8ab3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "rever passing localid to telmetry pipeline",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "hmalothu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-e8822c8e-55c2-4622-b9ef-48a80761ca6a.json
+++ b/change/@react-native-windows-telemetry-e8822c8e-55c2-4622-b9ef-48a80761ca6a.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fix to retrieve deviceId",
-  "packageName": "@react-native-windows/telemetry",
-  "email": "hmalothu@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
@@ -365,11 +365,6 @@ function verifyTestCommandTelemetryProcessor(
       // Verify basics
       const commonProperties = properties!.common;
       expect(commonProperties.commandName).toBe('test-command');
-      // Verify LocalId
-      const expectedLocalId = TelemetryTest.getCommonProperty('deviceId');
-      expect(envelope.ext?.device?.localId).toBeDefined();
-      expect(envelope.ext?.device?.localId).toBe(expectedLocalId);
-      expect(commonProperties.device?.localId).toBe(expectedLocalId); // Only if you know it's set in the event, not in static commonProperties
 
       // Verify versions info
       const versions = properties!.versions;

--- a/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
@@ -115,7 +115,7 @@ test('setup() verify static common property values with async sources', async ()
   await TelemetryTest.startTest();
 
   const props: Record<string, () => Promise<string | undefined>> = {
-    deviceId: basePropUtils.deviceId,
+    //deviceId: basePropUtils.deviceId,
     deviceLocale: basePropUtils.deviceLocale,
   };
 

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -202,7 +202,7 @@ export class Telemetry {
 
   /** Sets up any base properties that all telemetry events require. */
   private static async setupBaseProperties() {
-    Telemetry.commonProperties.deviceId = await basePropUtils.deviceId();
+    // Telemetry.commonProperties.deviceId = await basePropUtils.deviceId();
     Telemetry.commonProperties.fullBuildInfo =
       await basePropUtils.fullBuildInfo();
     Telemetry.commonProperties.deviceArchitecture =
@@ -369,7 +369,7 @@ export class Telemetry {
     // Populate Part A extensions
     telemetryItem.ext = {};
     telemetryItem.ext.device = {
-      id: Telemetry.commonProperties.deviceId,
+      //id: Telemetry.commonProperties.deviceId,
       deviceClass: Telemetry.commonProperties.deviceClass,
     };
     telemetryItem.ext.os = {

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -369,7 +369,7 @@ export class Telemetry {
     // Populate Part A extensions
     telemetryItem.ext = {};
     telemetryItem.ext.device = {
-      localId: Telemetry.commonProperties.deviceId,
+      id: Telemetry.commonProperties.deviceId,
       deviceClass: Telemetry.commonProperties.deviceClass,
     };
     telemetryItem.ext.os = {
@@ -385,8 +385,6 @@ export class Telemetry {
           numCPUs: Telemetry.commonProperties.numCPUs,
           totalMemory: Telemetry.commonProperties.totalMemory,
           diskFreeSpace: Telemetry.commonProperties.deviceDiskFreeSpace,
-          localId: Telemetry.commonProperties.deviceId,
-          deviceClass: Telemetry.commonProperties.deviceClass,
         },
         nodePlatform: Telemetry.commonProperties.nodePlatform,
         nodeArchitecture: Telemetry.commonProperties.nodeArchitecture,


### PR DESCRIPTION
Reverts microsoft/react-native-windows#15144 to prevent localid from being sent to onecollector
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15251)