### PR TITLE
Bump screenshot-desktop from 1.15.0 to 1.15.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10841,9 +10841,9 @@ scheduler@^0.23.2:
     loose-envify "^1.1.0"
 
 screenshot-desktop@^1.12.2:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/screenshot-desktop/-/screenshot-desktop-1.15.0.tgz#62109463865cdb1bbe61dff39003cd06ac404fb0"
-  integrity sha512-CLaZNBDEXU+KJ6BGsO8jSbKI7Zck7gQmFJHjzluBdwrVP0jOemP2avpD3ufWu81yqzwB92u2AMv+K9IlaslRsg==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/screenshot-desktop/-/screenshot-desktop-1.15.2.tgz#21489e1b4ac779659460cf65dc8db6f84023f30d"
+  integrity sha512-/uf8xhq3n/Ym7oOKT4XF1uLAYP9njABB9zMw7kkOaDVr8XOO1HBQsNJXT8lUvzD26Uj8IYkwQX46UMZG4Y/dIQ==
   dependencies:
     temp "^0.9.4"
 


### PR DESCRIPTION
## Description
Bump screenshot-desktop from 1.15.0 to 1.15.2 as a part of corporate governance

### Type of Change
- Security fix (non-breaking change which fixes an issue)

### Why
To fix CVE-2025-55294

Resolves [https://dev.azure.com/microsoft/ReactNative/_componentGovernance/177343/alert/9600318?typeId=19456657]

### What
Bump screenshot-desktop from 1.15.0 to 1.15.2 as a part of corporate governance

## Screenshots
Before
<img width="653" height="185" alt="cg-before" src="https://github.com/user-attachments/assets/4bd36f90-0240-41b1-a0b1-a6addefaf18f" />


After
<img width="567" height="249" alt="cg-after" src="https://github.com/user-attachments/assets/8368181f-d412-4f0e-b3e4-1ae7bcf5b798" />


## Testing
yarn build passes


## Changelog
Should this change be included in the release notes: _indicate yes 

Add a brief summary of the change to use in the release notes for the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15257)