### PR TITLE
Remove unused build configurations from integration tests

### DIFF
--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -31,14 +31,6 @@ parameters:
             BuildPlatform: ARM64
             BuildConfiguration: Debug
             DeployOptions: --no-deploy # We don't have Arm agents
-          - Name: X64WebDebug
-            BuildPlatform: x64
-            BuildConfiguration: Debug
-            DeployOptions:
-          - Name: X86WebDebug
-            BuildPlatform: x86
-            BuildConfiguration: Debug
-            DeployOptions:
           - Name: X64Release
             BuildPlatform: x64
             BuildConfiguration: Release
@@ -47,16 +39,6 @@ parameters:
             BuildPlatform: x86
             BuildConfiguration: Release
             DeployOptions:
-          - Name: X64ReleaseChakra
-            BuildPlatform: x64
-            BuildConfiguration: Release
-            DeployOptions:
-            UseChakra: true
-          - Name: X86ReleaseChakra
-            BuildPlatform: x86
-            BuildConfiguration: Release
-            DeployOptions:
-            UseChakra: true
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:


### PR DESCRIPTION
Eliminated X64WebDebug, X86WebDebug, X64ReleaseChakra, and X86ReleaseChakra configurations from the integration-test pipeline YAML. 
This streamlines the build matrix and removes configurations that are no longer needed.

Saves us time in not waiting for these tests to be cancelled automatically:
<img width="886" height="1023" alt="image" src="https://github.com/user-attachments/assets/fbc715db-b3e7-44d9-a100-fba72cf2ca7b" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15279)