### PR TITLE
Remove integration tests for Chakra and Web Debugger

### DIFF
--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -23,14 +23,6 @@ parameters:
             BuildPlatform: ARM64
             BuildConfiguration: Debug
             DeployOptions: --no-deploy # We don't have Arm agents
-          - Name: X64WebDebug
-            BuildPlatform: x64
-            BuildConfiguration: Debug
-            DeployOptions:
-          - Name: X86WebDebug
-            BuildPlatform: x86
-            BuildConfiguration: Debug
-            DeployOptions:
           - Name: X64Release
             BuildPlatform: x64
             BuildConfiguration: Release
@@ -39,16 +31,6 @@ parameters:
             BuildPlatform: x86
             BuildConfiguration: Release
             DeployOptions:
-          - Name: X64ReleaseChakra
-            BuildPlatform: x64
-            BuildConfiguration: Release
-            DeployOptions:
-            UseChakra: true
-          - Name: X86ReleaseChakra
-            BuildPlatform: x86
-            BuildConfiguration: Release
-            DeployOptions:
-            UseChakra: true
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:


### PR DESCRIPTION
## Description
Unblock the CI pipeline by removing the integration tests are not necessary anymore.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
In the last couple of weeks we cannot produce any new RNW releases because we have 4 integration tests failing:
- 2 tests for the Web Debugger since it is not supported anymore.
- 2 tests for the Chakra because it cannot load the modern JavaScript code such as named `RegEx` groups, `globalThis`, etc.

### What
This PR removes the obsolete integration tests from the CI pipeline.

## Testing
After these changes the CI pipeline succeeds:
https://dev.azure.com/ms/react-native-windows/_build/results?buildId=625798&view=results

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15347)