### PR TITLE
ESRP release to set npm tags

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -168,6 +168,8 @@ extends:
             displayName: Enable No-Publish (git)
             condition: ${{ parameters.skipGitPush }}
 
+          # Beachball publishes NPM packages to the "$(Pipeline.Workspace)\published-packages" folder.
+          # It pushes NPM version updates to Git depending on the SkipGitPushPublishArgs variable derived from the skipGitPush parameter.
           - script: |
               if exist "$(Pipeline.Workspace)\published-packages" rd /s /q "$(Pipeline.Workspace)\published-packages"
               mkdir "$(Pipeline.Workspace)\published-packages"
@@ -175,11 +177,23 @@ extends:
             displayName: Beachball Publish
 
           - script: dir /s "$(Pipeline.Workspace)\published-packages"
-            displayName: Show packaged npm artifacts
+            displayName: Show created npm packages
 
-          - task: 'SFP.release-tasks.custom-build-release-task.EsrpRelease@9'
-            displayName: 'ESRP Release to npmjs.com'
-            condition: and(succeeded(), ${{ not(parameters.skipNpmPublish) }})
+          # Beachball usually takes care about the NPM package tagging based on the values in package.json files.
+          # We use the ESRP Release where we must provide the tag explictly (the productstate parameter).
+          # Fortunately, we just use two tags: latest and some custom tag like "canary", "v0.73-stable", etc.
+          # The npmGroupByTag.js script groups the created NPM package by these two tags into the specified folders.
+          - pwsh: |
+              node .ado/scripts/npmGroupByTag.js "$(Pipeline.Workspace)\published-packages" "$(Pipeline.Workspace)\published-packages\custom-tag" "$(Pipeline.Workspace)\published-packages\latest-tag"
+            displayName: Group npm packages by tag
+
+          - script: dir /s "$(Pipeline.Workspace)\published-packages"
+            displayName: Show grouped npm packages by tag
+
+          # Publish NPM packages using ESRP Release task with the custom tag such as "canary", "v0.73-stable", etc.
+          - task: 'SFP.release-tasks.custom-build-release-task.EsrpRelease@10'
+            displayName: 'ESRP Release to npmjs.com (custom tag)'
+            condition: and(succeeded(), ${{ not(parameters.skipNpmPublish) }}, eq(variables['NpmCustomFolderHasContent'], 'true'))
             inputs:
               connectedservicename: 'ESRP-CodeSigning-OGX-JSHost-RNW'
               usemanagedidentity: false
@@ -189,7 +203,26 @@ extends:
               clientid: '0a35e01f-eadf-420a-a2bf-def002ba898d'
               domaintenantid: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
               contenttype: npm
-              folderlocation: '$(Pipeline.Workspace)\published-packages'
+              folderlocation: '$(NpmCustomFolder)'
+              productstate: '$(NpmCustomTag)'
+              owners: 'vmorozov@microsoft.com'
+              approvers: 'khosany@microsoft.com'
+
+          # Publish NPM packages using ESRP Release task with the "latest" tag.
+          - task: 'SFP.release-tasks.custom-build-release-task.EsrpRelease@10'
+            displayName: 'ESRP Release to npmjs.com (latest)'
+            condition: and(succeeded(), ${{ not(parameters.skipNpmPublish) }}, eq(variables['NpmLatestFolderHasContent'], 'true'))
+            inputs:
+              connectedservicename: 'ESRP-CodeSigning-OGX-JSHost-RNW'
+              usemanagedidentity: false
+              keyvaultname: 'OGX-JSHost-KV'
+              authcertname: 'OGX-JSHost-Auth4'
+              signcertname: 'OGX-JSHost-Sign3'
+              clientid: '0a35e01f-eadf-420a-a2bf-def002ba898d'
+              domaintenantid: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              contenttype: npm
+              folderlocation: '$(NpmLatestFolder)'
+              productstate: 'latest'
               owners: 'vmorozov@microsoft.com'
               approvers: 'khosany@microsoft.com'
 

--- a/.ado/scripts/npmGroupByTag.js
+++ b/.ado/scripts/npmGroupByTag.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// @ts-check
+
+// Groups packed npm tarballs into tag-specific folders so ESRP can publish with the
+// correct productstate value per tag.
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @typedef {Object} PackageJsonBeachball
+ * @property {string | undefined} [defaultNpmTag]
+ */
+
+/**
+ * @typedef {Object} PackageJson
+ * @property {string | undefined} [name]
+ * @property {string | undefined} [version]
+ * @property {boolean | undefined} [private]
+ * @property {PackageJsonBeachball | undefined} [beachball]
+ */
+
+/**
+ * @returns {{packRootArg: string, customRootArg: string, latestRootArg: string}}
+ */
+function ensureArgs() {
+  const [, , packRootArg, customRootArg, latestRootArg] = process.argv;
+  if (!packRootArg || !customRootArg || !latestRootArg) {
+    console.error('Usage: node npmGroupByTag.js <packRoot> <customRoot> <latestRoot>');
+    process.exit(1);
+  }
+  return {packRootArg, customRootArg, latestRootArg};
+}
+
+/**
+ * @param {string} filePath
+ * @returns {unknown}
+ */
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/**
+ * @param {string} pkgName
+ * @param {string} version
+ * @returns {string}
+ */
+function sanitizedTarballName(pkgName, version) {
+  const prefix = pkgName.startsWith('@')
+    ? pkgName.slice(1).replace(/\//g, '-').replace(/@/g, '-')
+    : pkgName.replace(/@/g, '-');
+  return `${prefix}-${version}.tgz`;
+}
+
+/**
+ * @param {string} tarballName
+ * @returns {string}
+ */
+function normalizePackedTarballName(tarballName) {
+  // beachball prefixes packed tarballs with a monotonically increasing number to avoid collisions
+  // when multiple packages share the same filename. Strip that prefix (single or repeated) for comparison.
+  return tarballName.replace(/^(?:\d+[._-])+/u, '');
+}
+
+/**
+ * @param {string} root
+ * @returns {string[]}
+ */
+function findPackageJsons(root) {
+  /** @type {string[]} */
+  const results = [];
+  /** @type {string[]} */
+  const stack = [root];
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    /** @type {fs.Stats | undefined} */
+    let stats;
+    try {
+      stats = fs.statSync(current);
+    } catch (e) {
+      continue;
+    }
+
+    if (!stats.isDirectory()) {
+      continue;
+    }
+
+    const entries = fs.readdirSync(current, {withFileTypes: true});
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.git') {
+        continue;
+      }
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile() && entry.name === 'package.json') {
+        results.push(entryPath);
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * @param {string} name
+ * @param {string} value
+ */
+function setPipelineVariable(name, value) {
+  console.log(`##vso[task.setvariable variable=${name}]${value}`);
+}
+
+(function main() {
+  const {packRootArg, customRootArg, latestRootArg} = ensureArgs();
+
+  const repoRoot = process.env.BUILD_SOURCESDIRECTORY || process.cwd();
+  const packRoot = path.resolve(packRootArg);
+  const customRoot = path.resolve(customRootArg);
+  const latestRoot = path.resolve(latestRootArg);
+
+  fs.mkdirSync(customRoot, {recursive: true});
+  fs.mkdirSync(latestRoot, {recursive: true});
+
+  /** @type {string | null} */
+  let customTag = null;
+  try {
+    const vnextPackageJson = /** @type {PackageJson} */ (
+      readJson(path.join(repoRoot, 'vnext', 'package.json'))
+    );
+    const tagFromVnext = vnextPackageJson?.beachball?.defaultNpmTag;
+    if (tagFromVnext && tagFromVnext !== 'latest') {
+      customTag = tagFromVnext;
+    }
+  } catch (e) {
+    console.warn('Unable to read vnext/package.json to determine custom tag.');
+  }
+
+  /** @type {string[]} */
+  const tarballs = fs.existsSync(packRoot)
+    ? fs.readdirSync(packRoot).filter(file => file.endsWith('.tgz'))
+    : [];
+
+  if (!tarballs.length) {
+    setPipelineVariable('NpmCustomTag', customTag || '');
+    setPipelineVariable('NpmCustomFolder', customRoot);
+    setPipelineVariable('NpmCustomFolderHasContent', 'false');
+    setPipelineVariable('NpmLatestFolder', latestRoot);
+    setPipelineVariable('NpmLatestFolderHasContent', 'false');
+    return;
+  }
+
+  /** @type {Set<string>} */
+  const customTarballs = new Set();
+
+  if (customTag) {
+    for (const packageJsonPath of findPackageJsons(repoRoot)) {
+      /** @type {PackageJson | undefined} */
+      let pkg;
+      try {
+        pkg = /** @type {PackageJson} */ (readJson(packageJsonPath));
+      } catch (e) {
+        continue;
+      }
+
+      if (!pkg?.name || !pkg?.version) {
+        continue;
+      }
+
+      const pkgTag = pkg?.beachball?.defaultNpmTag;
+      if (pkgTag === customTag && pkg.private !== true) {
+        customTarballs.add(sanitizedTarballName(pkg.name, pkg.version));
+      }
+    }
+  }
+
+  let customCount = 0;
+  let latestCount = 0;
+
+  for (const tarball of tarballs) {
+    const sourcePath = path.join(packRoot, tarball);
+    const normalizedName = normalizePackedTarballName(tarball);
+    const destinationRoot = customTag && customTarballs.has(normalizedName) ? customRoot : latestRoot;
+    const destinationPath = path.join(destinationRoot, tarball);
+    fs.mkdirSync(path.dirname(destinationPath), {recursive: true});
+    fs.renameSync(sourcePath, destinationPath);
+    if (destinationRoot === customRoot) {
+      customCount++;
+    } else {
+      latestCount++;
+    }
+  }
+
+  setPipelineVariable('NpmCustomTag', customTag || '');
+  setPipelineVariable('NpmCustomFolder', customRoot);
+  setPipelineVariable('NpmCustomFolderHasContent', customCount ? 'true' : 'false');
+  setPipelineVariable('NpmLatestFolder', latestRoot);
+  setPipelineVariable('NpmLatestFolderHasContent', latestCount ? 'true' : 'false');
+})();


### PR DESCRIPTION
## Description
Implement tagging of NPM packages released to `npmjs.com` by the ESRP release task.

### Type of Change
- New feature (non-breaking change that adds functionality)

### Why
The new ESRP release task introduced in PR #15365 enables the Microsoft process to release NPM packages through the central service. As [@Saadnajmi noted](https://github.com/microsoft/react-native-windows/pull/15365#issuecomment-3528363341) in post-merge feedback, the new process no longer applies the correct NPM tag that Beachball publish used to set automatically.

### What
The ESRP release task requires an explicit tag for each group of NPM packages it publishes, provided via the `productstate` parameter. Fortunately, we only use two tags when publishing our NPM packages: `latest` and a custom tag such as `canary`, `v0.73-stable`, etc.
This PR adds the npmGroupByTag.js script, which groups all created NPM packages into those two folders based on the tag declared in their corresponding package.json.
We then invoke the ESRP release task separately for each folder with the appropriate NPM tag.

## Testing
The script was exercised locally against placeholder `.tgz` artifacts.
The full `publish.yml` pipeline has not been executed because there are no pending changes to publish.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15372)