### PR TITLE
Enable UTs on more platforms

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -204,7 +204,7 @@
                       /p:RestoreForceEvaluate=true
 
                 - task: VSTest@2
-                  displayName: Run React Native Unit Tests (Native)
+                  displayName: Run Universal Unit Tests (Native)
                   timeoutInMinutes: 5 # Set smaller timeout , due to hangs
                   inputs:
                     testSelector: testAssemblies
@@ -221,3 +221,4 @@
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
                     failOnMinTestsNotRun: true
+                  condition: and(succeeded(), not(eq('${{ matrix.BuildPlatform }}', 'ARM64')))


### PR DESCRIPTION
## Description
I noticed that some of our UTs are only running against the x86 builds.  Try enabling them on all platforms.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15373)