### PR TITLE
Stop creating Nuget packages for Managed and Debug code

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -84,6 +84,8 @@ variables:
     value: microsoft
   - name: ArtifactServices.Symbol.PAT
     value: $(pat-symbols-publish-microsoft)
+  - name: SourceBranchWithFolders
+    value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 trigger: none
 pr: none
@@ -173,7 +175,7 @@ extends:
           - script: |
               if exist "$(Pipeline.Workspace)\published-packages" rd /s /q "$(Pipeline.Workspace)\published-packages"
               mkdir "$(Pipeline.Workspace)\published-packages"
-              npx beachball publish --no-publish $(SkipGitPushPublishArgs) --pack-to-path "$(Pipeline.Workspace)\published-packages" --branch origin/$(Build.SourceBranchName) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
+              npx beachball publish --no-publish $(SkipGitPushPublishArgs) --pack-to-path "$(Pipeline.Workspace)\published-packages" --branch origin/$(SourceBranchWithFolders) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
             displayName: Beachball Publish
 
           - script: dir /s "$(Pipeline.Workspace)\published-packages"
@@ -227,7 +229,7 @@ extends:
               approvers: 'khosany@microsoft.com'
 
           # Beachball reverts to local state after publish, but we want the updates it added
-          - script: git pull origin ${{ variables['Build.SourceBranchName'] }}
+          - script: git pull origin $(SourceBranchWithFolders)
             displayName: git pull
 
           - script: npx @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
@@ -361,8 +363,6 @@ extends:
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 contents: |
                   Microsoft.ReactNative\**
-                  Microsoft.ReactNative.Managed\**
-                  Microsoft.ReactNative.Managed.CodeGen\**
                   Microsoft.ReactNative.CsWinRT\**
 
             - template: .ado/templates/component-governance.yml@self
@@ -424,8 +424,6 @@ extends:
               npmVersion: $(npmVersion)
               packMicrosoftReactNative: true
               packMicrosoftReactNativeCxx: true
-              packMicrosoftReactNativeManaged: true
-              packMicrosoftReactNativeManagedCodeGen: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
                 signMicrosoft: true
               slices:
@@ -435,12 +433,6 @@ extends:
                   configuration: Release
                 - platform: ARM64
                   configuration: Release
-                - platform: x64
-                  configuration: Debug
-                - platform: x86
-                  configuration: Debug
-                - platform: ARM64
-                  configuration: Debug
 
           - template: .ado/templates/prep-and-pack-nuget.yml@self
             parameters:

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -28,12 +28,6 @@ parameters:
   - name: packMicrosoftReactNativeCxx
     type: boolean
     default: false
-  - name: packMicrosoftReactNativeManaged
-    type: boolean
-    default: false
-  - name: packMicrosoftReactNativeManagedCodeGen
-    type: boolean
-    default: false
 
   - name: signMicrosoft
     type: boolean
@@ -42,19 +36,15 @@ parameters:
 steps:
   - pwsh: |
       $slices = ConvertFrom-Json -NoEnumerate '${{ convertToJson(parameters.slices) }}'
-      $debugSlices = @($slices.where{$_.configuration -match 'Debug'});
       $releaseSlices = @($slices.where{$_.configuration -match 'Release'});
   
       $sliceTags = $slices | % {$_.platform + "." + $_.configuration} | ConvertTo-Json -AsArray -Compress
-      $debugSliceTags = $debugSlices | % {$_.platform + "." + $_.configuration} | ConvertTo-Json -AsArray -Compress
       $releaseSliceTags = $releaseSlices | % {$_.platform + "." + $_.configuration} | ConvertTo-Json -AsArray -Compress
 
       Write-Host "##vso[task.setvariable variable=allSlices]$sliceTags"
-      Write-Host "##vso[task.setvariable variable=debugSlices]$debugSliceTags"
       Write-Host "##vso[task.setvariable variable=releaseSlices]$releaseSliceTags"
 
       Write-Host "##vso[task.setvariable variable=basePlatform]$($slices[0].platform)"
-      Write-Host "##vso[task.setvariable variable=debugBasePlatform]$($debugSlices[0].platform)"
       Write-Host "##vso[task.setvariable variable=releaseBasePlatform]$($releaseSlices[0].platform)"
 
       Write-Host "##vso[task.setvariable variable=baseConfiguration]$($slices[0].configuration)"
@@ -89,7 +79,7 @@ steps:
         filePath: vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
         arguments: -TargetRoot ${{parameters.nugetroot}}
 
-  - ${{ if or(eq(parameters.packMicrosoftReactNative, true), eq(parameters.packMicrosoftReactNativeCxx, true), eq(parameters.packMicrosoftReactNativeManaged, true), eq(parameters.packMicrosoftReactNativeManagedCodeGen, true)) }}:
+  - ${{ if or(eq(parameters.packMicrosoftReactNative, true), eq(parameters.packMicrosoftReactNativeCxx, true)) }}:
     - powershell: |
         (Get-Content -Path ${{parameters.nugetroot}}\Microsoft.ReactNative.VersionCheck.targets) -replace '\$\$nuGetPackageVersion\$\$', '${{parameters.npmVersion}}' | Set-Content -Path  ${{parameters.nugetroot}}\Microsoft.ReactNative.VersionCheck.targets
       displayName: Patch version check file with version ${{parameters.npmVersion}}
@@ -103,16 +93,6 @@ steps:
         buildProperties: 'CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}}'
 
   - ${{ if eq(parameters.packMicrosoftReactNative, true) }}:
-    - ${{ if containsValue(parameters.slices.*.configuration, 'Debug') }}:
-      - template: prep-and-pack-single.yml
-        parameters:
-          outputPackage: Microsoft.ReactNative.Debug
-          nuspec: Microsoft.ReactNative
-          slices: $(debugSlices)
-          packageVersion: ${{parameters.npmVersion}}
-          codesignBinaries: ${{ parameters.signMicrosoft }}
-          codesignNuget: ${{ parameters.signMicrosoft }}
-          buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Debug;baseplatform=$(debugBasePlatform)
     - ${{ if containsValue(parameters.slices.*.configuration, 'Release') }}:
       - template: prep-and-pack-single.yml
         parameters:
@@ -132,32 +112,3 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=$(baseConfiguration);baseplatform=$(basePlatform)
         codesignNuget: ${{ parameters.signMicrosoft }}
 
-  - ${{ if eq(parameters.packMicrosoftReactNativeManaged, true) }}:
-    - ${{ if containsValue(parameters.slices.*.configuration, 'Debug') }}:
-      - template: prep-and-pack-single.yml
-        parameters:
-          outputPackage: Microsoft.ReactNative.Managed.Debug
-          nuspec: Microsoft.ReactNative.Managed
-          slices: $(debugSlices)
-          packageVersion: ${{parameters.npmVersion}}
-          codesignBinaries: ${{ parameters.signMicrosoft }}
-          codesignNuget: ${{ parameters.signMicrosoft }}
-          buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Debug;baseplatform=$(debugBasePlatform)
-    - ${{ if containsValue(parameters.slices.*.configuration, 'Release') }}:
-      - template: prep-and-pack-single.yml
-        parameters:
-          outputPackage: Microsoft.ReactNative.Managed
-          slices: $(releaseSlices)
-          packageVersion: ${{parameters.npmVersion}}
-          codesignBinaries: ${{ parameters.signMicrosoft }}
-          codesignNuget: ${{ parameters.signMicrosoft }}
-          buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=$(releaseBasePlatform)
-
-  - ${{ if eq(parameters.packMicrosoftReactNativeManagedCodeGen, true) }}:
-    - template: prep-and-pack-single.yml
-      parameters:
-        outputPackage: Microsoft.ReactNative.Managed.CodeGen
-        packageVersion: ${{parameters.npmVersion}}
-        buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=$(baseConfiguration);baseplatform=$(basePlatform)
-        codesignBinaries: ${{ parameters.signMicrosoft }}
-        codesignNuget: ${{ parameters.signMicrosoft }}


### PR DESCRIPTION
## Description
Stop creating Nuget packages for Managed and Debug code

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
After removing support for paper some Nuget packages cannot be created anymore and it breaks our Publish pipeline.

### What
This PR removes creation of Managed and Debug Nuget packages:
- Microsoft.ReactNative.Debug
- Microsoft.ReactNative.Managed.Debug
- Microsoft.ReactNative.Managed
- Microsoft.ReactNative.Managed.CodeGen

After this change the Publish pipeline must be unblocked.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15374)