### PR TITLE
[Cherry Pick 0.80]: Fix modal Crash after closing DesktopPopupSiteBridge 

### DIFF
--- a/change/react-native-windows-5bdf4573-dfbe-41fd-9dc0-4c4a7119957e.json
+++ b/change/react-native-windows-5bdf4573-dfbe-41fd-9dc0-4c4a7119957e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix  Crash after closing DesktopPopupSiteBridge",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description
 We’re seeing a crash when using DesktopPopupSiteBridge in React Native Windows: after closing the popup, the parent window crashes when processing subsequent messages (e.g., window move).
 
 
### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
resolves the modal crash on dismissing the modal.

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-windows/issues/15165

### What
Fix was to call `AppWindow::Destroy` in sequence -> : `AppWindow.Destroy`, `Popup.Hide`, `Popup.Close`

Only `DesktopPopupSiteBridge::{Hide,Close}` were called earlier. furthermore, EnableWindow is win32 API which was forcing the parent window to take input but the popup was never cleanly destroyed and hence the crash.

Now EnableWindow is no longer required as parent window automatically gets control when modal App window is destroyed. 

Credits - @sundaramramaswamy , the fix was first tested on sample win32 repro .
ref : https://github.com/iamAbhi-916/ModalTest/pull/1


## Screenshots

https://github.com/user-attachments/assets/47bf41a4-0ee8-4b5c-97bb-0369e8099d58




## Testing
tested in playground 



## Changelog
Should this change be included in the release notes: _indicate yes

Add a brief summary of the change to use in the release notes for the next release.
Fixed modal dialog crash when interacting with parent window after dismissal.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15390)