### PR TITLE
[Cherry pick 0.80] : Improve the inspector page name for modern debugger

### DIFF
--- a/change/react-native-windows-8863778a-7158-453c-abaf-e5c40ed489bc.json
+++ b/change/react-native-windows-8863778a-7158-453c-abaf-e5c40ed489bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add HostTargetMetadata with app name and device name for inspector page naming",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description
1>when we open devtools the current page target name which shows is React Native Windows (Experimental)  this PR enhances it to more informative format that includes: App Name + Device Name
For example: text (CPC-abhij-UF5EG)


2> lint:fix removes deep imports from vnext/src-win/src/private/specs_DEPRECATED/components/Xaml/XamlHostNativeComponent.js.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
1>improves page name 
2> removes deep imports from  vnext/src-win/src/private/specs_DEPRECATED/components/Xaml/XamlHostNativeComponent.js

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-windows/issues/15342
sub issue in : https://github.com/microsoft/react-native-windows/pull/15392

### What
App Name is extracted from options.Identity ( didnt use ReactInstanceSettings::DebuggerRuntimeName() is rarely set by apps - it's an optional property that developers must explicitly configure.)
Device Name is the Windows computer name obtained via GetComputerNameW()


## Screenshots
<img width="1193" height="606" alt="image" src="https://github.com/user-attachments/assets/d62840ba-a01c-4ac1-b23a-aa6eff09c1b2" />


## Testing
tested in playground.

## Changelog
Should this change be included in the release notes: no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15398)