### PR TITLE
Bump beachball from 2.51.0 to 2.58.0

### DIFF
--- a/packages/@rnw-scripts/beachball-config/package.json
+++ b/packages/@rnw-scripts/beachball-config/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@react-native-windows/package-utils": "0.81.0-preview.1",
     "@rnw-scripts/stamp-version": "0.0.0",
-    "find-up": "^4.1.0"
+    "find-up": "^4.1.0",
+    "parse-path": "^7.1.0"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "1.2.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10373,7 +10373,7 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==
 
-parse-path@*:
+parse-path@*, parse-path@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-7.1.0.tgz#41fb513cb122831807a4c7b29c8727947a09d8c6"
   integrity sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==


### PR DESCRIPTION
## Description
Bump beachball from 2.51.0 to 2.58.0

### Type of Change
Bump Change


## Changelog
Should this change be included in the release notes: _no_

Add a brief summary of the change to use in the release notes for the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15408)