### PR TITLE
[Cherry pick 0.81] Modern Debugger: Disable network domain from devtools UI until 0.83

### DIFF
--- a/change/react-native-windows-b5ea6091-37fa-414e-b602-ba1ff3df1f55.json
+++ b/change/react-native-windows-b5ea6091-37fa-414e-b602-ba1ff3df1f55.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "disable network domain for modern devtools until 0.83",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -310,10 +310,6 @@ class ReactNativeWindowsFeatureFlags : public facebook::react::ReactNativeFeatur
   bool fuseboxEnabledRelease() override {
     return true; // Enable Fusebox (modern CDP backend) by default for React Native Windows
   }
-
-  bool fuseboxNetworkInspectionEnabled() override {
-    return true; // Enable network inspection support in Fusebox
-  }
 };
 
 //=============================================================================================


### PR DESCRIPTION
## Description
Disable network domain from devtools UI until 0.83

Note :
enable-network-panel experiment persisted in local Storage of  RN devtools app -> If it was ever enabled (even once), it stays enabled until manually disabled.

to manually disable need to remove the value from localstorage 
In the React Native DevTools app , **DevTools: Settings → Experiments → uncheck (Enable Network panel)**

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Why
Upstream has disabled network domain unless we specifically opt in, we have decided to enable network in coming releases expected 0.83. 
upstream PR for ref :
https://github.com/facebook/react-native/pull/54516
https://github.com/facebook/react-native-devtools-frontend/pull/220 

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-windows/issues/15413

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
<img width="1785" height="898" alt="image" src="https://github.com/user-attachments/assets/df891efd-f167-408d-9ae9-4db856ca316e" />

## Testing
tested in playground.



## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15411)