### PR TITLE
Add GitHub Action to Create Fork Branch from Upstream Base

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,3 +29,31 @@ Cherry-picks a specific commit into a target branch.
 - The workflow will fail if there are merge conflicts during cherry-pick
 - If conflicts occur, you'll need to resolve them manually
 - The commit will be pushed directly to the target branch after successful cherry-pick
+
+---
+
+### Create Branch from Upstream
+
+**File:** `sync-upstream-branch.yml`
+
+Creates a new branch in your fork based on a branch from the upstream microsoft/react-native-windows repository.
+
+**Usage:**
+
+1. Go to the Actions tab in your fork
+2. Select "Create Branch from Upstream" workflow
+3. Click "Run workflow"
+4. Enter the required inputs:
+   - **Upstream branch name**: The branch from microsoft/react-native-windows to base your new branch on (e.g., `0.81-stable`, `main`)
+   - **New branch name** (optional): The name for the new branch in your fork. If left empty, the same name as the upstream branch will be used
+
+**Example:**
+
+- Upstream branch: `0.81-stable`
+- New branch name: `my-feature-0.81` (or leave empty to create `0.81-stable` in your fork)
+
+**Notes:**
+
+- The workflow will fail if the specified upstream branch does not exist
+- The workflow will fail if the branch already exists in your fork (to prevent overwriting)
+- This is useful for creating feature branches based on specific upstream stable releases

--- a/.github/workflows/sync-upstream-branch.yml
+++ b/.github/workflows/sync-upstream-branch.yml
@@ -1,0 +1,90 @@
+---
+name: Create Branch from Upstream
+
+'on':
+  workflow_dispatch:
+    inputs:
+      upstream_branch:
+        description: 'Upstream branch name to create from (e.g., 0.81-stable, main)'
+        required: true
+        type: string
+      new_branch_name:
+        description: 'Name for the new branch in your fork (leave empty to use same name as upstream)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  create-branch-from-upstream:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Clone repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          gh repo clone "${{ github.repository }}" repo
+          cd repo
+          git fetch origin
+
+      - name: Configure Git
+        working-directory: ./repo
+        run: |
+          git config user.name "React-Native-Windows Bot"
+          git config user.email "53619745+rnbot@users.noreply.github.com"
+
+      - name: Add upstream remote and fetch branch
+        working-directory: ./repo
+        run: |
+          UPSTREAM_BRANCH="${{ github.event.inputs.upstream_branch }}"
+
+          echo "🔗 Adding upstream remote (microsoft/react-native-windows)"
+          git remote get-url upstream 2>/dev/null || git remote add upstream https://github.com/microsoft/react-native-windows.git
+
+          echo "📥 Fetching upstream branch: $UPSTREAM_BRANCH"
+          if ! git fetch upstream "$UPSTREAM_BRANCH"; then
+            echo "❌ Failed to fetch branch '$UPSTREAM_BRANCH' from upstream."
+            echo "Please verify that the branch exists in microsoft/react-native-windows."
+            exit 1
+          fi
+
+          echo "✅ Successfully fetched upstream branch: $UPSTREAM_BRANCH"
+
+      - name: Create and push new branch
+        working-directory: ./repo
+        run: |
+          UPSTREAM_BRANCH="${{ github.event.inputs.upstream_branch }}"
+          NEW_BRANCH="${{ github.event.inputs.new_branch_name }}"
+
+          # Use upstream branch name if new branch name is not specified
+          if [ -z "$NEW_BRANCH" ]; then
+            NEW_BRANCH="$UPSTREAM_BRANCH"
+          fi
+
+          echo "🌿 Creating new branch: $NEW_BRANCH from upstream/$UPSTREAM_BRANCH"
+
+          # Check if the branch already exists in the fork
+          if git ls-remote --heads origin "$NEW_BRANCH" | grep -q "refs/heads/$NEW_BRANCH$"; then
+            echo "❌ Branch '$NEW_BRANCH' already exists in your fork."
+            echo "Please specify a different branch name or delete the existing branch first."
+            exit 1
+          fi
+
+          # Create the new branch based on upstream
+          git checkout -b "$NEW_BRANCH" "upstream/$UPSTREAM_BRANCH"
+
+          echo "📤 Pushing new branch to fork"
+          git push origin "$NEW_BRANCH"
+
+          echo "✅ Successfully created branch '$NEW_BRANCH' from upstream '$UPSTREAM_BRANCH'"
+          echo ""
+          echo "📋 Branch details:"
+          echo "   - Source: microsoft/react-native-windows/$UPSTREAM_BRANCH"
+          echo "   - Destination: ${{ github.repository }}/$NEW_BRANCH"


### PR DESCRIPTION
## Description
We already have a cherry-pick GitHub Action. However, most forks only track the main branch. When we need to create a branch off a different base (e.g., a stable/* branch), we’ve had to do this locally by adding the upstream remote and fetching branches. This new GitHub Action automates that workflow.

After merging this PR, you can create a branch in **your fork** based on **any branch** from the upstream repository no local setup required.

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
Creating branches off upstream non-main branches currently requires local environment setup (adding upstream remote, fetching, checking out, and pushing). This adds friction when preparing cherry-picks or hotfixes against stable lines.
This Action streamlines that process by allowing you to create a branch in your fork directly from any upstream branch, enabling faster cherry-picks and reducing setup effort.


## Screenshots
<img width="1687" height="1365" alt="image" src="https://github.com/user-attachments/assets/eab41da0-96d1-4f44-9eb6-30c5befa0f8b" />

Checked in the fork repo , working fine.


## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15422)