### PR TITLE
[0.80 Cherry pick] Modal outstanding issues (#15445)

### DIFF
--- a/change/react-native-windows-b90b1242-253d-40d8-af6d-4722b31c1677.json
+++ b/change/react-native-windows-b90b1242-253d-40d8-af6d-4722b31c1677.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "solve modal foreground/background issue and only have a closebutton on title bar with no icon",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
@@ -66,6 +66,12 @@ struct ModalHostView : public winrt::implements<ModalHostView, winrt::Windows::F
         m_appWindow = nullptr;
       }
 
+      // Bring parent window to foreground
+      if (m_parentHwnd) {
+        SetForegroundWindow(m_parentHwnd);
+        SetFocus(m_parentHwnd);
+      }
+
       // Close bridge
       m_popUp.Close();
       m_popUp = nullptr;
@@ -247,6 +253,12 @@ struct ModalHostView : public winrt::implements<ModalHostView, winrt::Windows::F
           m_reactContext.Properties().Handle(), m_prevWindowID);
     }
 
+    // Bring parent window to foreground
+    if (m_parentHwnd) {
+      SetForegroundWindow(m_parentHwnd);
+      SetFocus(m_parentHwnd);
+    }
+
     // Dispatch onDismiss event
     if (auto eventEmitter = EventEmitter()) {
       ::Microsoft::ReactNativeSpecs::ModalHostViewEventEmitter::OnDismiss eventArgs;
@@ -287,8 +299,15 @@ struct ModalHostView : public winrt::implements<ModalHostView, winrt::Windows::F
       overlappedPresenter.IsModal(true);
       overlappedPresenter.SetBorderAndTitleBar(true, true);
 
+      // modal should only have close button
+      overlappedPresenter.IsMinimizable(false);
+      overlappedPresenter.IsMaximizable(false);
+
       // Apply the presenter to the window
       m_appWindow.SetPresenter(overlappedPresenter);
+
+      // Hide the title bar icon
+      m_appWindow.TitleBar().IconShowOptions(winrt::Microsoft::UI::Windowing::IconShowOptions::HideIconAndSystemMenu);
 
       // Set initial title using the stored local props
       if (m_localProps && m_localProps->title.has_value()) {


### PR DESCRIPTION
## Description
1> On closing modal the focus should go back to the main wndproc along with the system event message pump.
2> Modal title bar should only have Close( X ) button.
3> Modal title bar shouldn't have default application icon.

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
Solves the UI/UX related problems with RNW modal

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-windows/issues/15443
https://github.com/microsoft/react-native-windows/issues/15444

### What
setforeground and setfocus for main window after closure of modal
remove icon from App window
disable minimize and maximize option for modal

## Screenshots

https://github.com/user-attachments/assets/a4f624cd-117d-49fb-939d-45e173f0aa2c




## Testing
tested in playground

## Changelog
Should this change be included in the release notes: _indicate yes

Add a brief summary of the change to use in the release notes for the next release.
Fixed focus restoration on close, removed minimize/maximize buttons, and hidden title bar icon for cleaner modal appearance.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15451)