### PR TITLE
Fix crash when switching bundles in playground

### DIFF
--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -228,7 +228,7 @@ struct WindowData {
   }
 
   void UpdateViewOptions() {
-    if (!m_appName)
+    if (!m_appName || !m_compRootView)
       return;
 
     winrt::Microsoft::ReactNative::ReactViewOptions viewOptions;
@@ -263,12 +263,12 @@ struct WindowData {
           winrt::Microsoft::ReactNative::ReactCoreInjection::SetTopLevelWindowId(
               host.InstanceSettings().Properties(), reinterpret_cast<uint64_t>(hwnd));
 
+          // Nudge the ReactNativeHost to create the instance and wrapping context
+          host.ReloadInstance();
+
           for (auto &window : g_windows) {
             window->UpdateViewOptions();
           }
-
-          // Nudge the ReactNativeHost to create the instance and wrapping context
-          host.ReloadInstance();
         }
 
         break;


### PR DESCRIPTION
## Description
Switching bundles in playground crashes in main with assertion.

Issue: When switching bundles we used (UpdateViewOptions → ReloadInstance) View hosts attached to old instance, then instance destroyed, because of the stale references crash used to happen with componentViewDescriptorWithTag asserts as they were stale tags.

Fix: Instance reloaded first, then view hosts attached to new instance as ReactViewHost is tied to ReactNativeHost (not a specific instance), when ReloadInstance() completes, the new instance notifies all attached view hosts and they render correctly.

  
### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
Fix crash, makes RNW playground stable.

Resolves https://github.com/microsoft/react-native-windows/issues/15477

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
Instance reloaded first, then view hosts attached to new instance as ReactViewHost is tied to ReactNativeHost (not a specific instance), when ReloadInstance() completes, the new instance notifies all attached view hosts and they render correctly.

## Screenshots

https://github.com/user-attachments/assets/16fc81a3-1d02-4235-b644-2ca7433943b2



## Testing
tested in playground 

## Changelog
Should this change be included in the release notes: _indicate  no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15478)