### PR TITLE
Release NPM packages in publish pipeline

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -197,6 +197,29 @@ extends:
             parameters:
               buildEnvironment: Continuous
 
+          - script: echo NpmDistTag is $(NpmDistTag)
+            displayName: Show NPM dist tag
+
+          - script: dir /s "$(Pipeline.Workspace)\published-packages"
+            displayName: Show npm packages before ESRP release
+
+          - task: 'SFP.release-tasks.custom-build-release-task.EsrpRelease@10'
+            displayName: 'ESRP Release to npmjs.com'
+            condition: and(succeeded(), ne(variables['NpmDistTag'], ''))
+            inputs:
+              connectedservicename: 'ESRP-CodeSigning-OGX-JSHost-RNW'
+              usemanagedidentity: false
+              keyvaultname: 'OGX-JSHost-KV'
+              authcertname: 'OGX-JSHost-Auth4'
+              signcertname: 'OGX-JSHost-Sign3'
+              clientid: '0a35e01f-eadf-420a-a2bf-def002ba898d'
+              domaintenantid: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              contenttype: npm
+              folderlocation: '$(Pipeline.Workspace)\published-packages'
+              productstate: '$(NpmDistTag)'
+              owners: 'vmorozov@microsoft.com'
+              approvers: 'khosany@microsoft.com'
+
           - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
             displayName: 📒 Generate Manifest Npm
             inputs:

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -29,46 +29,6 @@ extends:
     - stage: Release
       displayName: Publish artifacts
       jobs:
-      - job: PushNpm
-        displayName: npmjs.com - Publish npm packages
-        variables:
-        - group: RNW Secrets
-        timeoutInMinutes: 0
-        templateContext:
-          inputs:
-          - input: pipelineArtifact
-            pipeline: 'Publish'
-            artifactName: 'NpmPackedTarballs'
-            targetPath: '$(Pipeline.Workspace)/published-packages'
-          - input: pipelineArtifact
-            pipeline: 'Publish'
-            artifactName: 'VersionEnvVars'
-            targetPath: '$(Pipeline.Workspace)/VersionEnvVars'
-        steps:
-        - checkout: none
-        - task: CmdLine@2
-          displayName: Apply version variables
-          inputs:
-            script: node $(Pipeline.Workspace)/VersionEnvVars/versionEnvVars.js
-        - script: dir /s "$(Pipeline.Workspace)\published-packages"
-          displayName: Show npm packages
-        - task: 'SFP.release-tasks.custom-build-release-task.EsrpRelease@10'
-          displayName: 'ESRP Release to npmjs.com'
-          condition: and(succeeded(), ne(variables['NpmDistTag'], ''))
-          inputs:
-            connectedservicename: 'ESRP-CodeSigning-OGX-JSHost-RNW'
-            usemanagedidentity: false
-            keyvaultname: 'OGX-JSHost-KV'
-            authcertname: 'OGX-JSHost-Auth4'
-            signcertname: 'OGX-JSHost-Sign3'
-            clientid: '0a35e01f-eadf-420a-a2bf-def002ba898d'
-            domaintenantid: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
-            contenttype: npm
-            folderlocation: '$(Pipeline.Workspace)\published-packages'
-            productstate: '$(NpmDistTag)'
-            owners: 'vmorozov@microsoft.com'
-            approvers: 'khosany@microsoft.com'
-
       - job: PushPrivateAdo
         displayName: ADO - react-native
         timeoutInMinutes: 0


### PR DESCRIPTION
## Description

Fix issues in PR and CI pipelines in CLI tests.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
PR #15416 made the NPM packages to be released in the `release.yml` pipeline as Nuget packages.
The issue is that we have a number of PR and CI validation tests that use the current NPM version.
After the change these tests start to fail because it may pass a few hours between the NPM package version update and their publishing in the `npmjs.com`.

### What
Ideally we must fix the PR and CI tests to not use the versions that are not published yet.
But this is a much bigger change.
This PR reverts to the previous state where the NPM package were released in the `publish.yml` pipeline.
It should reduce the time gap between the updating the version and the NPM package publishing.

## Testing
The `publish.yml` pipeline was manually verified from a temporary branch.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15482)