### PR TITLE
[0.80] Remove unnecessary steps in verdaccio-start.yml

### DIFF
--- a/.ado/templates/verdaccio-start.yml
+++ b/.ado/templates/verdaccio-start.yml
@@ -16,26 +16,6 @@ steps:
 
   - template: compute-beachball-branch-name.yml
 
-  # Ensure native layout artifacts (e.g., JSI files) are copied before publishing
-  - script: |
-      cd vnext
-      npx just layoutMSRNCxx
-    displayName: Run layoutMSRNCxx (generate native headers/jsi)
-    env:
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-  - script: yarn build --no-cache
-    displayName: Build packages before publish (no cache)
-    env:
-      YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-  # Verify the generated JSI source exists before publishing
-  - powershell: |
-      if (-not (Test-Path "$(Build.SourcesDirectory)\vnext\Microsoft.ReactNative.Cxx\jsi\jsi.cpp")) {
-        Write-Error "Missing generated jsi.cpp; layoutMSRNCxx did not run"
-      }
-    displayName: Validate generated JSI layout
-
   - ${{ if eq(parameters.beachballPublish, true) }}:
     - script: npx beachball bump --branch origin/$(BeachBallBranchName) --no-push --yes --verbose --changehint "Run `yarn change` from root of repo to generate a change file."
       displayName: Beachball bump versions


### PR DESCRIPTION
The PR #15483 is merged too soon while I was still working on the PR solution.
Since I had an auto-merge, it was merged as soon as the PR validation passed.
I was planning to clean up the code a bit before the code is merged.

This PR has some clean up in the `verdaccio-start.yml` that I wanted to do before the merge.
It deletes some steps that were implemented as a part of of an early investigation, but which were not making any difference and are unnecessary. They do not not do any harm. Thus, I did not undo the whole PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15493)