### PR TITLE
SFI ES2.6 Migrate from service accounts to Managed Identities

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -80,10 +80,6 @@ variables:
     value: false
   - name: EnableCodesign
     value: false
-  - name: ArtifactServices.Symbol.AccountName
-    value: microsoft
-  - name: ArtifactServices.Symbol.PAT
-    value: $(pat-symbols-publish-microsoft)
   - name: SourceBranchWithFolders
     value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
@@ -346,6 +342,8 @@ extends:
             # Make symbols available through http://symweb.
             - task: PublishSymbols@2
               displayName: Publish symbols
+              env:
+                ARTIFACTSERVICES_SYMBOL_ACCOUNTNAME: microsoft
               inputs:
                 SearchPattern: vnext/target/**/*.pdb
                 SymbolServerType: TeamServices
@@ -436,6 +434,8 @@ extends:
           - task: PublishSymbols@2
             displayName: 'Publish Symbols to Microsoft Symbol Server'
             condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+            env:
+              ARTIFACTSERVICES_SYMBOL_ACCOUNTNAME: microsoft
             inputs:
               SymbolsFolder: '$(System.DefaultWorkingDirectory)\NugetRoot'
               SearchPattern: '**/*.pdb'

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -81,7 +81,7 @@ extends:
             approvers: 'khosany@microsoft.com'
 
       - job: PushPrivateAdo
-        displayName: ADO - react-native
+        displayName: ADO - nuget - react-native
         timeoutInMinutes: 0
         templateContext:
           inputs:
@@ -93,18 +93,15 @@ extends:
         - checkout: none
         - task: NuGetToolInstaller@1
           displayName: 'Use NuGet '
-        - task: NuGetAuthenticate@1
-          displayName: NuGet Authenticate
-          inputs:
-            nuGetServiceConnections: ms/react-native ADO Feed
+        - template: .ado/templates/authenticate-office-react-native-windows-bot.yml@self
         - task: CmdLine@2
           displayName: NuGet push (react-native)
           inputs:
-            script: nuget.exe push *.nupkg -ApiKey AzureArtifacts -Source https://pkgs.dev.azure.com/ms/_packaging/react-native/nuget/v3/index.json -NonInteractive -Verbosity Detailed -SkipDuplicate -NoSymbols
+            script: nuget.exe push *.nupkg -ApiKey $(oficeReactnativeWindowsBotAadAuthToken) -Source https://pkgs.dev.azure.com/ms/_packaging/react-native/nuget/v3/index.json -NonInteractive -Verbosity Detailed -SkipDuplicate -NoSymbols
             workingDirectory: $(Pipeline.Workspace)/ReactWindows-final-nuget
 
       - job: PushPublicAdo
-        displayName: ADO - react-native-public
+        displayName: ADO - nuget - react-native-public
         timeoutInMinutes: 0
         templateContext:
           inputs:
@@ -116,14 +113,11 @@ extends:
         - checkout: none
         - task: NuGetToolInstaller@1
           displayName: 'Use NuGet '
-        - task: NuGetAuthenticate@1
-          displayName: NuGet Authenticate
-          inputs:
-            nuGetServiceConnections: ms/react-native-public ADO Feed
+        - template: .ado/templates/authenticate-office-react-native-windows-bot.yml@self
         - task: CmdLine@2
           displayName: NuGet push (react-native-public)
           inputs:
-            script: nuget.exe push *.nupkg -ApiKey AzureArtifacts -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -NonInteractive -Verbosity Detailed -SkipDuplicate -NoSymbols
+            script: nuget.exe push *.nupkg -ApiKey $(oficeReactnativeWindowsBotAadAuthToken) -Source https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json -NonInteractive -Verbosity Detailed -SkipDuplicate -NoSymbols
             workingDirectory: $(Pipeline.Workspace)/ReactWindows-final-nuget
 
       - job: PushNuGetOrg

--- a/.ado/templates/authenticate-office-react-native-windows-bot.yml
+++ b/.ado/templates/authenticate-office-react-native-windows-bot.yml
@@ -1,0 +1,11 @@
+steps:
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'Office-React-Native-Windows-Bot'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+          # Note that the resource is specified to limit the token to Azure DevOps
+          aadToken=$(az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv)
+          echo "##vso[task.setvariable variable=oficeReactnativeWindowsBotAadAuthToken;issecret=true]$aadToken"
+    displayName: 'Generate oficeReactnativeWindowsBotAadAuthToken AAD token using Azure CLI'


### PR DESCRIPTION
## Description

### Type of Change
- Compliance

### Why
Compliance requires migration to Managed Identities instead of PAT's.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15559)