### PR TITLE
[0.82 cherry pick]: Implements italic underline and strikethrough styling for TextInputTextinput fontstyles cherrypick

### DIFF
--- a/change/react-native-windows-084fcc59-de79-4413-8539-af111bc24555.json
+++ b/change/react-native-windows-084fcc59-de79-4413-8539-af111bc24555.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: Apply fontStyle italic to TextInput component",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1508,18 +1508,26 @@ void WindowsTextInputComponentView::UpdateCharFormat() noexcept {
   cfNew.wWeight =
       props.textAttributes.fontWeight ? static_cast<WORD>(*props.textAttributes.fontWeight) : DWRITE_FONT_WEIGHT_NORMAL;
 
-  // set font style
-  // cfNew.dwMask |= (CFM_ITALIC | CFM_STRIKEOUT | CFM_UNDERLINE);
-  // int dFontStyle = fontDetails.FontStyle;
-  // if (dFontStyle & FS_Italic) {
-  //    cfNew.dwEffects |= CFE_ITALIC;
-  //  }
-  //  if (dFontStyle & FS_StrikeOut) {
-  // cfNew.dwEffects |= CFE_STRIKEOUT;
-  //}
-  // if (dFontStyle & FS_Underline) {
-  //    cfNew.dwEffects |= CFE_UNDERLINE;
-  //  }
+  // set font style (italic)
+  cfNew.dwMask |= CFM_ITALIC;
+  if (props.textAttributes.fontStyle == facebook::react::FontStyle::Italic ||
+      props.textAttributes.fontStyle == facebook::react::FontStyle::Oblique) {
+    cfNew.dwEffects |= CFE_ITALIC;
+  }
+
+  // set text decoration (underline and strikethrough)
+  cfNew.dwMask |= (CFM_UNDERLINE | CFM_STRIKEOUT);
+  if (props.textAttributes.textDecorationLineType.has_value()) {
+    auto decorationType = *props.textAttributes.textDecorationLineType;
+    if (decorationType == facebook::react::TextDecorationLineType::Underline ||
+        decorationType == facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
+      cfNew.dwEffects |= CFE_UNDERLINE;
+    }
+    if (decorationType == facebook::react::TextDecorationLineType::Strikethrough ||
+        decorationType == facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
+      cfNew.dwEffects |= CFE_STRIKEOUT;
+    }
+  }
 
   // set font family
   if (!props.textAttributes.fontFamily.empty()) {


### PR DESCRIPTION
## Description
[cherry pick] Implements italic underline and strikethrough styling for TextInput

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why
Bug fix

Resolves
https://github.com/microsoft/react-native-gallery/issues/767

### What
Implements italic, underline, and strikethrough styling for TextInput by setting CFE_ITALIC, CFE_UNDERLINE, and CFE_STRIKEOUT effects in UpdateCharFormat().


## Screenshots



https://github.com/user-attachments/assets/9001f478-5f5c-4575-b51b-8f0f0e71da3d




## Testing
Tested in playground


## Changelog
Should this change be included in the release notes: _indicate yes

Add a brief summary of the change to use in the release notes for the next release.
Added support for italic underline and strikethrough styling for TextInput

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15563)
