### PR TITLE
fix(cli): fix template info not detecting mixed architecture projects

### DIFF
--- a/change/@react-native-windows-cli-67af0813-4acc-4796-b7a7-a05f5eb1d623.json
+++ b/change/@react-native-windows-cli-67af0813-4acc-4796-b7a7-a05f5eb1d623.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed template info not detecting mixed architecture projects",
+  "packageName": "@react-native-windows/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
@@ -143,22 +143,6 @@ export function getRawTemplateInfo(filePath: string): RawTemplateInfo {
     if (
       importProjectExists(
         projectContents,
-        'Microsoft.ReactNative.Uwp.CppApp.targets',
-      )
-    ) {
-      result.projectType = 'app';
-      result.projectArch = 'old';
-    } else if (
-      importProjectExists(
-        projectContents,
-        'Microsoft.ReactNative.Uwp.CppLib.targets',
-      )
-    ) {
-      result.projectType = 'lib';
-      result.projectArch = 'old';
-    } else if (
-      importProjectExists(
-        projectContents,
         'Microsoft.ReactNative.Composition.CppApp.targets',
       )
     ) {
@@ -180,6 +164,22 @@ export function getRawTemplateInfo(filePath: string): RawTemplateInfo {
     ) {
       result.projectType = 'lib';
       result.projectArch = 'mixed';
+    } else if (
+      importProjectExists(
+        projectContents,
+        'Microsoft.ReactNative.Uwp.CppApp.targets',
+      )
+    ) {
+      result.projectType = 'app';
+      result.projectArch = 'old';
+    } else if (
+      importProjectExists(
+        projectContents,
+        'Microsoft.ReactNative.Uwp.CppLib.targets',
+      )
+    ) {
+      result.projectType = 'lib';
+      result.projectArch = 'old';
     }
   }
 


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Libraries that still support both new and old architecture are incorrectly detected as 'old'.

### What

Moved the checks for new architecture up so that we return `new` before checking for old arch.

## Screenshots

n/a

## Testing

n/a

## Changelog

Should this change be included in the release notes: yes

Fixed detection of projects with mixed architecture support

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15567)