### PR TITLE
[0.82] cherry picks: Fix selectable text not receiving pointer events inside ScrollView

### DIFF
--- a/change/react-native-windows-230b1cbb-2867-42d5-b799-bfb0f33c6baf.json
+++ b/change/react-native-windows-230b1cbb-2867-42d5-b799-bfb0f33c6baf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix selectable text not working inside ScrollView",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -171,6 +171,26 @@ void ParagraphComponentView::updateTextAlignment(
   m_textLayout = nullptr;
 }
 
+facebook::react::Tag ParagraphComponentView::hitTest(
+    facebook::react::Point pt,
+    facebook::react::Point &localPt,
+    bool ignorePointerEvents) const noexcept {
+  facebook::react::Point ptLocal{pt.x - m_layoutMetrics.frame.origin.x, pt.y - m_layoutMetrics.frame.origin.y};
+  const auto &props = paragraphProps();
+  const auto &vProps = *viewProps();
+
+  if (props.isSelectable && ptLocal.x >= 0 && ptLocal.x <= m_layoutMetrics.frame.size.width && ptLocal.y >= 0 &&
+      ptLocal.y <= m_layoutMetrics.frame.size.height) {
+    // claims if pointer events are enabled for this component
+    if (ignorePointerEvents || vProps.pointerEvents == facebook::react::PointerEventsMode::Auto ||
+        vProps.pointerEvents == facebook::react::PointerEventsMode::BoxOnly) {
+      localPt = ptLocal;
+      return Tag();
+    }
+  }
+  return Super::hitTest(pt, localPt, ignorePointerEvents);
+}
+
 bool ParagraphComponentView::IsTextSelectableAtPoint(facebook::react::Point pt) noexcept {
   // paragraph-level selectable prop is enabled
   const auto &props = paragraphProps();
@@ -543,7 +563,8 @@ void ParagraphComponentView::OnPointerPressed(
     return;
   }
 
-  auto pp = args.GetCurrentPoint(-1);
+  // Use Tag() to get coordinates in component's local space
+  auto pp = args.GetCurrentPoint(static_cast<int32_t>(Tag()));
 
   // Ignores right-click
   if (pp.Properties().PointerUpdateKind() ==
@@ -554,8 +575,8 @@ void ParagraphComponentView::OnPointerPressed(
 
   auto position = pp.Position();
 
-  facebook::react::Point localPt{
-      position.X - m_layoutMetrics.frame.origin.x, position.Y - m_layoutMetrics.frame.origin.y};
+  // GetCurrentPoint(Tag()) returns position relative to component origin
+  facebook::react::Point localPt{position.X, position.Y};
 
   std::optional<int32_t> charPosition = GetTextPositionAtPoint(localPt);
 
@@ -629,7 +650,7 @@ void ParagraphComponentView::OnPointerMoved(
 void ParagraphComponentView::OnPointerReleased(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   // Check for right-click to show context menu
-  auto pp = args.GetCurrentPoint(-1);
+  auto pp = args.GetCurrentPoint(static_cast<int32_t>(Tag()));
   if (pp.Properties().PointerUpdateKind() ==
       winrt::Microsoft::ReactNative::Composition::Input::PointerUpdateKind::RightButtonReleased) {
     const auto &props = paragraphProps();

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -49,6 +49,11 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
   static facebook::react::SharedViewProps defaultProps() noexcept;
   const facebook::react::ParagraphProps &paragraphProps() const noexcept;
 
+  facebook::react::Tag hitTest(
+      facebook::react::Point pt,
+      facebook::react::Point &localPt,
+      bool ignorePointerEvents = false) const noexcept override;
+
   // Returns true when text is selectable
   bool focusable() const noexcept override;
 


### PR DESCRIPTION
## Description
Selectable text (`<Text selectable={true}>`) was not working when placed inside a ScrollView or other parent components that consume pointer events.


### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why
Make selectable text consume pointer events irrespective of parent container


Resolves
https://github.com/microsoft/react-native-windows/issues/15578

### What
- Override `hitTest()` in `ParagraphComponentView` to claim pointer events for selectable text before parent components
- Use `GetCurrentPoint(Tag())` instead of `GetCurrentPoint(-1)` to get correct local coordinates

## Screenshots

https://github.com/user-attachments/assets/948229fe-1de1-4bac-b783-2889e1723a88


## Testing
tested in playground


## Changelog
Should this change be included in the release notes: _indicate yes

Add a brief summary of the change to use in the release notes for the next release.
Fixed selectable text not receiving pointer events inside ScrollView

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15580)