### PR TITLE
[0.82] Cherry-picks: Add web multipart/form-data test

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -105,6 +105,7 @@
         BaseOutDir;
         ReactNativeDir;
         ReactNativeWindowsDir;
+        RnwNewArch;
         FollyDir;
         YogaDir;
         WinVer;

--- a/change/react-native-windows-14d8afe5-5c05-4205-aeec-11134992e9c2.json
+++ b/change/react-native-windows-14d8afe5-5c05-4205-aeec-11134992e9c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add multipart/form-data test endpoint",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/TestWebSite/Microsoft/Office/OfficeJsTests.cs
+++ b/vnext/TestWebSite/Microsoft/Office/OfficeJsTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Office.Test
 {
@@ -11,6 +12,32 @@ namespace Microsoft.Office.Test
       response.StatusCode = 200;
 
       var bytes = Encoding.UTF8.GetBytes("Check headers: [Access-Control-Allow-Origin]");
+      await response.Body.WriteAsync(bytes);
+    }
+
+    public static async Task Issue5869(HttpContext context)
+    {
+      var response = context.Response;
+      response.ContentType = "text/plain";
+      response.StatusCode = 200;
+
+      var request = context.Request;
+
+      string? resBody;
+      if (Regex.IsMatch(request.ContentType!, @"multipart/form-data(;\s+.*)?"))
+      {
+        resBody = $"Multipart form data with {request.Form.Count} entries";
+      }
+      else if (request.ContentType == "application/x-www-form-urlencoded")
+      {
+        resBody = $"URL-encoded form data with {request.Form.Count} entries";
+      }
+      else
+      {
+        resBody = $"Unknown Content-Type [{request.ContentType}]";
+      }
+
+      var bytes = Encoding.UTF8.GetBytes(resBody);
       await response.Body.WriteAsync(bytes);
     }
   }

--- a/vnext/TestWebSite/Program.cs
+++ b/vnext/TestWebSite/Program.cs
@@ -85,6 +85,10 @@ app.MapGet(
    Microsoft.Office.Test.OfficeJsTests.Issue4144)
   .RequireCors(originPolicyName);
 
+app.MapPost(
+  "/officedev/office-js/issues/5869",
+   Microsoft.Office.Test.OfficeJsTests.Issue5869);
+
 #endregion Request Mappings
 
 await app.RunAsync();


### PR DESCRIPTION
## Description

Adds an HTTP test endpoint to validate multipart form data requests.

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
See https://github.com/OfficeDev/office-js/issues/5869.

There is currently no coverage for form data HTTP requests.

### What
Add test website endpoint `/officedev/office-js/issues/5869`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15550)