### PR TITLE
[0.82] Skips publishing symbols for preview build

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -344,8 +344,10 @@ extends:
             - template: .ado/templates/component-governance.yml@self
 
             # Make symbols available through http://symweb.
+            # TODO: Re-enable after fixing symbol publishing authentication for 0.82 release
             - task: PublishSymbols@2
               displayName: Publish symbols
+              enabled: false
               inputs:
                 SearchPattern: vnext/target/**/*.pdb
                 SymbolServerType: TeamServices
@@ -433,8 +435,10 @@ extends:
                   configuration: Debug
 
           # Symbol Publishing for Work Item 59264834 - MSRC Compliance
+          # TODO: Re-enable after fixing symbol publishing authentication
           - task: PublishSymbols@2
             displayName: 'Publish Symbols to Microsoft Symbol Server'
+            enabled: false
             condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
             inputs:
               SymbolsFolder: '$(System.DefaultWorkingDirectory)\NugetRoot'


### PR DESCRIPTION
Skips publishing symbols for preview build, will enable it with release build for RNW 0.82
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15596)