### PR TITLE
[0.81] Cherry-picks: Fix selectable text not receiving pointer events inside ScrollView 

### DIFF
--- a/change/react-native-windows-230b1cbb-2867-42d5-b799-bfb0f33c6baf.json
+++ b/change/react-native-windows-230b1cbb-2867-42d5-b799-bfb0f33c6baf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix selectable text not working inside ScrollView",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -49,6 +49,11 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
   static facebook::react::SharedViewProps defaultProps() noexcept;
   const facebook::react::ParagraphProps &paragraphProps() const noexcept;
 
+  facebook::react::Tag hitTest(
+      facebook::react::Point pt,
+      facebook::react::Point &localPt,
+      bool ignorePointerEvents = false) const noexcept override;
+
   // Returns true when text is selectable
   bool focusable() const noexcept override;
 


### PR DESCRIPTION
backports https://github.com/microsoft/react-native-windows/pull/15577 into 0.81
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15598)