### PR TITLE
[0.82] Bring Narrator focus to XAML island

### DIFF
--- a/change/react-native-windows-6aa7fa60-ce9f-4693-b4ec-7fe965283489.json
+++ b/change/react-native-windows-6aa7fa60-ce9f-4693-b4ec-7fe965283489.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use automationoption as frameworkbased for childsite",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.h
@@ -70,10 +70,6 @@ struct ContentIslandComponentView : ContentIslandComponentViewT<ContentIslandCom
 
   // Automation
   void ConfigureChildSiteLinkAutomation() noexcept;
-  winrt::event_token m_fragmentRootAutomationProviderRequestedToken{};
-  winrt::event_token m_parentAutomationProviderRequestedToken{};
-  winrt::event_token m_nextSiblingAutomationProviderRequestedToken{};
-  winrt::event_token m_previousSiblingAutomationProviderRequestedToken{};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation


### PR DESCRIPTION
## Description
Earlier for childsite link automation we were fragment-based option. Since XAML island will take care of it automation on its own , we are using framework-based option

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
To bring narrator focus to the XAML island cause of community modules native components are using XAML Island.

Resolves [ #15320 ]

### What
Changed automation option for child site to be framework based.

## Screenshots


https://github.com/user-attachments/assets/9facbef4-3521-4360-bc06-87a7ac4a6a15





## Testing
Tested in playground.

## Changelog
Should this change be included in the release notes: _yes_

Bring Narrator focus to the XAML island

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15612)