### PR TITLE
[0.81] Enables word-extension during drag after a double-click select

### DIFF
--- a/change/react-native-windows-3c6ddb8b-a7f5-4d43-a953-7461a9bc110c.json
+++ b/change/react-native-windows-3c6ddb8b-a7f5-4d43-a953-7461a9bc110c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "enables word-extension during drag after a double-click selection",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -100,6 +100,7 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
 
   // Selects the word at the given character position
   void SelectWordAtPosition(int32_t charPosition) noexcept;
+  std::pair<int32_t, int32_t> GetWordBoundariesAtPosition(int32_t charPosition) noexcept;
 
   // Shows a context menu with Copy/Select All options on right-click
   void ShowContextMenu() noexcept;
@@ -117,6 +118,11 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
   std::optional<int32_t> m_selectionStart;
   std::optional<int32_t> m_selectionEnd;
   bool m_isSelecting{false};
+
+  // Double click + drag selection
+  bool m_isWordSelecting{false};
+  int32_t m_wordAnchorStart{0};
+  int32_t m_wordAnchorEnd{0};
 
   // Double-click detection
   std::chrono::steady_clock::time_point m_lastClickTime{};


### PR DESCRIPTION
backports https://github.com/microsoft/react-native-windows/pull/15640
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15654)