### PR TITLE
Fix prepare-release-bot pipeline

### DIFF
--- a/.ado/prepare-release-bot.yml
+++ b/.ado/prepare-release-bot.yml
@@ -52,15 +52,25 @@ jobs:
           Write-Host "##vso[task.setvariable variable=GitHubOAuthToken;issecret=true]$token"
         displayName: Extract GitHub OAuth token
 
-      - template: templates/prepare-js-env.yml
-        parameters:
-          agentImage: HostedImage
+      - task: NodeTool@0
+        displayName: Set Node Version
+        inputs:
+          versionSpec: '24.x'
+
+      - script: if not exist %APPDATA%\npm (mkdir %APPDATA%\npm)
+        displayName: Ensure npm directory for npx commands
+
+      - script: npx --yes midgard-yarn@1.23.34 --ignore-scripts --frozen-lockfile
+        displayName: yarn install
+
+      - script: npx lage build --scope @rnw-scripts/prepare-release --scope @rnw-scripts/beachball-config
+        displayName: Build prepare-release and dependencies
 
       - ${{ if ne(parameters.targetBranch, '(source branch)') }}:
-        - script: echo ##vso[task.setvariable variable=TargetBranch]${{ parameters.targetBranch }}
+        - pwsh: Write-Host "##vso[task.setvariable variable=TargetBranch]${{ parameters.targetBranch }}"
           displayName: Set target branch from parameter
       - ${{ else }}:
-        - script: echo ##vso[task.setvariable variable=TargetBranch]$(Build.SourceBranchName)
+        - pwsh: Write-Host "##vso[task.setvariable variable=TargetBranch]$(Build.SourceBranchName)"
           displayName: Set target branch from source
 
       - script: npx prepare-release --branch $(TargetBranch) --no-color


### PR DESCRIPTION
## Description

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
The prepare-release bot pipeline needed GitHub API access to create and update PRs, but relied on a GitHub PAT stored in the `RNW Secrets` variable group. With PAT lifespans being reduced, this approach is no longer viable.

### What
- **Use OAuth token instead of PAT**: Extract the GitHub OAuth token from `persistCredentials` at runtime and pass it as `GH_TOKEN`. This removes the dependency on `$(githubAuthToken)` from the `RNW Secrets` variable group.
- **Add target branch parameter**: Operators can select a specific target branch (`main`, `0.82-stable`, etc.) from a dropdown when running manually, instead of always using the pipeline source branch.
- **Optimize build time**: Replace `prepare-js-env.yml` (full monorepo `yarn build` ~16 min) with a scoped `lage build` of only the required packages. Pipeline runs dropped from ~21 min to ~6 min.
- **Optimize checkout**: Replace `checkout-full.yml` with shallow checkout (`fetchDepth: 1`, `fetchTags: false`).
- **Use `windows-latest` pool**: Replace named `rnw-pool-2-microsoft` pool with `vmImage: windows-latest`.
- **Use Node 24**: Updated from Node 22 to Node 24.
- **Move triggers to ADO UI**: Removed YAML `schedules` block; triggers are configured in the ADO pipeline settings.

## Screenshots
N/A

## Testing
Pipeline tested end-to-end: successfully creates and updates PRs via the GitHub API using the extracted OAuth token.

## Changelog
Should this change be included in the release notes: no
