### PR TITLE
Enable perf results PR comment on CI runs

### DIFF
--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      pull-requests: write
 
     steps:
       # ── Setup ──────────────────────────────────────────────
@@ -82,6 +83,14 @@ jobs:
             packages/e2e-test-app-fabric/.perf-results/
             packages/e2e-test-app-fabric/test/__perf__/**/__perf_snapshots__/
           retention-days: 30
+
+      # ── PR Comment ────────────────────────────────────────
+      - name: Post perf results to PR
+        if: github.event_name == 'pull_request' && always()
+        working-directory: packages/e2e-test-app-fabric
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn perf:ci:report
 
       # ── Status Gate ────────────────────────────────────────
       - name: Check for regressions


### PR DESCRIPTION
## Description
Enable perf results PR comment on CI runs

### Type of Change
- New feature (non-breaking change which adds functionality)


### Why
Added "Post perf results to PR" step that runs [yarn perf:ci:report on every PR, posts/updates a comment with the full results table

Resolves https://github.com/microsoft/react-native-windows/issues/15665

### What
Regressions table — if any exist
Passed table — collapsed details block showing all passing scenarios with median, stdDev, % vs baseline
New scenarios — if your PR adds new perf tests





## Changelog
Should this change be included in the release notes: no_

Add a brief summary of the change to use in the release notes for the next release.
