### PR TITLE
fix(ci): Use workflow_run for perf PR comments to support fork PRs

### DIFF
--- a/.github/workflows/perf-comment.yml
+++ b/.github/workflows/perf-comment.yml
@@ -1,0 +1,94 @@
+name: Post Perf Results to PR
+
+# Runs after the Perf Tests workflow completes. Uses workflow_run so
+# the GITHUB_TOKEN is scoped to the base repo and can write PR comments
+# even when the PR comes from a fork.
+on:
+  workflow_run:
+    workflows: ['Perf Tests']
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post PR Comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+
+    permissions:
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download perf results artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-results
+          path: perf-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          if [ ! -f perf-results/pr-number.txt ]; then
+            echo "No PR number file found — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER=$(cat perf-results/pr-number.txt | tr -d '[:space:]')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Read markdown report
+        if: steps.pr.outputs.skip != 'true'
+        id: report
+        run: |
+          if [ ! -f perf-results/report.md ]; then
+            echo "No report.md found — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: steps.pr.outputs.skip != 'true' && steps.report.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- rnw-perf-results -->';
+            const reportPath = 'perf-results/report.md';
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+
+            const markdown = fs.readFileSync(reportPath, 'utf-8');
+            const body = `${marker}\n${markdown}`;
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing comment (id: ${existing.id})`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info('Created new comment');
+            }

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -32,7 +32,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      pull-requests: write
 
     steps:
       # ── Setup ──────────────────────────────────────────────
@@ -83,14 +82,6 @@ jobs:
             packages/e2e-test-app-fabric/.perf-results/
             packages/e2e-test-app-fabric/test/__perf__/**/__perf_snapshots__/
           retention-days: 30
-
-      # ── PR Comment ────────────────────────────────────────
-      - name: Post perf results to PR
-        if: github.event_name == 'pull_request' && always()
-        working-directory: packages/e2e-test-app-fabric
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn perf:ci:report
 
       # ── Status Gate ────────────────────────────────────────
       - name: Check for regressions


### PR DESCRIPTION
## Description
he "Post perf results to PR" step fails with 403: Resource not accessible by integration on fork PRs because GITHUB_TOKEN from the trigger is scoped to the fork and cannot write comments on the base repo.

This splits the PR comment logic into a separate workflow_run-triggered workflow that runs in the base repo context with write access to PR comments.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15758)