### PR TITLE
Fix name of Release runs

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -24,8 +24,8 @@ resources:
         include:
         - main
         - refs/heads/main
-        - '*.stable'
-        - 'refs/heads/*.stable'
+        - '*-stable'
+        - 'refs/heads/*-stable'
   repositories:
   - repository: 1ESPipelineTemplates
     type: git


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The NuGet Release pipeline shows incorrect run names and branch info when triggered
by Publish pipeline completion. All triggered runs display the latest `main` commit
message and `main` as the branch, regardless of which branch the Publish pipeline
actually ran on. This causes the RELEASE stage condition to skip legitimate releases.

Example from 2026-03-12:
- Publish `0.0.2603.12002` ran on `main` with a RELEASE commit, but the Release run
  showed "Bump beachball..." (the latest main commit) and was incorrectly **skipped**
- Publish `0.0.2603.12003` ran on `0.82-stable`, but the Release run also showed
  `main` branch and the same wrong commit message

Root cause: the Release pipeline uses a **classic UI build completion trigger** which
always runs against the default branch. This is a
[documented limitation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops) —
UI build completion triggers cannot run the triggered pipeline on the same branch as
the triggering pipeline. Additionally, UI triggers override YAML triggers, so previous
attempts to fix this with YAML triggers failed because the UI trigger was still present.

### What
- Replaced `trigger: none` on the Publish pipeline resource with a YAML pipeline
  resource trigger with branch filters for `main` and `*-stable`
  (with `refs/heads/` variants for robustness per ADO docs recommendation)
- Updated the header comment to warn against re-adding UI build completion triggers

**Manual steps required after merge:**
1. Remove the classic UI build completion trigger: Pipeline editor → Triggers tab →
   Build completion → delete the "Publish" entry → Save
2. Synchronize resource triggers: Pipeline three-dot menu → Triggers →
   Resource triggers tab → click "Synchronize"

No backport to stable branches is needed — ADO evaluates trigger branch filters from
the default branch (`main`) only.

## Screenshots
N/A

## Testing
This cannot be fully tested without merging to `main` and triggering a real Publish
completion. However:
- The YAML syntax is straightforward (no new parameters or templates)
- The trigger behavior is well-documented by Microsoft
- Manual runs are unaffected (the stage condition allows them unconditionally)
- Pipeline resource triggers are evaluated from the default branch's YAML, so
  PRs cannot modify trigger behavior (no security concern)

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15770)