### PR TITLE
Increase build pipeline timeouts for CodeQL

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -107,7 +107,7 @@ extends:
           displayName: Setup
           variables: [template: .ado/variables/shared.yml@self]
           pool: ${{ parameters.AgentPool.Medium }}
-          timeoutInMinutes: 15
+          timeoutInMinutes: 60 # CodeQL requires 3x usual build timeout
           steps:
           # 1. Detect whether this is a release build or a developer build
           - pwsh: |
@@ -224,7 +224,7 @@ extends:
         - job: RnwNpmPack
           displayName: Create NPM packages
           pool: ${{ parameters.AgentPool.Medium }}
-          timeoutInMinutes: 60
+          timeoutInMinutes: 120 # CodeQL requires 3x usual build timeout
           cancelTimeoutInMinutes: 5
           steps:
           - template: .ado/templates/checkout-shallow.yml@self


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
We often see build stopped because of timeout when CodeQL is injected into the build pipeline.

### What
Increased the allowed timeouts in the build-template.yml.

## Testing
If PR validation passes, then the change can be considered to be tested.

## Changelog
Should this change be included in the release notes: _no_

Increased the allowed timeouts in the build-template.yml.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15870)