### PR TITLE
Disable CodeQL in Setup job

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -206,6 +206,9 @@ extends:
             condition: and(succeeded(), eq('${{ parameters.buildEnvironment }}', 'Continuous'))
 
           templateContext:
+            sdl:
+              codeql:
+                enabled: false
             outputs:
               - output: pipelineArtifact
                 displayName: 'Publish version variables'


### PR DESCRIPTION
## Description

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
The Setup job in `build-template.yml` does not compile any C++ or C# code — it only detects the build scenario, bumps versions, and publishes version variables. However, it inherits the pipeline-level CodeQL SDL configuration which attempts to scan for `cpp` and `csharp`. Since no source code is built, CodeQL's C# `pre-finalize.cmd` hangs indefinitely, consuming the full job timeout (1h+) before being cancelled.

### What
Disable CodeQL in the Setup job by adding `templateContext.sdl.codeql.enabled: false` to the job definition in `.ado/build-template.yml`.

CodeQL scanning remains enabled on all Desktop and Universal build jobs where compiled code is actually produced.

## Screenshots
N/A

## Testing
- Run the CI pipeline and verify the Setup job completes in ~5 minutes without the CodeQL Finalize timeout.
- Verify CodeQL Initialize/Finalize steps no longer appear in the Setup job.
- Verify CodeQL still runs on Desktop and Universal build jobs.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15882)