### PR TITLE
fix: resolve artifact path mismatch in perf-comment workflow

### DIFF
--- a/.github/workflows/perf-comment.yml
+++ b/.github/workflows/perf-comment.yml
@@ -32,24 +32,27 @@ jobs:
       - name: Read PR number
         id: pr
         run: |
-          if [ ! -f perf-results/pr-number.txt ]; then
+          PR_FILE=$(find perf-results -name pr-number.txt -type f | head -1)
+          if [ -z "$PR_FILE" ]; then
             echo "No PR number file found — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PR_NUMBER=$(cat perf-results/pr-number.txt | tr -d '[:space:]')
+          PR_NUMBER=$(cat "$PR_FILE" | tr -d '[:space:]')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Read markdown report
-        if: steps.pr.outputs.skip != 'true'
         id: report
+        if: steps.pr.outputs.skip != 'true'
         run: |
-          if [ ! -f perf-results/report.md ]; then
+          REPORT_FILE=$(find perf-results -name report.md -type f | head -1)
+          if [ -z "$REPORT_FILE" ]; then
             echo "No report.md found — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "path=$REPORT_FILE" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Post or update PR comment
@@ -59,7 +62,7 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- rnw-perf-results -->';
-            const reportPath = 'perf-results/report.md';
+            const reportPath = '${{ steps.report.outputs.path }}';
             const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
 
             const markdown = fs.readFileSync(reportPath, 'utf-8');


### PR DESCRIPTION
## Description
resolve artifact path mismatch in perf-comment workflow

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The perf-comment.yml workflow never posted PR comments because it looked for pr-number.txt and report.md at hardcoded flat paths (perf-results/pr-number.txt), but download-artifact@v4 preserves the nested directory structure from the upload, placing files at perf-results/packages/e2e-test-app-fabric/.perf-results/.

### What

- Replaced hardcoded file path checks with find to locate pr-number.txt and report.md regardless of artifact directory nesting
- Passed the discovered report.md path as a step output to the PR comment posting step

## Testing

## Changelog
Should this change be included in the release notes: _indicate: no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15883)