### PR TITLE
Harden Release publishing

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -199,6 +199,7 @@ extends:
           - template: .ado/templates/set-version-vars.yml@self
             parameters:
               buildEnvironment: Continuous
+              isReleaseBuild: $(isReleaseBuild)
 
           # 8. Include npmPack.js for Release pipeline (CI only)
           - script: copy ".ado\scripts\npmPack.js" "$(Build.StagingDirectory)\versionEnvVars\npmPack.js"

--- a/.ado/release-pipeline.yml
+++ b/.ado/release-pipeline.yml
@@ -19,6 +19,12 @@ name: RNW Release $(Date:yyyyMMdd).$(Rev:r)
 trigger: none
 pr: none
 
+parameters:
+  - name: forceRelease
+    displayName: 'Force release (override CI flag — emergency use only)'
+    type: boolean
+    default: false
+
 resources:
   pipelines:
   - pipeline: 'CI'
@@ -57,6 +63,12 @@ extends:
       jobs:
       - job: Evaluate
         displayName: Check if release should proceed
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: 'CI'
+            artifactName: 'VersionEnvVars'
+            targetPath: '$(Pipeline.Workspace)/VersionEnvVars'
         steps:
         - checkout: none
 
@@ -99,10 +111,15 @@ extends:
             CI_REQUESTEDFOR: $(resources.pipeline.CI.requestedFor)
             CI_REQUESTEDFORID: $(resources.pipeline.CI.requestedForID)
 
+        # Apply version variables from the CI artifact (sets IsReleaseBuild, npmVersion, etc.)
+        - task: CmdLine@2
+          displayName: Apply CI version variables
+          inputs:
+            script: node $(Pipeline.Workspace)/VersionEnvVars/versionEnvVars.js
+
         - pwsh: |
-            $buildReason = $env:BUILD_REASON
-            # Use only the first line of the commit message
-            $sourceMessage = ($env:SOURCE_MESSAGE -split "`n")[0].Trim()
+            $forceRelease = '${{ parameters.forceRelease }}'
+            $isReleaseBuild = $env:IS_RELEASE_BUILD
             $ciRunName = $env:CI_RUN_NAME
             $sourceBranch = $env:SOURCE_BRANCH -replace '^refs/heads/', ''
 
@@ -111,10 +128,31 @@ extends:
             $originalBuildNumber = $env:BUILD_BUILDNUMBER
             $dateStamp = if ($originalBuildNumber -match '(\d{8}\.\d+)$') { $Matches[1] } else { "" }
 
+            # Fallback: if IsReleaseBuild is not in the CI artifact (old branches),
+            # fall back to commit message detection for backward compatibility.
+            if (-not $isReleaseBuild) {
+              $sourceMessage = ($env:SOURCE_MESSAGE -split "`n")[0].Trim()
+              $isReleaseBuild = if ($sourceMessage.StartsWith("RELEASE:")) { 'True' } else { 'False' }
+              Write-Host "##[warning]IsReleaseBuild not found in CI artifact, fell back to commit message detection: $isReleaseBuild"
+            }
+
+            Write-Host "isReleaseBuild (from CI): $isReleaseBuild"
+            Write-Host "forceRelease (param):     $forceRelease"
+
             $shouldRelease = $false
             $buildNumber = ""
 
-            if ($buildReason -eq "Manual") {
+            if ($forceRelease -eq 'True') {
+              # Emergency override — allow publishing regardless of CI flag
+              $shouldRelease = $true
+              if ($ciRunName) {
+                $buildNumber = "$ciRunName [FORCED] ($sourceBranch) - $dateStamp"
+              } else {
+                $buildNumber = "Release [FORCED] ($sourceBranch) - $dateStamp"
+              }
+              Write-Host "##[warning]Release forced by parameter override"
+            }
+            elseif ($isReleaseBuild -eq 'True') {
               $shouldRelease = $true
               if ($ciRunName) {
                 $buildNumber = "$ciRunName ($sourceBranch) - $dateStamp"
@@ -122,14 +160,10 @@ extends:
                 $buildNumber = "Release ($sourceBranch) - $dateStamp"
               }
             }
-            elseif ($sourceMessage.StartsWith("RELEASE:")) {
-              $shouldRelease = $true
-              $buildNumber = "$ciRunName ($sourceBranch) - $dateStamp"
-            }
             else {
               $shouldRelease = $false
               # Truncate commit message for readability
-              $shortMsg = $sourceMessage
+              $shortMsg = ($env:SOURCE_MESSAGE -split "`n")[0].Trim()
               if ($shortMsg.Length -gt 60) {
                 $shortMsg = $shortMsg.Substring(0, 57) + "..."
               }
@@ -147,20 +181,20 @@ extends:
             Write-Host "##vso[build.updatebuildnumber]$buildNumber"
             Write-Host "##vso[task.setvariable variable=shouldRelease;isOutput=true]$shouldRelease"
           name: gate
-          displayName: Determine release eligibility and set build number
+          displayName: Determine release eligibility from CI artifact
           env:
-            BUILD_REASON: $(Build.Reason)
             BUILD_BUILDNUMBER: $(Build.BuildNumber)
-            SOURCE_MESSAGE: $(Build.SourceVersionMessage)
+            IS_RELEASE_BUILD: $(IsReleaseBuild)
             CI_RUN_NAME: $(resources.pipeline.CI.runName)
             SOURCE_BRANCH: $(resources.pipeline.CI.sourceBranch)
+            SOURCE_MESSAGE: $(Build.SourceVersionMessage)
 
         - script: echo Proceeding with release
           displayName: RELEASING - proceeding to publish
           condition: eq(variables['gate.shouldRelease'], 'True')
 
         - script: echo Skipping release
-          displayName: SKIPPED - not a RELEASE commit
+          displayName: SKIPPED - not a release build
           condition: eq(variables['gate.shouldRelease'], 'False')
 
     - stage: Release

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -14,6 +14,12 @@ name: RNW NuGet Release $(Date:yyyyMMdd).$(Rev:r)
 trigger: none
 pr: none
 
+parameters:
+  - name: forceRelease
+    displayName: 'Force release (override CI flag — emergency use only)'
+    type: boolean
+    default: false
+
 resources:
   pipelines:
   - pipeline: 'Publish'
@@ -52,6 +58,12 @@ extends:
       jobs:
       - job: Evaluate
         displayName: Check if release should proceed
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            pipeline: 'Publish'
+            artifactName: 'VersionEnvVars'
+            targetPath: '$(Pipeline.Workspace)/VersionEnvVars'
         steps:
         - checkout: none
 
@@ -94,10 +106,15 @@ extends:
             PUBLISH_REQUESTEDFOR: $(resources.pipeline.Publish.requestedFor)
             PUBLISH_REQUESTEDFORID: $(resources.pipeline.Publish.requestedForID)
 
+        # Apply version variables from the CI artifact (sets IsReleaseBuild, npmVersion, etc.)
+        - task: CmdLine@2
+          displayName: Apply CI version variables
+          inputs:
+            script: node $(Pipeline.Workspace)/VersionEnvVars/versionEnvVars.js
+
         - pwsh: |
-            $buildReason = $env:BUILD_REASON
-            # Use only the first line of the commit message
-            $sourceMessage = ($env:SOURCE_MESSAGE -split "`n")[0].Trim()
+            $forceRelease = '${{ parameters.forceRelease }}'
+            $isReleaseBuild = $env:IS_RELEASE_BUILD
             $publishRunName = $env:PUBLISH_RUN_NAME
             $sourceBranch = $env:SOURCE_BRANCH -replace '^refs/heads/', ''
 
@@ -106,10 +123,31 @@ extends:
             $originalBuildNumber = $env:BUILD_BUILDNUMBER
             $dateStamp = if ($originalBuildNumber -match '(\d{8}\.\d+)$') { $Matches[1] } else { "" }
 
+            # Fallback: if IsReleaseBuild is not in the CI artifact (old branches),
+            # fall back to commit message detection for backward compatibility.
+            if (-not $isReleaseBuild) {
+              $sourceMessage = ($env:SOURCE_MESSAGE -split "`n")[0].Trim()
+              $isReleaseBuild = if ($sourceMessage.StartsWith("RELEASE:")) { 'True' } else { 'False' }
+              Write-Host "##[warning]IsReleaseBuild not found in CI artifact, fell back to commit message detection: $isReleaseBuild"
+            }
+
+            Write-Host "isReleaseBuild (from CI): $isReleaseBuild"
+            Write-Host "forceRelease (param):     $forceRelease"
+
             $shouldRelease = $false
             $buildNumber = ""
 
-            if ($buildReason -eq "Manual") {
+            if ($forceRelease -eq 'True') {
+              # Emergency override — allow publishing regardless of CI flag
+              $shouldRelease = $true
+              if ($publishRunName) {
+                $buildNumber = "$publishRunName [FORCED] ($sourceBranch) - $dateStamp"
+              } else {
+                $buildNumber = "Release [FORCED] ($sourceBranch) - $dateStamp"
+              }
+              Write-Host "##[warning]Release forced by parameter override"
+            }
+            elseif ($isReleaseBuild -eq 'True') {
               $shouldRelease = $true
               if ($publishRunName) {
                 $buildNumber = "$publishRunName ($sourceBranch) - $dateStamp"
@@ -117,14 +155,10 @@ extends:
                 $buildNumber = "Release ($sourceBranch) - $dateStamp"
               }
             }
-            elseif ($sourceMessage.StartsWith("RELEASE:")) {
-              $shouldRelease = $true
-              $buildNumber = "$publishRunName ($sourceBranch) - $dateStamp"
-            }
             else {
               $shouldRelease = $false
               # Truncate commit message for readability
-              $shortMsg = $sourceMessage
+              $shortMsg = ($env:SOURCE_MESSAGE -split "`n")[0].Trim()
               if ($shortMsg.Length -gt 60) {
                 $shortMsg = $shortMsg.Substring(0, 57) + "..."
               }
@@ -142,20 +176,20 @@ extends:
             Write-Host "##vso[build.updatebuildnumber]$buildNumber"
             Write-Host "##vso[task.setvariable variable=shouldRelease;isOutput=true]$shouldRelease"
           name: gate
-          displayName: Determine release eligibility and set build number
+          displayName: Determine release eligibility from CI artifact
           env:
-            BUILD_REASON: $(Build.Reason)
             BUILD_BUILDNUMBER: $(Build.BuildNumber)
-            SOURCE_MESSAGE: $(Build.SourceVersionMessage)
+            IS_RELEASE_BUILD: $(IsReleaseBuild)
             PUBLISH_RUN_NAME: $(resources.pipeline.Publish.runName)
             SOURCE_BRANCH: $(resources.pipeline.Publish.sourceBranch)
+            SOURCE_MESSAGE: $(Build.SourceVersionMessage)
 
         - script: echo Proceeding with release
           displayName: RELEASING - proceeding to publish
           condition: eq(variables['gate.shouldRelease'], 'True')
 
         - script: echo Skipping release
-          displayName: SKIPPED - not a RELEASE commit
+          displayName: SKIPPED - not a release build
           condition: eq(variables['gate.shouldRelease'], 'False')
 
     - stage: Release

--- a/.ado/scripts/setVersionEnvVars.js
+++ b/.ado/scripts/setVersionEnvVars.js
@@ -21,6 +21,15 @@ if (buildId == undefined) {
   throw new Error("Missing argument for the buildid")
 }
 
+// Optional: isReleaseBuild flag from CI setup detection step.
+// When present, it is included in the VersionEnvVars artifact so the Release
+// pipeline can read the authoritative release/developer classification without
+// re-deriving it from commit messages.
+const isReleaseBuild = process.argv[4] === 'True' ? 'True' : 'False';
+if (process.argv[4] == null) {
+  console.log("##[warning]isReleaseBuild argument not provided, defaulting to False");
+}
+
 let adoBuildVersion=pkgJson.version;
 if (isPr) {
   adoBuildVersion += `.pr${buildId}`;
@@ -38,6 +47,7 @@ const versionEnvVars = {
   reactDevDependency: pkgJson.devDependencies['react'],
   reactNativeDevDependency: pkgJson.devDependencies['react-native'],
   npmDistTag: pkgJson?.beachball?.defaultNpmTag?.trim(),
+  IsReleaseBuild: isReleaseBuild,
 }
 
 if (!versionEnvVars.npmDistTag) {
@@ -46,7 +56,12 @@ if (!versionEnvVars.npmDistTag) {
 
 // Set the build number so the build in the publish pipeline and the release pipeline are named with the convenient version
 // See: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#updatebuildnumber-override-the-automatically-generated-build-number
-console.log(`##vso[build.updatebuildnumber]RNW_${adoBuildVersion}`)
+// CI builds include [Release] or [Dev] tag for at-a-glance identification in pipeline history.
+let buildNumber = `RNW_${adoBuildVersion}`;
+if (!isPr) {
+  buildNumber += isReleaseBuild === 'True' ? ' [Release]' : ' [Dev]';
+}
+console.log(`##vso[build.updatebuildnumber]${buildNumber}`)
 
 // Set env variable to allow VS to build dll with correct version information
 console.log(`##vso[task.setvariable variable=RNW_PKG_VERSION_STR]${versionEnvVars.RNW_PKG_VERSION_STR}`);
@@ -60,6 +75,7 @@ console.log(`##vso[task.setvariable variable=publishCommitId]${versionEnvVars.pu
 console.log(`##vso[task.setvariable variable=reactDevDependency]${versionEnvVars.reactDevDependency}`);
 console.log(`##vso[task.setvariable variable=reactNativeDevDependency]${versionEnvVars.reactNativeDevDependency}`);
 console.log(`##vso[task.setvariable variable=NpmDistTag]${versionEnvVars.npmDistTag}`);
+console.log(`##vso[task.setvariable variable=IsReleaseBuild]${versionEnvVars.IsReleaseBuild}`);
 
 const runnerTemp = process.env.RUNNER_TEMP;
 if (!runnerTemp) {
@@ -80,4 +96,5 @@ console.log("##vso[task.setvariable variable=publishCommitId]${versionEnvVars.pu
 console.log("##vso[task.setvariable variable=reactDevDependency]${versionEnvVars.reactDevDependency}");
 console.log("##vso[task.setvariable variable=reactNativeDevDependency]${versionEnvVars.reactNativeDevDependency}");
 console.log("##vso[task.setvariable variable=NpmDistTag]${versionEnvVars.npmDistTag}");
+console.log("##vso[task.setvariable variable=IsReleaseBuild]${versionEnvVars.IsReleaseBuild}");
 `);

--- a/.ado/templates/set-version-vars.yml
+++ b/.ado/templates/set-version-vars.yml
@@ -6,9 +6,12 @@ parameters:
     values:
       - PullRequest
       - Continuous
+  - name: isReleaseBuild
+    type: string
+    default: 'False'
 
 steps:
-  - script: node ./.ado/scripts/setVersionEnvVars.js ${{ parameters.buildEnvironment }} $(Build.BuildId)
+  - script: node ./.ado/scripts/setVersionEnvVars.js ${{ parameters.buildEnvironment }} $(Build.BuildId) ${{ parameters.isReleaseBuild }}
     displayName: Set version variables
     name: setVersionEnvVars
     env:


### PR DESCRIPTION
## Description

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
The Release pipeline decides whether to publish artifacts to feeds by re-parsing
the commit message at release time. This is fragile — a developer can manually
trigger the Release pipeline against a non-release CI run and accidentally publish
dev-quality artifacts while a Release PR is still in progress.

### What
- **CI pipeline**: The `setVersionEnvVars.js` script now accepts an `isReleaseBuild`
  flag from the CI Setup detection step and bakes it into the `VersionEnvVars`
  artifact as `IsReleaseBuild`. This is the single source of truth for whether the
  CI run was a release or developer build.
- **CI build title**: CI run names now include `[Release]` or `[Dev]` for
  at-a-glance identification in pipeline history.
- **Release pipeline**: Both `release-pipeline.yml` and `release.yml` Gate stages
  now download the `VersionEnvVars` artifact from the triggering CI run and read
  `IsReleaseBuild` instead of re-deriving it from the commit message. Manual runs
  no longer auto-approve — they also check the CI flag.
- **`forceRelease` parameter**: An explicit boolean parameter on both Release
  pipelines allows emergency override. When used, the build title shows `[FORCED]`
  so it is clearly visible in pipeline history.
- **Backward compatibility**: If `IsReleaseBuild` is missing from the artifact
  (old stable branches that haven't picked up this change), the Gate falls back to
  the previous commit-message detection with a warning.

### Changed files
| File | Change |
|------|--------|
| `.ado/scripts/setVersionEnvVars.js` | Accept `isReleaseBuild` arg; include in pipeline vars and artifact; add `[Release]`/`[Dev]` to CI build title |
| `.ado/templates/set-version-vars.yml` | New `isReleaseBuild` parameter, passed through to the script |
| `.ado/build-template.yml` | Pass `$(isReleaseBuild)` to set-version-vars template |
| `.ado/release-pipeline.yml` | Add `forceRelease` param; Gate downloads artifact and uses `IsReleaseBuild` |
| `.ado/release.yml` | Same Gate changes (backward-compat copy using `Publish` resource) |

## Screenshots
N/A — pipeline YAML changes only.

## Testing
- [ ] CI pipeline build title shows `[Dev]` for a non-release commit
- [ ] CI pipeline build title shows `[Release]` for a RELEASE: commit
- [ ] PR pipeline build title is unchanged (no tag)
- [ ] `VersionEnvVars` artifact contains `IsReleaseBuild` variable
- [ ] Release pipeline skips publishing for a non-release CI run
- [ ] Release pipeline proceeds for a release CI run
- [ ] Manual Release run without `forceRelease` respects the CI flag
- [ ] Manual Release run with `forceRelease=true` publishes and shows `[FORCED]`
- [ ] Old stable branch without `IsReleaseBuild` in artifact falls back to commit-message detection with warning

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15902)