### PR TITLE
Reduce Dependabot noise for stable branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-# main branch
+# main branch - all dependency updates (minor + patch), daily
 - package-ecosystem: npm
   directory: "/"
   target-branch: "main"
@@ -22,6 +22,8 @@ updates:
     prefix: 📦
   open-pull-requests-limit: 5
 
+# Stable branches - weekly cadence, 1 grouped PR at a time
+
 # 0.74 branch
 - package-ecosystem: npm
   directory: "/"
@@ -34,15 +36,15 @@ updates:
         - 'minor'
         - 'patch'
   schedule:
-    interval: daily
+    interval: weekly
     time: "05:00"
     timezone: "America/Los_Angeles"
   labels:
   - dependencies
   versioning-strategy: lockfile-only
   commit-message:
-    prefix: 📦
-  open-pull-requests-limit: 5
+    prefix: "📦 [0.74]"
+  open-pull-requests-limit: 1
 
 # 0.81 branch
 - package-ecosystem: npm
@@ -56,15 +58,15 @@ updates:
         - 'minor'
         - 'patch'
   schedule:
-    interval: daily
+    interval: weekly
     time: "05:00"
     timezone: "America/Los_Angeles"
   labels:
   - dependencies
   versioning-strategy: lockfile-only
   commit-message:
-    prefix: 📦
-  open-pull-requests-limit: 5
+    prefix: "📦 [0.81]"
+  open-pull-requests-limit: 1
 
 # 0.82 branch
 - package-ecosystem: npm
@@ -78,15 +80,15 @@ updates:
         - 'minor'
         - 'patch'
   schedule:
-    interval: daily
+    interval: weekly
     time: "05:00"
     timezone: "America/Los_Angeles"
   labels:
   - dependencies
   versioning-strategy: lockfile-only
   commit-message:
-    prefix: 📦
-  open-pull-requests-limit: 5
+    prefix: "📦 [0.82]"
+  open-pull-requests-limit: 1
 
 # 0.83 branch
 - package-ecosystem: npm
@@ -100,12 +102,34 @@ updates:
         - 'minor'
         - 'patch'
   schedule:
-    interval: daily
+    interval: weekly
     time: "05:00"
     timezone: "America/Los_Angeles"
   labels:
   - dependencies
   versioning-strategy: lockfile-only
   commit-message:
-    prefix: 📦
-  open-pull-requests-limit: 5
+    prefix: "📦 [0.83]"
+  open-pull-requests-limit: 1
+
+# 0.84 branch
+- package-ecosystem: npm
+  directory: "/"
+  target-branch: "0.84-stable"
+  groups:
+    all-dependencies:
+      patterns:
+        - '*'
+      update-types:
+        - 'minor'
+        - 'patch'
+  schedule:
+    interval: weekly
+    time: "05:00"
+    timezone: "America/Los_Angeles"
+  labels:
+  - dependencies
+  versioning-strategy: lockfile-only
+  commit-message:
+    prefix: "📦 [0.84]"
+  open-pull-requests-limit: 1


### PR DESCRIPTION
## Description

### Type of Change
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
The previous Dependabot configuration created up to 5 PRs per day per stable branch, generating excessive noise. Stable branches don't need the same update velocity as main. This change targets to reduce the review burden.

### What
- **Stable branches** (0.74, 0.81, 0.82, 0.83, 0.84): schedule changed from daily to weekly, PR limit reduced from 5 to 1 (all updates grouped into a single PR)
- **Commit prefix** for stable branches: `📦` -> `📦 [0.XX]` to identify the target branch at a glance
- **Added** configuration for `0.84-stable` branch
- **Main branch**: no functional changes (daily, up to 5 PRs)

## Screenshots
N/A

## Testing
Dependabot configuration is declarative YAML — changes take effect on the next scheduled run. No local tests applicable.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15938)