### PR TITLE
Use hermes-windows 0.0.0-2604.6001-5335deff

### DIFF
--- a/change/@react-native-windows-automation-channel-9261cfbb-1a71-4572-9026-b1d880b41d52.json
+++ b/change/@react-native-windows-automation-channel-9261cfbb-1a71-4572-9026-b1d880b41d52.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new Hermes version",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-77541cbf-377f-44e4-bb83-29a67ecd9169.json
+++ b/change/react-native-windows-77541cbf-377f-44e4-bb83-29a67ecd9169.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use new Hermes version",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/packages.lock.json
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric.Package/packages.lock.json
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric.Package/packages.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -182,7 +182,7 @@
         "type": "Project",
         "dependencies": {
           "AutomationChannel": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/packages.lock.json
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -175,7 +175,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/playground/windows/playground-composition.Package/packages.experimentalwinui3.lock.json
+++ b/packages/playground/windows/playground-composition.Package/packages.experimentalwinui3.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -156,7 +156,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",
@@ -166,7 +166,7 @@
       "playground-composition": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",

--- a/packages/playground/windows/playground-composition.Package/packages.lock.json
+++ b/packages/playground/windows/playground-composition.Package/packages.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -156,7 +156,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -166,7 +166,7 @@
       "playground-composition": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",

--- a/packages/playground/windows/playground-composition/packages.experimentalwinui3.lock.json
+++ b/packages/playground/windows/playground-composition/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -166,7 +166,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/playground/windows/playground-composition/packages.lock.json
+++ b/packages/playground/windows/playground-composition/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -166,7 +166,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/sample-app-fabric/windows/SampleAppFabric.Package/packages.lock.json
+++ b/packages/sample-app-fabric/windows/SampleAppFabric.Package/packages.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -156,7 +156,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -172,7 +172,7 @@
       "sampleappfabric": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",

--- a/packages/sample-app-fabric/windows/SampleAppFabric/packages.lock.json
+++ b/packages/sample-app-fabric/windows/SampleAppFabric/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -166,7 +166,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/sample-custom-component/windows/SampleCustomComponent/packages.experimentalwinui3.lock.json
+++ b/packages/sample-custom-component/windows/SampleCustomComponent/packages.experimentalwinui3.lock.json
@@ -44,8 +44,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/sample-custom-component/windows/SampleCustomComponent/packages.lock.json
+++ b/packages/sample-custom-component/windows/SampleCustomComponent/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.ABITests/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop.ABITests/packages.experimentalwinui3.lock.json
@@ -26,8 +26,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -168,7 +168,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",
@@ -179,7 +179,7 @@
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
           "ReactNative.V8Jsi.Windows": "[0.71.8, )",

--- a/vnext/Desktop.ABITests/packages.lock.json
+++ b/vnext/Desktop.ABITests/packages.lock.json
@@ -26,8 +26,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -168,7 +168,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -179,7 +179,7 @@
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
           "ReactNative.V8Jsi.Windows": "[0.71.8, )",

--- a/vnext/Desktop.DLL/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop.DLL/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -160,7 +160,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.DLL/packages.lock.json
+++ b/vnext/Desktop.DLL/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -160,7 +160,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.IntegrationTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop.IntegrationTests/packages.experimentalwinui3.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -164,7 +164,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",
@@ -175,7 +175,7 @@
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
           "ReactNative.V8Jsi.Windows": "[0.71.8, )",

--- a/vnext/Desktop.IntegrationTests/packages.lock.json
+++ b/vnext/Desktop.IntegrationTests/packages.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -164,7 +164,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -175,7 +175,7 @@
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
           "ReactNative.V8Jsi.Windows": "[0.71.8, )",

--- a/vnext/Desktop.UnitTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop.UnitTests/packages.experimentalwinui3.lock.json
@@ -21,8 +21,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -163,7 +163,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.UnitTests/packages.lock.json
+++ b/vnext/Desktop.UnitTests/packages.lock.json
@@ -21,8 +21,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -163,7 +163,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/Desktop/packages.lock.json
+++ b/vnext/Desktop/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.experimentalwinui3.lock.json
@@ -37,8 +37,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -158,7 +158,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
@@ -37,8 +37,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -158,7 +158,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative.IntegrationTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/packages.experimentalwinui3.lock.json
@@ -50,8 +50,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -171,7 +171,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/packages.lock.json
@@ -50,8 +50,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -171,7 +171,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/Microsoft.ReactNative/packages.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2512.22001-bc3d0ed7, )",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "requested": "[0.0.0-2604.6001-5335deff, )",
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -6,7 +6,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">true</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.0.0-2512.22001-bc3d0ed7</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.0.0-2604.6001-5335deff</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgMicrosoft_JavaScript_Hermes)')">$(PkgMicrosoft_JavaScript_Hermes)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\Microsoft.JavaScript.Hermes\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>

--- a/vnext/ReactCommon.UnitTests/packages.experimentalwinui3.lock.json
+++ b/vnext/ReactCommon.UnitTests/packages.experimentalwinui3.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -164,7 +164,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/ReactCommon.UnitTests/packages.lock.json
+++ b/vnext/ReactCommon.UnitTests/packages.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2512.22001-bc3d0ed7",
-        "contentHash": "aMuCKrIwkCAnT56+oKqmxgfIaAHlKRVt8IiG/jtMbG01QH1mLPwL7wP89jRMsYSJzikW96trqgpUllZZa3O+Qw=="
+        "resolved": "0.0.0-2604.6001-5335deff",
+        "contentHash": "NVcqyPfcbntSde8S2gi/e9+9vxASUqKcK7t/qKOEbb6VXfQbNBjOfWM9nGn3DuE8ZeJvsU6uOXaEjx9GlAuXmg=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -164,7 +164,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2512.22001-bc3d0ed7, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.6001-5335deff, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",


### PR DESCRIPTION
## Description

### Type of Change
- Dependencies (updating a dependency version)

### Why
Update the Hermes engine NuGet package to pick up the latest Hermes build from the hermes-windows repo.

### What
- **Updated** `HermesVersion` in `vnext/PropertySheets/JSEngine.props` from `0.0.0-2512.22001-bc3d0ed7` to `0.0.0-2604.6001-5335deff`
- **Regenerated** all `packages.lock.json` files across the repo to reflect the new package version (32 files updated)

NuGet package: https://www.nuget.org/packages/Microsoft.JavaScript.Hermes/0.0.0-2604.6001-5335deff

## Screenshots
N/A

## Testing
- Built `vnext/ReactWindows-Desktop.sln` (Debug|x64) successfully — all native projects compiled with no errors related to the Hermes update.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15982)