### PR TITLE
Fix playground composition for Node.js 24.x

### DIFF
--- a/change/react-native-windows-9d93df46-79f8-4116-b0c8-7985a9c67d91.json
+++ b/change/react-native-windows-9d93df46-79f8-4116-b0c8-7985a9c67d91.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix project compilation",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -11,10 +11,10 @@ const path = require('path');
 
 // On Windows, require.resolve through symlinks (e.g. yarn workspace links) can
 // return paths with a different drive letter case than process.cwd(). Metro's
-// file system lookup is case-sensitive, so we must normalize to match.
+// file system lookup is case-sensitive, so we normalize to match cwd.
 function normalizePathDrive(p) {
   if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
-    return p[0].toUpperCase() + p.slice(1);
+    return process.cwd()[0] + p.slice(1);
   }
   return p;
 }

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -9,13 +9,23 @@ const {makeMetroConfig} = require('@rnw-scripts/metro-dev-config');
 const fs = require('fs');
 const path = require('path');
 
-const rnwPath = fs.realpathSync(
-  path.dirname(require.resolve('react-native-windows/package.json')),
-);
+// On Windows, require.resolve through symlinks (e.g. yarn workspace links) can
+// return paths with a different drive letter case than process.cwd(). Metro's
+// file system lookup is case-sensitive, so we must normalize to match.
+function normalizePathDrive(p) {
+  if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
+    return p[0].toUpperCase() + p.slice(1);
+  }
+  return p;
+}
 
-const rnwTesterPath = fs.realpathSync(
+const rnwPath = normalizePathDrive(fs.realpathSync(
+  path.dirname(require.resolve('react-native-windows/package.json')),
+));
+
+const rnwTesterPath = normalizePathDrive(fs.realpathSync(
   path.dirname(require.resolve('@react-native-windows/tester/package.json')),
-);
+));
 
 const devPackages = {
   'react-native': path.normalize(rnwPath),
@@ -144,8 +154,25 @@ function tryResolveDevRelativeImport(
   return null;
 }
 
-module.exports = makeMetroConfig({
+const baseConfig = makeMetroConfig({
   resolver: {
     resolveRequest: devResolveRequest,
   },
 });
+
+// The getModulesRunBeforeMainModule paths (from @rnx-kit/metro-config) may have
+// wrong drive letter case on Windows due to require.resolve through symlinks.
+// Metro compares these paths via strict equality against module paths in the
+// bundle graph, so the case must match exactly.
+const originalGetModulesRunBeforeMainModule =
+  baseConfig.serializer.getModulesRunBeforeMainModule;
+baseConfig.serializer = {
+  ...baseConfig.serializer,
+  getModulesRunBeforeMainModule: (...args) => {
+    return originalGetModulesRunBeforeMainModule(...args).map(p =>
+      normalizePathDrive(fs.realpathSync(p)),
+    );
+  },
+};
+
+module.exports = baseConfig;

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.54",
   "private": true,
   "scripts": {
-    "start": "npx @react-native-community/cli rnx-start",
+    "start": "react-native rnx-start",
     "lint:fix": "rnw-scripts lint:fix",
     "lint": "rnw-scripts lint",
-    "windows": "npx @react-native-community/cli run-windows"
+    "windows": "react-native run-windows"
   },
   "dependencies": {
     "@react-native-picker/picker": "2.11.0",

--- a/packages/playground/windows/playground-composition.sln
+++ b/packages/playground/windows/playground-composition.sln
@@ -29,6 +29,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Include", "..\..\..\vnext\include\Include.vcxitems", "{EF074BA1-2D54-4D49-A28E-5E040B47CD2E}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SampleCustomComponent", "..\..\sample-custom-component\windows\SampleCustomComponent\SampleCustomComponent.vcxproj", "{A8DA218C-4CB5-48CB-A9EE-9E6337165D07}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136} = {F7D32BD0-2749-483E-9A0D-1635EF7E3136}
+	EndProjectSection
 EndProject
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\..\vnext\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -4,21 +4,29 @@
   <!-- This import will noop when customer code is built. This import is here to help building the bits in the react-native-windows repository. -->
   <Import Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../')))" Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-  <!--Allow implicitly restoring NuGet dependencies in C++ projects using the Visual Studio IDE.-->
-  <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.vcxproj'">
+  <!--
+    Allow implicitly restoring NuGet dependencies in C++ and C# projects using the Visual Studio IDE.
+
+    For vcxproj: VS does not automatically restore PackageReference or packages.config dependencies.
+    For csproj referencing vcxproj: VS's NuGet restore cannot evaluate vcxproj PackageReferences
+    through the project reference chain (the VC project system does not report them via the CPS
+    nomination API), causing NU1004 lock file mismatches. An explicit msbuild /t:Restore during
+    the build resolves this because msbuild loads VCTargets and evaluates vcxproj fully.
+  -->
+  <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND ('$(MSBuildProjectExtension)' == '.vcxproj' OR '$(MSBuildProjectExtension)' == '.csproj')">
     <!--
       Ensure restoring of PackageReference dependencies.
     -->
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" Condition="@(PackageReference->Count()) &gt; 0" />
 
     <!--
-      Ensure restoring of packages.config dependencies.
+      Ensure restoring of packages.config dependencies (vcxproj only).
 
       RestoreProjectStyle=PackagesConfig    - Required to use the packages.config mechanism
       RestorePackagesConfig=true            - Required to use the packages.config mechanism
       RestoreUseStaticGraphEvaluation=false - Override setting from Directory.Build.props
     -->
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;RestoreUseStaticGraphEvaluation=false" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;RestoreUseStaticGraphEvaluation=false" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'" />
   </Target>
 
   <!-- This ensures NuGet restores use the nuget config's feed and not any pre-installed files. -->

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -412,9 +412,6 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <Natvis Include="$(ExternalDir)folly\Folly.natvis" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Common\Common.vcxproj">
       <Project>{fca38f3c-7c73-4c47-be4e-32f77fa8538d}</Project>
     </ProjectReference>

--- a/vnext/PropertySheets/Autolink.props
+++ b/vnext/PropertySheets/Autolink.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <RunAutolinkCheck Condition="'$(RunAutolinkCheck)' == ''">true</RunAutolinkCheck>
-    <AutolinkCommand Condition="'$(AutolinkCommand)' == ''">npx --yes @react-native-community/cli autolink-windows</AutolinkCommand>
+    <AutolinkCommand Condition="'$(AutolinkCommand)' == ''">npx --yes --no-workspaces @react-native-community/cli autolink-windows</AutolinkCommand>
     <AutolinkCommandWorkingDir Condition="'$(AutolinkCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(ProjectDir), 'package.json'))</AutolinkCommandWorkingDir>
     <AutolinkCommandArgs Condition="'$(AutolinkCommandArgs)' == '' And '$(SolutionPath)' != '' And '$(SolutionPath)' != '*Undefined*' And '$(ProjectPath)' != ''">--check --sln "$([MSBuild]::MakeRelative($(AutolinkCommandWorkingDir), $(SolutionPath)))" --proj "$([MSBuild]::MakeRelative($(AutolinkCommandWorkingDir), $(ProjectPath)))"</AutolinkCommandArgs>
     <AutolinkCommandArgs Condition="'$(AutolinkCommandArgs)' == ''">--check</AutolinkCommandArgs>

--- a/vnext/PropertySheets/Bundle.props
+++ b/vnext/PropertySheets/Bundle.props
@@ -39,7 +39,7 @@
     <BundlerExtraArgs Condition="'$(BundlerExtraArgs)' == ''">--minify false</BundlerExtraArgs>
 
     <!-- Command to use to create a bundle -->
-    <BundleCliCommand Condition="'$(BundleCliCommand)' == ''">npx @react-native-community/cli bundle</BundleCliCommand>
+    <BundleCliCommand Condition="'$(BundleCliCommand)' == ''">npx --no-workspaces @react-native-community/cli bundle</BundleCliCommand>
 
     <!-- This should be the app package root, this is where the bundle command will be run from -->
     <BundleCommandWorkingDir Condition="'$(BundleCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(ProjectDir), 'package.json'))</BundleCommandWorkingDir>

--- a/vnext/PropertySheets/Bundle.props
+++ b/vnext/PropertySheets/Bundle.props
@@ -39,7 +39,7 @@
     <BundlerExtraArgs Condition="'$(BundlerExtraArgs)' == ''">--minify false</BundlerExtraArgs>
 
     <!-- Command to use to create a bundle -->
-    <BundleCliCommand Condition="'$(BundleCliCommand)' == ''">npx --no-workspaces @react-native-community/cli bundle</BundleCliCommand>
+    <BundleCliCommand Condition="'$(BundleCliCommand)' == ''">npx --yes --no-workspaces @react-native-community/cli bundle</BundleCliCommand>
 
     <!-- This should be the app package root, this is where the bundle command will be run from -->
     <BundleCommandWorkingDir Condition="'$(BundleCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(ProjectDir), 'package.json'))</BundleCommandWorkingDir>

--- a/vnext/PropertySheets/Codegen.props
+++ b/vnext/PropertySheets/Codegen.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <RunCodegenWindows Condition="'$(RunCodegenWindows)' == ''">true</RunCodegenWindows>
-    <CodegenCommand Condition="'$(CodegenCommand)' == ''">npx --yes @react-native-community/cli codegen-windows</CodegenCommand>
+    <CodegenCommand Condition="'$(CodegenCommand)' == ''">npx --yes --no-workspaces @react-native-community/cli codegen-windows</CodegenCommand>
     <CodegenCommandWorkingDir Condition="'$(CodegenCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(ProjectDir), 'package.json'))</CodegenCommandWorkingDir>
     <CodegenCommandArgs Condition="'$(CodegenCommandArgs)' == ''">--logging</CodegenCommandArgs>
   </PropertyGroup>

--- a/vnext/PropertySheets/NuGet.LockFile.props
+++ b/vnext/PropertySheets/NuGet.LockFile.props
@@ -9,6 +9,14 @@
 
   <PropertyGroup>
     <RestoreLockedMode Condition="'$(RestoreLockedMode)'=='' OR '$(BuildingInRnwRepo)'=='true'">true</RestoreLockedMode>
+    <!--
+      VS's NuGet restore cannot evaluate vcxproj PackageReferences through the project reference
+      chain (the VC project system does not report them via the CPS nomination API). This causes
+      NU1004 lock file mismatches for csproj files that reference vcxproj. Disable locked mode
+      in VS so the initial restore succeeds and package targets load correctly.
+      CI is unaffected: it passes /p:RestoreLockedMode=true as a global property which overrides this.
+    -->
+    <RestoreLockedMode Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.csproj'">false</RestoreLockedMode>
 
     <NuGetLockFileName>packages</NuGetLockFileName>
     <NuGetLockFileName Condition="'$(UseExperimentalWinUI3)'=='true'">$(NuGetLockFileName).experimentalwinui3</NuGetLockFileName>

--- a/vnext/template/metro.config.js
+++ b/vnext/template/metro.config.js
@@ -3,9 +3,19 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 const fs = require('fs');
 const path = require('path');
 
-const rnwPath = fs.realpathSync(
+// On Windows, require.resolve through yarn workspace junctions can return paths
+// with a different drive letter case than process.cwd(). Metro's internal file
+// system lookup is case-sensitive, so we normalize to match.
+function normalizePathDrive(p) {
+  if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
+    return p[0].toUpperCase() + p.slice(1);
+  }
+  return p;
+}
+
+const rnwPath = normalizePathDrive(fs.realpathSync(
   path.resolve(require.resolve('react-native-windows/package.json'), '..'),
-);
+));
 
 //{{#devMode}} [devMode
 const rnwRootNodeModules = path.resolve(rnwPath, '..', 'node_modules');

--- a/vnext/template/metro.config.js
+++ b/vnext/template/metro.config.js
@@ -5,10 +5,10 @@ const path = require('path');
 
 // On Windows, require.resolve through yarn workspace junctions can return paths
 // with a different drive letter case than process.cwd(). Metro's internal file
-// system lookup is case-sensitive, so we normalize to match.
+// system lookup is case-sensitive, so we normalize to match cwd.
 function normalizePathDrive(p) {
   if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
-    return p[0].toUpperCase() + p.slice(1);
+    return process.cwd()[0] + p.slice(1);
   }
   return p;
 }

--- a/vnext/templates/cpp-app/metro.config.js
+++ b/vnext/templates/cpp-app/metro.config.js
@@ -5,10 +5,10 @@ const path = require('node:path');
 
 // On Windows, require.resolve through yarn workspace junctions can return paths
 // with a different drive letter case than process.cwd(). Metro's internal file
-// system lookup is case-sensitive, so we normalize to match.
+// system lookup is case-sensitive, so we normalize to match cwd.
 function normalizePathDrive(p) {
   if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
-    return p[0].toUpperCase() + p.slice(1);
+    return process.cwd()[0] + p.slice(1);
   }
   return p;
 }

--- a/vnext/templates/cpp-app/metro.config.js
+++ b/vnext/templates/cpp-app/metro.config.js
@@ -3,9 +3,19 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 const fs = require('fs');
 const path = require('node:path');
 
-const rnwPath = fs.realpathSync(
+// On Windows, require.resolve through yarn workspace junctions can return paths
+// with a different drive letter case than process.cwd(). Metro's internal file
+// system lookup is case-sensitive, so we normalize to match.
+function normalizePathDrive(p) {
+  if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
+    return p[0].toUpperCase() + p.slice(1);
+  }
+  return p;
+}
+
+const rnwPath = normalizePathDrive(fs.realpathSync(
   path.resolve(require.resolve('react-native-windows/package.json'), '..'),
-);
+));
 
 //{{#devMode}} [devMode
 const rnwRootNodeModules = path.resolve(rnwPath, '..', 'node_modules');

--- a/vnext/templates/cpp-lib/example/metro.config.js
+++ b/vnext/templates/cpp-lib/example/metro.config.js
@@ -9,10 +9,10 @@ const modules = Object.keys({ ...pack.peerDependencies });
 
 // On Windows, require.resolve through yarn workspace junctions can return paths
 // with a different drive letter case than process.cwd(). Metro's internal file
-// system lookup is case-sensitive, so we normalize to match.
+// system lookup is case-sensitive, so we normalize to match cwd.
 function normalizePathDrive(p) {
   if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
-    return p[0].toUpperCase() + p.slice(1);
+    return process.cwd()[0] + p.slice(1);
   }
   return p;
 }

--- a/vnext/templates/cpp-lib/example/metro.config.js
+++ b/vnext/templates/cpp-lib/example/metro.config.js
@@ -7,9 +7,19 @@ const pack = require('../package.json');
 const root = path.resolve(__dirname, '..');
 const modules = Object.keys({ ...pack.peerDependencies });
 
-const rnwPath = fs.realpathSync(
+// On Windows, require.resolve through yarn workspace junctions can return paths
+// with a different drive letter case than process.cwd(). Metro's internal file
+// system lookup is case-sensitive, so we normalize to match.
+function normalizePathDrive(p) {
+  if (process.platform === 'win32' && p.length >= 2 && p[1] === ':') {
+    return p[0].toUpperCase() + p.slice(1);
+  }
+  return p;
+}
+
+const rnwPath = normalizePathDrive(fs.realpathSync(
   path.resolve(require.resolve('react-native-windows/package.json'), '..'),
-);
+));
 
 //{{#devMode}} [devMode
 const rnwRootNodeModules = path.resolve(rnwPath, '..', 'node_modules');


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix

### Why
Fix regressions introduced by PR #15979 ("Use fork-sync for Folly and FastFloat") and compatibility issues with Node v24 / npm v11 that broke the `playground-composition` solution: build failures, Metro bundler crashes, and runtime errors preventing the RNTester UI from loading.

### What

**1. Remove stale Folly project references after fork-sync migration**

PR #15979 moved Folly into `vnext/external/folly/folly.vcxitems` (a shared items project), but left behind direct references to the old standalone `Folly.vcxproj` in several places. These caused duplicate item errors and missing project errors:
- `Microsoft.ReactNative.vcxproj`: removed `<Natvis>` and `<ProjectReference>` entries pointing at the old `Folly.vcxproj`
- `Microsoft.ReactNative.vcxproj.filters`: updated Natvis path from `$(ReactNativeWindowsDir)Folly\` to `$(ExternalDir)folly\`
- `Playground-Composition.vcxproj`: removed stale `<Natvis>` reference to `$(ReactNativeWindowsDir)Folly\Folly.natvis`
- `playground-composition.sln`: removed the `Folly` project entry and its build configurations; removed the `ReactCommon` -> `Folly` dependency
- `React.Cpp.props`: updated `AdditionalIncludeDirectories` from `$(FollyDir)` / `$(FastFloatDir)include` to `$(ExternalDir)folly` / `$(ExternalDir)fast-float\include`
- NuGet lock files (`packages.lock.json`, `packages.experimentalwinui3.lock.json`) in `Microsoft.ReactNative`, `playground-composition`, and `playground-composition.Package`: removed stale `Folly` project dependency entries

**2. Fix build order in `playground-composition.sln`**

`SampleCustomComponent` processes `DrawingIsland.idl` which imports `Microsoft.ReactNative.winmd`. Because `SampleCustomComponent` had no declared dependency on `Microsoft.ReactNative`, Visual Studio could start building it before `Microsoft.ReactNative` was ready, causing:
```
midlrt : error MIDL1001: cannot open input file Microsoft.ReactNative.winmd
```
Fix: added `ProjectDependencies` section to the `SampleCustomComponent` project entry in the solution file, declaring a dependency on `Microsoft.ReactNative`.

**3. Fix `yarn start` / `yarn windows` for the playground package**

The `start` and `windows` scripts used `npx @react-native-community/cli <cmd>`, which invokes npm 11's arborist to scan the workspace tree. npm 11 crashes with `Cannot read properties of null (reading 'package')` when it encounters the Yarn-managed `node_modules` structure.

Fix: replaced `npx @react-native-community/cli` with the `react-native` binary directly, which is provided by `@react-native-community/cli` (already a devDependency) and is available on `PATH` when run via yarn without going through npm's arborist.

**4. Fix MSBuild CLI invocations crashing with npm v11 in yarn workspaces**

Three MSBuild property sheets run `npx @react-native-community/cli <command>` during build. In npm v11.8.0 (bundled with Node v24), `npx` calls `Exec.execWorkspaces` which tries to build an npm arborist tree. Since this repo uses Yarn workspaces, the arborist fails:
```
error MSB3073: The command "npx --yes @react-native-community/cli codegen-windows --logging" exited with code 1.
```
Fix: added `--no-workspaces` flag to all three property sheets to skip npm's workspace tree resolution, which is not needed for running the CLI:
- `Codegen.props`: codegen-windows command
- `Autolink.props`: autolink-windows command
- `Bundle.props`: bundle command

**5. Fix Metro resolver failing to find `react-native` modules (Node v24 + Windows)**

On Windows, `require.resolve()` through yarn workspace junctions (e.g. `node_modules/react-native-windows` -> `vnext/`) returns paths with a different drive letter case than `process.cwd()` in Node v24. Metro's internal file system tree derives its paths from `process.cwd()`, and `fileSystemLookup` uses case-sensitive string comparison, so all resolved module paths from the playground's custom `devResolveRequest` resolver failed to match:
```
Error: Unable to resolve module react-native
```
Fix: added `normalizePathDrive()` helper in the playground's `metro.config.js` and the three app/lib template metro configs (`vnext/template/metro.config.js`, `vnext/templates/cpp-app/metro.config.js`, `vnext/templates/cpp-lib/example/metro.config.js`) to normalize the drive letter to match `process.cwd()` after `fs.realpathSync` / `require.resolve`.

**6. Fix `InitializeCore.js` not running before main module (Node v24 + Windows)**

The `getModulesRunBeforeMainModule` paths (computed by `@rnx-kit/metro-config` via `require.resolve`) also had the wrong drive letter case. Metro's `getAppendScripts` compares these paths against module paths in the bundle graph using strict equality (`===`). The case mismatch caused `InitializeCore.js` to silently not be required before the main module, so `setUpGlobals.js` never ran `global.window = global`, leading to:
```
[runtime not ready]: ReferenceError: Property 'window' doesn't exist
```
Fix: overrode `getModulesRunBeforeMainModule` in the playground's `metro.config.js` to normalize paths through `fs.realpathSync` + `normalizePathDrive()`, ensuring they match the resolved module paths in the bundle graph.

**7. Fix Universal solution (`Microsoft.ReactNative.NewArch.sln`) compilation in Visual Studio**

VS's NuGet restore fails with NU1004 for `Microsoft.ReactNative.CsWinRT.csproj` because VS uses the CPS nomination API to evaluate project references, while the lock files are generated by `msbuild /t:Restore` which fully evaluates vcxproj targets. When a .csproj references a .vcxproj, VS's NuGet restore only discovers ProjectReferences (Common.vcxproj, ReactCommon.vcxproj), but the lock file also contains the vcxproj's PackageReferences (boost, Hermes, SourceLink, etc.) — causing a mismatch.

Two fixes:
- `NuGet.LockFile.props`: disable `RestoreLockedMode` for .csproj files when `BuildingInsideVisualStudio=true`, so VS's initial NuGet restore succeeds and package targets load correctly. CI is unaffected because it passes `/p:RestoreLockedMode=true` as a global property which overrides project-level settings.
- `Directory.Build.targets`: extend the existing `BeforeResolveReferences` workaround (which already handles vcxproj PackageReference restore in VS) to also cover .csproj files, providing an explicit `msbuild /t:Restore` fallback during the build.

## Screenshots
N/A

## Testing
- Built `packages/playground/windows/playground-composition.sln` (Debug|x64) successfully.
- `yarn start` from `packages/playground` launches the Metro bundler without errors.
- The RNTester UI loads and renders correctly in the playground-composition app.
- Built `vnext/Microsoft.ReactNative.NewArch.sln` (Debug|x64) in Visual Studio successfully.

## Changelog
Should this change be included in the release notes: no
