### PR TITLE
Fix ScrollView keyboard scroll drift on long key press

### DIFF
--- a/change/react-native-windows-c5ccd437-3b14-4157-926e-e9c76f440c38.json
+++ b/change/react-native-windows-c5ccd437-3b14-4157-926e-e9c76f440c38.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ScrollView keyboard scroll drift on long key press",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -1023,16 +1023,16 @@ void ScrollViewComponentView::OnKeyDown(
       args.Handled(pageUp(true));
       break;
     case winrt::Windows::System::VirtualKey::Up:
-      args.Handled(lineUp(true));
+      args.Handled(lineUp(false));
       break;
     case winrt::Windows::System::VirtualKey::Down:
-      args.Handled(lineDown(true));
+      args.Handled(lineDown(false));
       break;
     case winrt::Windows::System::VirtualKey::Left:
-      args.Handled(lineLeft(true));
+      args.Handled(lineLeft(false));
       break;
     case winrt::Windows::System::VirtualKey::Right:
-      args.Handled(lineRight(true));
+      args.Handled(lineRight(false));
       break;
   }
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
When a user long-presses arrow keys (Left/Right/Up/Down) on a focused ScrollView, the scroll continues drifting after the key is released. This happens because the animated ScrollBy path accumulates offsets onto m_targetPosition during rapid key-repeat events, building up a long-running animation that overshoots. Native WinUI ScrollViewer does not exhibit this behavior.

Resolves [Add Relevant Issue Here]

### What
Changed arrow key scroll handling in [ScrollViewComponentView::OnKeyDown] to use [animate=false instead of [animate=true] for Up/Down/Left/Right keys.

## Screenshots
Before 


https://github.com/user-attachments/assets/dff12f04-6088-4a82-b13f-6599cfb7c867


After

https://github.com/user-attachments/assets/db2717fc-c347-4d96-b53c-c531a8c60806



## Testing
Locally tested

## Changelog
Should this change be included in the release notes: _indicate yes

Add a brief summary of the change to use in the release notes for the next release.
Fix ScrollView keyboard scroll drift on long key press