### PR TITLE
[0.84] Fix multiline TextInput crash from TxDrawD2D reentrancy

### DIFF
--- a/change/react-native-windows-fd21e9f2-3f90-4b4a-94f5-fbf8802080dc.json
+++ b/change/react-native-windows-fd21e9f2-3f90-4b4a-94f5-fbf8802080dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix multiline TextInput crash from TxDrawD2D reentrancy",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1780,7 +1780,10 @@ void WindowsTextInputComponentView::DrawText() noexcept {
       }
 
       // TODO keep track of proper invalid rect
+      // Prevent reentrancy: TxDrawD2D may call TxViewChange -> DrawText
+      m_cDrawBlock++;
       auto hrDraw = m_textServices->TxDrawD2D(d2dDeviceContext, &rc, nullptr, TXTVIEW_ACTIVE);
+      m_cDrawBlock--;
       winrt::check_hresult(hrDraw);
 
       // draw placeholder text if needed


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
when text wraps to a new line RichEdit's TxDrawD2D internally calls TxViewChange, which re-enters DrawText(), causing infinite recursion and a stack overflow.

Resolves [Add Relevant Issue Here]

### What
Added m_cDrawBlock reentrancy guard around TxDrawD2D() in DrawText(), matching the existing pattern used for OnTxInPlaceActivate

## Screenshots

https://github.com/user-attachments/assets/6b436350-197d-466b-9cca-11b22dbcc759



## Testing
locally tested in playground



## Changelog
Should this change be included in the release notes: yes

Add a brief summary of the change to use in the release notes for the next release.
Fix multiline TextInput crash from TxDrawD2D reentrancy

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15990)