### PR TITLE
Port perf tests to 0.82-stable

### DIFF
--- a/.github/workflows/perf-comment.yml
+++ b/.github/workflows/perf-comment.yml
@@ -1,0 +1,94 @@
+name: Post Perf Results to PR
+
+# Runs after the Perf Tests workflow completes. Uses workflow_run so
+# the GITHUB_TOKEN is scoped to the base repo and can write PR comments
+# even when the PR comes from a fork.
+on:
+  workflow_run:
+    workflows: ['Perf Tests']
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post PR Comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+
+    permissions:
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download perf results artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-results
+          path: perf-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          if [ ! -f perf-results/pr-number.txt ]; then
+            echo "No PR number file found — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER=$(cat perf-results/pr-number.txt | tr -d '[:space:]')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Read markdown report
+        if: steps.pr.outputs.skip != 'true'
+        id: report
+        run: |
+          if [ ! -f perf-results/report.md ]; then
+            echo "No report.md found — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: steps.pr.outputs.skip != 'true' && steps.report.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- rnw-perf-results -->';
+            const reportPath = 'perf-results/report.md';
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+
+            const markdown = fs.readFileSync(reportPath, 'utf-8');
+            const body = `${marker}\n${markdown}`;
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing comment (id: ${existing.id})`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info('Created new comment');
+            }

--- a/.github/workflows/perf-comment.yml
+++ b/.github/workflows/perf-comment.yml
@@ -32,24 +32,27 @@ jobs:
       - name: Read PR number
         id: pr
         run: |
-          if [ ! -f perf-results/pr-number.txt ]; then
+          PR_FILE=$(find perf-results -name pr-number.txt -type f | head -1)
+          if [ -z "$PR_FILE" ]; then
             echo "No PR number file found — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PR_NUMBER=$(cat perf-results/pr-number.txt | tr -d '[:space:]')
+          PR_NUMBER=$(cat "$PR_FILE" | tr -d '[:space:]')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Read markdown report
-        if: steps.pr.outputs.skip != 'true'
         id: report
+        if: steps.pr.outputs.skip != 'true'
         run: |
-          if [ ! -f perf-results/report.md ]; then
+          REPORT_FILE=$(find perf-results -name report.md -type f | head -1)
+          if [ -z "$REPORT_FILE" ]; then
             echo "No report.md found — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "path=$REPORT_FILE" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Post or update PR comment
@@ -59,7 +62,7 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- rnw-perf-results -->';
-            const reportPath = 'perf-results/report.md';
+            const reportPath = '${{ steps.report.outputs.path }}';
             const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
 
             const markdown = fs.readFileSync(reportPath, 'utf-8');

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -1,0 +1,91 @@
+name: Perf Tests
+
+# Triggers on PRs touching source that could affect perf,
+# and on pushes to main/stable for baseline updates.
+on:
+  pull_request:
+    branches: [main, '*-stable']
+    paths:
+      - 'vnext/**'
+      - 'packages/**'
+      - 'vnext/Scripts/perf/**'
+      - '.github/workflows/perf-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/e2e-test-app-fabric/test/__perf__/**'
+
+  # Allow manual trigger for debugging
+  workflow_dispatch:
+
+# Cancel in-progress runs for the same PR
+concurrency:
+  group: perf-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  perf-tests:
+    name: Component Performance Tests
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      # ── Setup ──────────────────────────────────────────────
+      - name: Checkout head (PR)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0    # Need history for baseline comparison
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build perf-testing package
+        run: yarn workspace @react-native-windows/perf-testing build
+
+      # ── Run Tests ──────────────────────────────────────────
+      - name: Run perf tests
+        id: perf-run
+        working-directory: packages/e2e-test-app-fabric
+        env:
+          CI: 'true'
+          RN_TARGET_PLATFORM: windows
+        run: yarn perf:ci
+        continue-on-error: true   # Don't fail here — let comparison decide
+
+      # ── Compare & Report ───────────────────────────────────
+      - name: Compare against baselines
+        id: compare
+        working-directory: packages/e2e-test-app-fabric
+        run: yarn perf:ci:compare
+        continue-on-error: true
+
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > packages/e2e-test-app-fabric/.perf-results/pr-number.txt
+
+      - name: Upload perf results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-results
+          path: |
+            packages/e2e-test-app-fabric/.perf-results/
+            packages/e2e-test-app-fabric/test/__perf__/**/__perf_snapshots__/
+          retention-days: 30
+
+      # ── Status Gate ────────────────────────────────────────
+      - name: Check for regressions
+        if: steps.compare.outcome == 'failure'
+        run: |
+          echo "::error::Performance regressions detected. See PR comment for details."
+          exit 1

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      pull-requests: write
 
     steps:
       # ── Setup ──────────────────────────────────────────────
@@ -82,6 +83,14 @@ jobs:
             packages/e2e-test-app-fabric/.perf-results/
             packages/e2e-test-app-fabric/test/__perf__/**/__perf_snapshots__/
           retention-days: 30
+
+      # ── PR Comment ────────────────────────────────────────
+      - name: Post perf results to PR
+        if: github.event_name == 'pull_request' && always()
+        working-directory: packages/e2e-test-app-fabric
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn perf:ci:report
 
       # ── Status Gate ────────────────────────────────────────
       - name: Check for regressions

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -32,7 +32,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      pull-requests: write
 
     steps:
       # ── Setup ──────────────────────────────────────────────
@@ -83,14 +82,6 @@ jobs:
             packages/e2e-test-app-fabric/.perf-results/
             packages/e2e-test-app-fabric/test/__perf__/**/__perf_snapshots__/
           retention-days: 30
-
-      # ── PR Comment ────────────────────────────────────────
-      - name: Post perf results to PR
-        if: github.event_name == 'pull_request' && always()
-        working-directory: packages/e2e-test-app-fabric
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn perf:ci:report
 
       # ── Status Gate ────────────────────────────────────────
       - name: Check for regressions

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -27,7 +27,7 @@ jobs:
   perf-tests:
     name: Component Performance Tests
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     permissions:
       contents: read
@@ -49,8 +49,28 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Detect preinstalled Windows SDK
+        id: winsdk
+        shell: pwsh
+        run: |
+          # Find the latest SDK version already installed on the runner
+          $sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\Include"
+          $versions = Get-ChildItem $sdkRoot -Directory | Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } | Sort-Object { [version]$_.Name } -Descending
+          if ($versions.Count -eq 0) {
+            echo "::error::No Windows SDK found on runner"
+            exit 1
+          }
+          $sdk = $versions[0].Name
+          echo "version=$sdk" >> $env:GITHUB_OUTPUT
+          echo "::notice::Using preinstalled Windows SDK $sdk"
+
       - name: Build perf-testing package
         run: yarn workspace @react-native-windows/perf-testing build
+
+      # ── Build & Deploy RNTesterApp-Fabric (for native perf tests) ──
+      - name: Build and deploy RNTesterApp-Fabric
+        working-directory: packages/e2e-test-app-fabric
+        run: yarn windows --release --no-launch --logging --msbuildprops WindowsTargetPlatformVersion=${{ steps.winsdk.outputs.version }}
 
       # ── Run Tests ──────────────────────────────────────────
       - name: Run perf tests
@@ -61,7 +81,14 @@ jobs:
           RN_TARGET_PLATFORM: windows
         run: yarn perf:ci
         continue-on-error: true   # Don't fail here — let comparison decide
-
+      - name: Run native perf tests
+        id: native-perf-run
+        working-directory: packages/e2e-test-app-fabric
+        env:
+          CI: 'true'
+          RN_TARGET_PLATFORM: windows
+        run: yarn perf:native:ci
+        continue-on-error: true
       # ── Compare & Report ───────────────────────────────────
       - name: Compare against baselines
         id: compare
@@ -80,7 +107,9 @@ jobs:
           name: perf-results
           path: |
             packages/e2e-test-app-fabric/.perf-results/
+            packages/e2e-test-app-fabric/.native-perf-results/
             packages/e2e-test-app-fabric/test/__perf__/**/__perf_snapshots__/
+            packages/e2e-test-app-fabric/test/__native_perf__/**/__perf_snapshots__/
           retention-days: 30
 
       # ── Status Gate ────────────────────────────────────────

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: perf-results
+          include-hidden-files: true
           path: |
             packages/e2e-test-app-fabric/.perf-results/
             packages/e2e-test-app-fabric/.native-perf-results/

--- a/change/@react-native-windows-automation-78164800-9ca8-4247-80db-488d96ee93bf.json
+++ b/change/@react-native-windows-automation-78164800-9ca8-4247-80db-488d96ee93bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-a4bcc22f-ba9f-409b-baeb-eac0e646b9d6.json
+++ b/change/@react-native-windows-automation-a4bcc22f-ba9f-409b-baeb-eac0e646b9d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add native perf benchmarking infrastructure for Fabric components",
+  "packageName": "@react-native-windows/automation",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-66589478-9bd2-42e2-ab34-98bbf1e1af38.json
+++ b/change/@react-native-windows-automation-channel-66589478-9bd2-42e2-ab34-98bbf1e1af38.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-commands-f8e5375a-d777-4ae0-a076-d79c397c6d13.json
+++ b/change/@react-native-windows-automation-commands-f8e5375a-d777-4ae0-a076-d79c397c6d13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-60591a59-c0f3-421d-93ab-c50b80733ce4.json
+++ b/change/@react-native-windows-codegen-60591a59-c0f3-421d-93ab-c50b80733ce4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: capture live run metrics in PerfJsonReporter instead of re-reading baselines",
+  "packageName": "@react-native-windows/codegen",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-220b4fd8-6fce-4f20-bbc0-ba50f2f89d15.json
+++ b/change/@react-native-windows-perf-testing-220b4fd8-6fce-4f20-bbc0-ba50f2f89d15.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: capture live run metrics in PerfJsonReporter instead of re-reading baselines",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-4734971c-72bb-4389-b990-27e212a15295.json
+++ b/change/@react-native-windows-perf-testing-4734971c-72bb-4389-b990-27e212a15295.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add native perf benchmarking infrastructure for Fabric components",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-f0fab0f1-4984-4664-b8af-b24ff2f15cd7.json
+++ b/change/@react-native-windows-perf-testing-f0fab0f1-4984-4664-b8af-b24ff2f15cd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Performance tests for react native windows(Fabric)",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-1f753cb4-5264-49b2-a35d-47fd9d986207.json
+++ b/change/react-native-windows-1f753cb4-5264-49b2-a35d-47fd9d986207.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Performance tests for react native windows(Fabric)",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-3a2f7870-03db-4287-b76f-b81c75d05ee8.json
+++ b/change/react-native-windows-3a2f7870-03db-4287-b76f-b81c75d05ee8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: respect track mode in compare-results to avoid false regression failures",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-980552ca-b77f-42da-aed5-217170e502a6.json
+++ b/change/react-native-windows-980552ca-b77f-42da-aed5-217170e502a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update performance test results markdown header",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-995b7359-8f60-46fd-9939-5497cea09515.json
+++ b/change/react-native-windows-995b7359-8f60-46fd-9939-5497cea09515.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
+++ b/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
@@ -209,16 +209,24 @@ export default class AutomationEnvironment extends NodeEnvironment {
       // Set up the "Desktop" or Root session
       const rootBrowser = await webdriverio.remote(this.rootWebDriverOptions);
 
-      // Get the list of windows
-      const allWindows = await rootBrowser.$$('//Window');
-
-      // Find our target window
+      // Poll for the app window with timeout (cold starts can be slow)
+      const windowTimeout = 300000; // 5 minutes
+      const pollInterval = 2000;
+      const deadline = Date.now() + windowTimeout;
       let appWindow: webdriverio.Element | undefined;
-      for (const window of allWindows) {
-        if ((await window.getAttribute('Name')) === appName) {
-          appWindow = window;
+
+      while (Date.now() < deadline) {
+        const allWindows = await rootBrowser.$$('//Window');
+        for (const window of allWindows) {
+          if ((await window.getAttribute('Name')) === appName) {
+            appWindow = window;
+            break;
+          }
+        }
+        if (appWindow) {
           break;
         }
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
       }
 
       if (!appWindow) {

--- a/packages/@react-native-windows/perf-testing/.eslintrc.js
+++ b/packages/@react-native-windows/perf-testing/.eslintrc.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+module.exports = {
+  extends: ['@rnw-scripts/eslint-config'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/@react-native-windows/perf-testing/.gitignore
+++ b/packages/@react-native-windows/perf-testing/.gitignore
@@ -1,0 +1,3 @@
+lib/
+lib-commonjs/
+*.tsbuildinfo

--- a/packages/@react-native-windows/perf-testing/README.md
+++ b/packages/@react-native-windows/perf-testing/README.md
@@ -1,0 +1,155 @@
+# @react-native-windows/perf-testing
+
+Performance testing utilities for React Native Windows components.
+
+## Overview
+
+This package provides infrastructure for measuring and tracking performance of React Native components. It enables:
+
+- **Automated performance regression detection** on every PR
+- **Component-wise performance baselines** (mount, unmount, re-render times)
+- **Lightweight perf snapshots** similar to Jest snapshots
+- **Easy extensibility** for new components via base classes
+
+## Installation
+
+```bash
+npm install @react-native-windows/perf-testing --save-dev
+# or
+yarn add @react-native-windows/perf-testing --dev
+```
+
+## Quick Start
+
+### 1. Create a Performance Test
+
+```typescript
+import { ComponentPerfTestBase, IScenario } from '@react-native-windows/perf-testing';
+import { View } from 'react-native';
+
+class ViewPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'View';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-view';
+
+  createComponent(props?: Record<string, unknown>) {
+    return <View testID={this.testId} {...props} />;
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'nested-views',
+        description: 'Test nested views performance',
+        run: () => this.measureNestedViews(50),
+      },
+    ];
+  }
+}
+```
+
+### 2. Write Tests
+
+```typescript
+const viewPerfTest = new ViewPerfTest();
+
+describe('View Performance', () => {
+  test('mount time', async () => {
+    const perf = await viewPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await viewPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+});
+```
+
+### 3. Run Tests
+
+```bash
+# Run perf tests
+yarn perf
+
+# Update baselines
+yarn perf:update
+```
+
+## API Reference
+
+### Core Functions
+
+| Function | Description |
+|----------|-------------|
+| `measurePerf(component, options)` | Core measurement function |
+| `toMatchPerfSnapshot(threshold?)` | Jest matcher for perf snapshots |
+
+### Base Classes
+
+| Class | Description |
+|-------|-------------|
+| `ComponentPerfTestBase` | Abstract base class for component perf tests |
+
+### Interfaces
+
+| Interface | Description |
+|-----------|-------------|
+| `PerfMetrics` | Measurement results |
+| `PerfThreshold` | Pass/fail thresholds |
+| `IComponentPerfTest` | Contract for component tests |
+| `IScenario` | Custom scenario interface |
+
+### Threshold Presets
+
+```typescript
+import { ThresholdPresets } from '@react-native-windows/perf-testing';
+
+// Available presets
+ThresholdPresets.core       // 10% regression threshold
+ThresholdPresets.list       // 15% for list components
+ThresholdPresets.interactive // 20% for animated components
+ThresholdPresets.community  // 25% relaxed threshold for external use
+```
+
+## Extending for Custom Components
+
+Community developers can create perf tests for their custom native components:
+
+```typescript
+import { ComponentPerfTestBase } from '@react-native-windows/perf-testing';
+import { MyCustomSlider } from 'my-custom-component';
+
+class MyCustomSliderPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'MyCustomSlider';
+  readonly category = 'custom' as const;
+  readonly testId = 'perf-test-slider';
+
+  createComponent(props?: Record<string, unknown>) {
+    return <MyCustomSlider testID={this.testId} {...props} />;
+  }
+}
+```
+
+## Configuration
+
+### Jest Setup
+
+Add to your Jest setup file:
+
+```typescript
+import '@react-native-windows/perf-testing/matchers';
+```
+
+### Custom Thresholds
+
+```typescript
+expect(perf).toMatchPerfSnapshot({
+  maxDurationIncrease: 15,  // Allow 15% regression
+  maxRenderCount: 5,
+});
+```
+
+## License
+
+MIT

--- a/packages/@react-native-windows/perf-testing/just-task.js
+++ b/packages/@react-native-windows/perf-testing/just-task.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ * @ts-check
+ */
+
+require('@rnw-scripts/just-task');

--- a/packages/@react-native-windows/perf-testing/package.json
+++ b/packages/@react-native-windows/perf-testing/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@react-native-windows/perf-testing",
+  "version": "0.0.0-canary.1033",
+  "description": "Performance testing utilities for React Native Windows components",
+  "main": "lib-commonjs/index.js",
+  "types": "lib-commonjs/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows",
+    "directory": "packages/@react-native-windows/perf-testing"
+  },
+  "license": "MIT",
+  "private": false,
+  "scripts": {
+    "build": "rnw-scripts build",
+    "clean": "rnw-scripts clean",
+    "lint": "rnw-scripts lint",
+    "lint:fix": "rnw-scripts lint:fix",
+    "watch": "rnw-scripts watch"
+  },
+  "dependencies": {
+    "@react-native-windows/fs": "0.82.0-preview.1"
+  },
+  "devDependencies": {
+    "@rnw-scripts/eslint-config": "1.2.38",
+    "@rnw-scripts/just-task": "2.3.58",
+    "@rnw-scripts/ts-config": "2.0.6",
+    "@types/jest": "^29.2.2",
+    "@types/node": "^22.14.0",
+    "@types/react": "^19.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.1.1",
+    "@typescript-eslint/parser": "^7.1.1",
+    "eslint": "^8.19.0",
+    "prettier": "2.8.8",
+    "typescript": "5.0.4"
+  },
+  "peerDependencies": {
+    "jest": ">=29.0.3",
+    "react": ">=18.0.0",
+    "react-native": ">=0.72.0",
+    "react-test-renderer": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react-test-renderer": {
+      "optional": true
+    }
+  },
+  "files": [
+    "lib-commonjs",
+    "README.md"
+  ],
+  "beachball": {
+    "defaultNpmTag": "preview",
+    "disallowedChangeTypes": [
+      "major",
+      "minor",
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
+    ]
+  },
+  "promoteRelease": true,
+  "engines": {
+    "node": ">= 22"
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/base/ComponentPerfTestBase.ts
+++ b/packages/@react-native-windows/perf-testing/src/base/ComponentPerfTestBase.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {measurePerf} from '../core/measurePerf';
+import type {
+  IComponentPerfTest,
+  IScenario,
+  PerfTestCategory,
+} from '../interfaces/IComponentPerfTest';
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import type {PerfThreshold} from '../interfaces/PerfThreshold';
+import {DEFAULT_THRESHOLD} from '../interfaces/PerfThreshold';
+
+/**
+ * Abstract base class for all component performance tests.
+ *
+ * Subclasses provide componentName, category, testId, and createComponent().
+ * The base class handles standard mount/unmount/rerender scenarios and
+ * test suite generation.
+ */
+export abstract class ComponentPerfTestBase implements IComponentPerfTest {
+  abstract readonly componentName: string;
+  abstract readonly category: PerfTestCategory;
+  abstract readonly testId: string;
+
+  get defaultThreshold(): PerfThreshold {
+    return DEFAULT_THRESHOLD;
+  }
+
+  abstract createComponent(props?: Record<string, unknown>): React.ReactElement;
+
+  async measureMount(): Promise<PerfMetrics> {
+    return measurePerf(this.createComponent(), {
+      name: `${this.componentName} mount`,
+      runs: this.defaultThreshold.minRuns ?? 10,
+      warmupRuns: 1,
+    });
+  }
+
+  async measureUnmount(): Promise<PerfMetrics> {
+    return measurePerf(this.createComponent(), {
+      name: `${this.componentName} unmount`,
+      runs: this.defaultThreshold.minRuns ?? 10,
+      warmupRuns: 1,
+      measureUnmount: true,
+    });
+  }
+
+  async measureRerender(): Promise<PerfMetrics> {
+    const component = this.createComponent();
+    return measurePerf(component, {
+      name: `${this.componentName} rerender`,
+      runs: this.defaultThreshold.minRuns ?? 10,
+      warmupRuns: 1,
+      scenario: async helpers => {
+        // Default re-render: update with a changed prop to force reconciliation
+        helpers.rerender(this.createComponent({__perfRerenderKey: Date.now()}));
+      },
+    });
+  }
+
+  /**
+   * Override to add component-specific scenarios.
+   */
+  getCustomScenarios(): IScenario[] {
+    return [];
+  }
+
+  generateTestSuite(customThreshold?: Partial<PerfThreshold>): void {
+    describe(`${this.componentName} Performance`, () => {
+      test('mount time', async () => {
+        const perf = await this.measureMount();
+        expect(perf).toMatchPerfSnapshot(customThreshold);
+      });
+
+      test('unmount time', async () => {
+        const perf = await this.measureUnmount();
+        expect(perf).toMatchPerfSnapshot(customThreshold);
+      });
+
+      test('rerender time', async () => {
+        const perf = await this.measureRerender();
+        expect(perf).toMatchPerfSnapshot(customThreshold);
+      });
+
+      // Custom scenarios
+      const customScenarios = this.getCustomScenarios();
+      if (customScenarios.length > 0) {
+        describe(`${this.componentName}-Specific Scenarios`, () => {
+          for (const scenario of customScenarios) {
+            test(scenario.name, async () => {
+              const perf = await scenario.run();
+              expect(perf).toMatchPerfSnapshot(customThreshold);
+            });
+          }
+        });
+      }
+    });
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/ci/BaselineComparator.ts
+++ b/packages/@react-native-windows/perf-testing/src/ci/BaselineComparator.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import type {PerfThreshold} from '../interfaces/PerfThreshold';
+import {DEFAULT_THRESHOLD} from '../interfaces/PerfThreshold';
+import type {SnapshotFile} from '../matchers/snapshotManager';
+import type {ComparisonResult} from '../reporters/MarkdownReporter';
+import {coefficientOfVariation, mannWhitneyU} from '../core/statistics';
+
+/**
+ * Options for baseline comparison.
+ */
+export interface CompareOptions {
+  defaultThreshold?: PerfThreshold;
+  thresholdOverrides?: Record<string, Partial<PerfThreshold>>;
+}
+
+/**
+ * Full comparison output for a test suite.
+ */
+export interface SuiteComparison {
+  suiteName: string;
+  comparisons: ComparisonResult[];
+  hasRegressions: boolean;
+}
+
+/**
+ * Compares head (current) perf snapshots against base (main) snapshots.
+ */
+export class BaselineComparator {
+  static compareSuite(
+    suiteName: string,
+    headSnapshots: SnapshotFile,
+    baseSnapshots: SnapshotFile,
+    options: CompareOptions = {},
+  ): SuiteComparison {
+    const defaultThreshold = options.defaultThreshold || DEFAULT_THRESHOLD;
+    const comparisons: ComparisonResult[] = [];
+
+    // Compare all entries present in head
+    for (const [key, headEntry] of Object.entries(headSnapshots)) {
+      const baseEntry = baseSnapshots[key];
+      const threshold = {
+        ...defaultThreshold,
+        ...headEntry.threshold,
+        ...(options.thresholdOverrides?.[key] || {}),
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!baseEntry) {
+        comparisons.push({
+          metrics: headEntry.metrics,
+          baselineMetrics: undefined,
+          percentChange: undefined,
+          passed: true, // New scenarios always pass
+        });
+        continue;
+      }
+
+      const result = BaselineComparator.compareEntry(
+        headEntry.metrics,
+        baseEntry.metrics,
+        threshold,
+      );
+      comparisons.push(result);
+    }
+
+    // Flag scenarios removed in head
+    for (const key of Object.keys(baseSnapshots)) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!headSnapshots[key]) {
+        comparisons.push({
+          metrics: {
+            ...baseSnapshots[key].metrics,
+            name: `[REMOVED] ${baseSnapshots[key].metrics.name}`,
+          },
+          baselineMetrics: baseSnapshots[key].metrics,
+          percentChange: undefined,
+          passed: true,
+        });
+      }
+    }
+
+    return {
+      suiteName,
+      comparisons,
+      hasRegressions: comparisons.some(c => !c.passed),
+    };
+  }
+
+  static compareEntry(
+    head: PerfMetrics,
+    base: PerfMetrics,
+    threshold: PerfThreshold,
+  ): ComparisonResult {
+    const resolved: Required<PerfThreshold> = {
+      ...DEFAULT_THRESHOLD,
+      ...threshold,
+    };
+
+    const percentChange =
+      base.medianDuration > 0
+        ? ((head.medianDuration - base.medianDuration) / base.medianDuration) *
+          100
+        : head.medianDuration > 0
+        ? Infinity
+        : 0;
+
+    const errors: string[] = [];
+    const isTrackMode = resolved.mode === 'track';
+
+    // CV gate: skip regression check if measurement is too noisy
+    const cv =
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      head.durations && head.durations.length >= 2
+        ? coefficientOfVariation(head.durations)
+        : 0;
+    const tooNoisy = cv > resolved.maxCV;
+
+    // Statistical significance gate (Mann-Whitney U)
+    let statSignificant = true;
+    if (
+      !tooNoisy &&
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      head.durations &&
+      head.durations.length >= 2 &&
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      base.durations &&
+      base.durations.length >= 2
+    ) {
+      const mwResult = mannWhitneyU(base.durations, head.durations);
+      statSignificant = mwResult.significant;
+    }
+
+    // Check percentage increase AND absolute delta
+    const absoluteDelta = head.medianDuration - base.medianDuration;
+    if (
+      !tooNoisy &&
+      statSignificant &&
+      percentChange > resolved.maxDurationIncrease &&
+      absoluteDelta > resolved.minAbsoluteDelta
+    ) {
+      errors.push(
+        `Duration increased by ${percentChange.toFixed(
+          1,
+        )}% / +${absoluteDelta.toFixed(2)}ms ` +
+          `(threshold: ${resolved.maxDurationIncrease}% & ${resolved.minAbsoluteDelta}ms)`,
+      );
+    }
+
+    // Check absolute max
+    if (head.medianDuration > resolved.maxDuration) {
+      errors.push(
+        `Duration ${head.medianDuration.toFixed(2)}ms exceeds ` +
+          `max ${resolved.maxDuration}ms`,
+      );
+    }
+
+    // Check render count
+    if (head.renderCount > resolved.maxRenderCount) {
+      errors.push(
+        `Render count ${head.renderCount} exceeds ` +
+          `max ${resolved.maxRenderCount}`,
+      );
+    }
+
+    // Track mode: report but never fail
+    const passed = isTrackMode ? true : errors.length === 0;
+
+    return {
+      metrics: head,
+      baselineMetrics: base,
+      percentChange,
+      passed,
+      error: errors.length > 0 ? errors.join('; ') : undefined,
+    };
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
+++ b/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import fs from '@react-native-windows/fs';
+import * as path from 'path';
+import {SnapshotManager} from '../matchers/snapshotManager';
+import type {SnapshotFile} from '../matchers/snapshotManager';
+
+/**
+ * Summary of a single test suite's perf results.
+ */
+export interface SuiteResult {
+  testFilePath: string;
+  suiteName: string;
+  snapshots: SnapshotFile;
+  passed: number;
+  failed: number;
+  totalDuration: number;
+}
+
+/**
+ * Full CI perf run results.
+ */
+export interface CIRunResults {
+  timestamp: string;
+  branch: string;
+  commitSha: string;
+  suites: SuiteResult[];
+  summary: {
+    totalSuites: number;
+    totalTests: number;
+    passed: number;
+    failed: number;
+    durationMs: number;
+  };
+}
+
+/**
+ * Custom Jest reporter that collects perf snapshot data
+ * and writes a JSON results file for CI.
+ */
+export class PerfJsonReporter {
+  private readonly outputFile: string;
+
+  constructor(
+    _globalConfig: Record<string, unknown>,
+    options: {outputFile?: string} = {},
+  ) {
+    this.outputFile = options.outputFile || '.perf-results/results.json';
+  }
+
+  onRunComplete(
+    _testContexts: Set<unknown>,
+    results: {
+      numTotalTestSuites: number;
+      numPassedTestSuites: number;
+      numFailedTestSuites: number;
+      numTotalTests: number;
+      numPassedTests: number;
+      numFailedTests: number;
+      startTime: number;
+      testResults: Array<{
+        testFilePath: string;
+        testResults: Array<{
+          ancestorTitles: string[];
+          title: string;
+          status: string;
+          duration?: number;
+        }>;
+        perfTimer?: {start: number; end: number};
+      }>;
+    },
+  ): void {
+    const suites: SuiteResult[] = [];
+
+    for (const suite of results.testResults) {
+      // Load the snapshot file for this test suite (written by toMatchPerfSnapshot)
+      const {file: snapshotFilePath} = SnapshotManager.getSnapshotPath(
+        suite.testFilePath,
+      );
+      const snapshots = SnapshotManager.load(snapshotFilePath);
+
+      const passed = suite.testResults.filter(
+        t => t.status === 'passed',
+      ).length;
+      const failed = suite.testResults.filter(
+        t => t.status === 'failed',
+      ).length;
+      const totalDuration = suite.testResults.reduce(
+        (acc, t) => acc + (t.duration || 0),
+        0,
+      );
+
+      suites.push({
+        testFilePath: suite.testFilePath,
+        suiteName: path.basename(suite.testFilePath, '.perf-test.tsx'),
+        snapshots,
+        passed,
+        failed,
+        totalDuration,
+      });
+    }
+
+    const ciResults: CIRunResults = {
+      timestamp: new Date().toISOString(),
+      branch:
+        process.env.BUILD_SOURCEBRANCH ||
+        process.env.GITHUB_HEAD_REF ||
+        process.env.GITHUB_REF ||
+        'unknown',
+      commitSha:
+        process.env.BUILD_SOURCEVERSION || process.env.GITHUB_SHA || 'unknown',
+      suites,
+      summary: {
+        totalSuites: results.numTotalTestSuites,
+        totalTests: results.numTotalTests,
+        passed: results.numPassedTests,
+        failed: results.numFailedTests,
+        durationMs: Date.now() - results.startTime,
+      },
+    };
+
+    // Write results
+    const outputDir = path.dirname(this.outputFile);
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, {recursive: true});
+    }
+    fs.writeFileSync(
+      this.outputFile,
+      JSON.stringify(ciResults, null, 2) + '\n',
+      'utf-8',
+    );
+
+    console.log(`\n📊 Perf results written to: ${this.outputFile}`);
+  }
+}
+
+// Default export for Jest reporter compatibility
+module.exports = PerfJsonReporter;

--- a/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
+++ b/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
@@ -78,11 +78,11 @@ export class PerfJsonReporter {
     const suites: SuiteResult[] = [];
 
     for (const suite of results.testResults) {
-      // Load the snapshot file for this test suite (written by toMatchPerfSnapshot)
+      // Use live run metrics captured during the test run
       const {file: snapshotFilePath} = SnapshotManager.getSnapshotPath(
         suite.testFilePath,
       );
-      const snapshots = SnapshotManager.load(snapshotFilePath);
+      const snapshots = SnapshotManager.getRunMetrics(snapshotFilePath) ?? {};
 
       const passed = suite.testResults.filter(
         t => t.status === 'passed',

--- a/packages/@react-native-windows/perf-testing/src/ci/index.ts
+++ b/packages/@react-native-windows/perf-testing/src/ci/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * CI/CD integration utilities for perf testing.
+ *
+ * @format
+ */
+
+export {PerfJsonReporter} from './PerfJsonReporter';
+export type {SuiteResult, CIRunResults} from './PerfJsonReporter';
+
+export {BaselineComparator} from './BaselineComparator';
+export type {CompareOptions, SuiteComparison} from './BaselineComparator';

--- a/packages/@react-native-windows/perf-testing/src/config/defaultConfig.ts
+++ b/packages/@react-native-windows/perf-testing/src/config/defaultConfig.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import type {PerfThreshold} from '../interfaces/PerfThreshold';
+
+export interface PerfTestConfig {
+  defaultRuns: number;
+  defaultWarmupRuns: number;
+  defaultThreshold: Required<PerfThreshold>;
+  verbose: boolean;
+  outputDir: string;
+}
+
+export const DEFAULT_CONFIG: Readonly<PerfTestConfig> = {
+  defaultRuns: 10,
+  defaultWarmupRuns: 1,
+  defaultThreshold: {
+    maxDurationIncrease: 10,
+    maxDuration: Infinity,
+    minAbsoluteDelta: 3,
+    maxRenderCount: 5,
+    minRuns: 10,
+    maxCV: 0.5,
+    mode: 'gate',
+  },
+  verbose: false,
+  outputDir: '.perf-results',
+};
+
+export function createPerfConfig(
+  overrides: Partial<PerfTestConfig>,
+): PerfTestConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...overrides,
+    defaultThreshold: {
+      ...DEFAULT_CONFIG.defaultThreshold,
+      ...(overrides.defaultThreshold ?? {}),
+    },
+  };
+}

--- a/packages/@react-native-windows/perf-testing/src/config/index.ts
+++ b/packages/@react-native-windows/perf-testing/src/config/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+export {DEFAULT_CONFIG, createPerfConfig} from './defaultConfig';
+export type {PerfTestConfig} from './defaultConfig';
+export {ThresholdPresets} from './thresholdPresets';

--- a/packages/@react-native-windows/perf-testing/src/config/thresholdPresets.ts
+++ b/packages/@react-native-windows/perf-testing/src/config/thresholdPresets.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import type {PerfThreshold} from '../interfaces/PerfThreshold';
+
+/**
+ * Pre-configured threshold presets for different component categories.
+ */
+export const ThresholdPresets: Readonly<
+  Record<string, Required<PerfThreshold>>
+> = {
+  /** Stable core components (View, Text, Image) — tight thresholds */
+  core: {
+    maxDurationIncrease: 10,
+    maxDuration: Infinity,
+    minAbsoluteDelta: 3,
+    maxRenderCount: 2,
+    minRuns: 10,
+    maxCV: 0.4,
+    mode: 'gate',
+  },
+
+  /** Complex list/scroll components — slightly relaxed */
+  list: {
+    maxDurationIncrease: 15,
+    maxDuration: Infinity,
+    minAbsoluteDelta: 5,
+    maxRenderCount: 5,
+    minRuns: 5,
+    maxCV: 0.5,
+    mode: 'gate',
+  },
+
+  /** Interactive components with animations — more relaxed */
+  interactive: {
+    maxDurationIncrease: 20,
+    maxDuration: Infinity,
+    minAbsoluteDelta: 5,
+    maxRenderCount: 10,
+    minRuns: 10,
+    maxCV: 0.5,
+    mode: 'gate',
+  },
+
+  /** Community/custom components — most relaxed */
+  community: {
+    maxDurationIncrease: 25,
+    maxDuration: Infinity,
+    minAbsoluteDelta: 5,
+    maxRenderCount: 15,
+    minRuns: 5,
+    maxCV: 0.6,
+    mode: 'track',
+  },
+};

--- a/packages/@react-native-windows/perf-testing/src/config/thresholdPresets.ts
+++ b/packages/@react-native-windows/perf-testing/src/config/thresholdPresets.ts
@@ -56,4 +56,14 @@ export const ThresholdPresets: Readonly<
     maxCV: 0.6,
     mode: 'track',
   },
+
+  native: {
+    maxDurationIncrease: 15,
+    maxDuration: Infinity,
+    minAbsoluteDelta: 5,
+    maxRenderCount: 1,
+    minRuns: 10,
+    maxCV: 0.5,
+    mode: 'gate',
+  },
 };

--- a/packages/@react-native-windows/perf-testing/src/core/PerfProfiler.tsx
+++ b/packages/@react-native-windows/perf-testing/src/core/PerfProfiler.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+
+/**
+ * Result from a single profiler measurement.
+ */
+export interface ProfilerResult {
+  phase: 'mount' | 'update' | 'nested-update';
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+}
+
+export type OnRenderCallback = (result: ProfilerResult) => void;
+
+interface PerfProfilerProps {
+  id: string;
+  onResult: OnRenderCallback;
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper around React.Profiler that collects structured performance data.
+ */
+export function PerfProfiler({
+  id,
+  onResult,
+  children,
+}: PerfProfilerProps): React.ReactElement {
+  const onRender = React.useCallback(
+    (
+      _id: string,
+      phase: 'mount' | 'update' | 'nested-update',
+      actualDuration: number,
+      baseDuration: number,
+      startTime: number,
+      commitTime: number,
+    ) => {
+      onResult({
+        phase,
+        actualDuration,
+        baseDuration,
+        startTime,
+        commitTime,
+      });
+    },
+    [onResult],
+  );
+
+  return (
+    <React.Profiler id={id} onRender={onRender}>
+      {children}
+    </React.Profiler>
+  );
+}

--- a/packages/@react-native-windows/perf-testing/src/core/measurePerf.ts
+++ b/packages/@react-native-windows/perf-testing/src/core/measurePerf.ts
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import {mean, median, standardDeviation} from './statistics';
+import type {ProfilerResult} from './PerfProfiler';
+import {PerfProfiler} from './PerfProfiler';
+
+// React 19 requires all state-updating calls to be wrapped in act().
+// We lazy-require react-test-renderer, so we also lazy-resolve act.
+let cachedAct: ((cb: () => void) => void) | undefined;
+function getAct(): (cb: () => void) => void {
+  if (!cachedAct) {
+    const {act} = require('react-test-renderer');
+    cachedAct = act;
+  }
+  return cachedAct!;
+}
+
+/**
+ * Options for the `measurePerf` function.
+ */
+export interface MeasurePerfOptions {
+  name: string;
+  runs?: number;
+  warmupRuns?: number;
+  scenario?: (helpers: RenderHelpers) => Promise<void>;
+  measureUnmount?: boolean;
+}
+
+/**
+ * Helpers passed to scenario callbacks during measurement.
+ */
+export interface RenderHelpers {
+  rerender: (element: React.ReactElement) => void;
+  unmount: () => void;
+}
+
+/**
+ * Result from a single measurement iteration.
+ */
+interface SingleRunResult {
+  duration: number;
+  renderCount: number;
+}
+
+/**
+ * Core measurement function.
+ *
+ * Renders a component multiple times wrapped in React.Profiler,
+ * collects timing data, and returns aggregated metrics.
+ */
+export async function measurePerf(
+  component: React.ReactElement,
+  options: MeasurePerfOptions,
+): Promise<PerfMetrics> {
+  const {
+    name,
+    runs = 10,
+    warmupRuns = 1,
+    scenario,
+    measureUnmount = false,
+  } = options;
+
+  // Lazy-require react-test-renderer to keep it as a peerDep
+
+  const TestRenderer = require('react-test-renderer');
+
+  const durations: number[] = [];
+  let totalRenderCount = 0;
+
+  for (let i = 0; i < warmupRuns; i++) {
+    await runSingleMeasurement(
+      TestRenderer,
+      component,
+      `${name}-warmup-${i}`,
+      scenario,
+      measureUnmount,
+    );
+  }
+
+  for (let i = 0; i < runs; i++) {
+    const result = await runSingleMeasurement(
+      TestRenderer,
+      component,
+      `${name}-run-${i}`,
+      scenario,
+      measureUnmount,
+    );
+    durations.push(result.duration);
+    totalRenderCount += result.renderCount;
+  }
+
+  return {
+    name,
+    meanDuration: mean(durations),
+    medianDuration: median(durations),
+    stdDev: standardDeviation(durations),
+    renderCount: Math.round(totalRenderCount / runs),
+    runs,
+    durations,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Execute a single measurement iteration.
+ */
+async function runSingleMeasurement(
+  testRenderer: typeof import('react-test-renderer'),
+  component: React.ReactElement,
+  profilerId: string,
+  scenario?: (helpers: RenderHelpers) => Promise<void>,
+  measureUnmount: boolean = false,
+): Promise<SingleRunResult> {
+  const results: ProfilerResult[] = [];
+
+  const onResult = (result: ProfilerResult) => {
+    results.push(result);
+  };
+
+  const wrappedComponent = React.createElement(PerfProfiler, {
+    id: profilerId,
+    onResult,
+    children: component,
+  });
+
+  let renderer!: ReturnType<typeof testRenderer.create>;
+
+  const act = getAct();
+
+  if (measureUnmount) {
+    act(() => {
+      renderer = testRenderer.create(wrappedComponent);
+    });
+
+    results.length = 0;
+
+    const unmountStart = performance.now();
+    act(() => {
+      renderer.unmount();
+    });
+    const unmountDuration = performance.now() - unmountStart;
+
+    return {
+      duration: unmountDuration,
+      renderCount: 0,
+    };
+  }
+
+  // Measure mount
+  const mountStart = performance.now();
+  act(() => {
+    renderer = testRenderer.create(wrappedComponent);
+  });
+  const mountDuration = performance.now() - mountStart;
+
+  if (scenario) {
+    const helpers: RenderHelpers = {
+      rerender: (element: React.ReactElement) => {
+        const wrappedUpdate = React.createElement(PerfProfiler, {
+          id: profilerId,
+          onResult,
+          children: element,
+        });
+        act(() => {
+          renderer.update(wrappedUpdate);
+        });
+      },
+      unmount: () => {
+        act(() => {
+          renderer.unmount();
+        });
+      },
+    };
+    await scenario(helpers);
+  }
+
+  // Clean up
+  try {
+    act(() => {
+      renderer.unmount();
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!msg.includes('unmount') && !msg.includes('not mounted')) {
+      throw e;
+    }
+  }
+
+  // Prefer Profiler actualDuration, fallback to manual timing
+  const totalActualDuration = results.reduce(
+    (sum, r) => sum + r.actualDuration,
+    0,
+  );
+
+  return {
+    duration: totalActualDuration > 0 ? totalActualDuration : mountDuration,
+    renderCount: results.length,
+  };
+}

--- a/packages/@react-native-windows/perf-testing/src/core/statistics.ts
+++ b/packages/@react-native-windows/perf-testing/src/core/statistics.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+export function mean(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export function standardDeviation(values: number[]): number {
+  if (values.length < 2) {
+    return 0;
+  }
+  const avg = mean(values);
+  const squaredDiffs = values.map(v => (v - avg) ** 2);
+  return Math.sqrt(
+    squaredDiffs.reduce((sum, v) => sum + v, 0) / (values.length - 1),
+  );
+}
+
+export function coefficientOfVariation(values: number[]): number {
+  if (values.length < 2) {
+    return 0;
+  }
+  const avg = mean(values);
+  if (avg === 0) {
+    return 0;
+  }
+  return standardDeviation(values) / avg;
+}
+
+/**
+ * Normal CDF approximation (Abramowitz & Stegun 26.2.17).
+ * Accurate to ~1.5e-7 for all z.
+ */
+function normalCDF(z: number): number {
+  if (z < -8) {
+    return 0;
+  }
+  if (z > 8) {
+    return 1;
+  }
+
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+
+  const sign = z < 0 ? -1 : 1;
+  const x = Math.abs(z) / Math.sqrt(2);
+  const t = 1.0 / (1.0 + p * x);
+  const y =
+    1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
+
+  return 0.5 * (1.0 + sign * y);
+}
+
+export interface MannWhitneyResult {
+  U: number;
+  z: number;
+  p: number;
+  significant: boolean;
+}
+
+/**
+ * Mann-Whitney U test (one-tailed: is sample2 significantly greater?).
+ *
+ * Non-parametric test appropriate for perf measurements that may not
+ * follow a normal distribution. Uses the normal approximation with
+ * tie correction, valid for n >= 8.
+ *
+ * @param sample1 - Baseline durations
+ * @param sample2 - Current (head) durations
+ * @param alpha - Significance level (default 0.05)
+ * @returns Test result with U statistic, z-score, p-value, and significance flag
+ */
+export function mannWhitneyU(
+  sample1: number[],
+  sample2: number[],
+  alpha: number = 0.05,
+): MannWhitneyResult {
+  const n1 = sample1.length;
+  const n2 = sample2.length;
+
+  if (n1 < 2 || n2 < 2) {
+    return {U: 0, z: 0, p: 1, significant: false};
+  }
+
+  // Tag each value with its group and combine
+  const combined: Array<{value: number; group: number}> = [
+    ...sample1.map(v => ({value: v, group: 1})),
+    ...sample2.map(v => ({value: v, group: 2})),
+  ];
+
+  // Sort by value
+  combined.sort((a, b) => a.value - b.value);
+
+  // Assign ranks with tie handling (average rank for ties)
+  const ranks = new Array<number>(combined.length);
+  let i = 0;
+  while (i < combined.length) {
+    let j = i;
+    while (j < combined.length && combined[j].value === combined[i].value) {
+      j++;
+    }
+    const avgRank = (i + 1 + j) / 2;
+    for (let k = i; k < j; k++) {
+      ranks[k] = avgRank;
+    }
+    i = j;
+  }
+
+  // Sum of ranks for sample 1
+  let R1 = 0;
+  for (let idx = 0; idx < combined.length; idx++) {
+    if (combined[idx].group === 1) {
+      R1 += ranks[idx];
+    }
+  }
+
+  // U statistics
+  const U1 = n1 * n2 + (n1 * (n1 + 1)) / 2 - R1;
+  const U2 = n1 * n2 - U1;
+  const U = Math.min(U1, U2);
+
+  // Normal approximation with tie correction
+  const n = n1 + n2;
+  const meanU = (n1 * n2) / 2;
+
+  // Calculate tie correction factor
+  let tieCorrection = 0;
+  let idx = 0;
+  while (idx < combined.length) {
+    let tieCount = 1;
+    while (
+      idx + tieCount < combined.length &&
+      combined[idx + tieCount].value === combined[idx].value
+    ) {
+      tieCount++;
+    }
+    if (tieCount > 1) {
+      tieCorrection += tieCount ** 3 - tieCount;
+    }
+    idx += tieCount;
+  }
+
+  const sigmaU = Math.sqrt(
+    (n1 * n2 * (n + 1)) / 12 - (n1 * n2 * tieCorrection) / (12 * n * (n - 1)),
+  );
+
+  if (sigmaU === 0) {
+    return {U, z: 0, p: 1, significant: false};
+  }
+
+  // One-tailed: is sample2 significantly greater than sample1?
+  // Lower U1 means sample2 tends to have higher ranks
+  const z = (U - meanU) / sigmaU;
+  const p = normalCDF(z);
+
+  return {U, z, p, significant: p < alpha};
+}

--- a/packages/@react-native-windows/perf-testing/src/index.ts
+++ b/packages/@react-native-windows/perf-testing/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+export {measurePerf} from './core/measurePerf';
+export type {MeasurePerfOptions, RenderHelpers} from './core/measurePerf';
+export {PerfProfiler} from './core/PerfProfiler';
+export type {ProfilerResult} from './core/PerfProfiler';
+export {
+  mean,
+  median,
+  standardDeviation,
+  coefficientOfVariation,
+  mannWhitneyU,
+} from './core/statistics';
+export type {MannWhitneyResult} from './core/statistics';
+
+export type {PerfMetrics} from './interfaces/PerfMetrics';
+export type {PerfThreshold} from './interfaces/PerfThreshold';
+export {DEFAULT_THRESHOLD} from './interfaces/PerfThreshold';
+export type {
+  IComponentPerfTest,
+  IScenario,
+  PerfTestCategory,
+} from './interfaces/IComponentPerfTest';
+
+export {ComponentPerfTestBase} from './base/ComponentPerfTestBase';
+
+export {MountScenario} from './scenarios/MountScenario';
+export {UnmountScenario} from './scenarios/UnmountScenario';
+export {RerenderScenario} from './scenarios/RerenderScenario';
+
+import './matchers';
+export {SnapshotManager} from './matchers/snapshotManager';
+export type {SnapshotEntry, SnapshotFile} from './matchers/snapshotManager';
+
+export {DEFAULT_CONFIG, createPerfConfig} from './config/defaultConfig';
+export type {PerfTestConfig} from './config/defaultConfig';
+export {ThresholdPresets} from './config/thresholdPresets';
+
+export {ConsoleReporter} from './reporters/ConsoleReporter';
+export {MarkdownReporter} from './reporters/MarkdownReporter';
+export type {ComparisonResult} from './reporters/MarkdownReporter';
+
+export {PerfJsonReporter} from './ci/PerfJsonReporter';
+export type {SuiteResult, CIRunResults} from './ci/PerfJsonReporter';
+export {BaselineComparator} from './ci/BaselineComparator';
+export type {CompareOptions, SuiteComparison} from './ci/BaselineComparator';

--- a/packages/@react-native-windows/perf-testing/src/interfaces/IComponentPerfTest.ts
+++ b/packages/@react-native-windows/perf-testing/src/interfaces/IComponentPerfTest.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import type {PerfMetrics} from './PerfMetrics';
+import type {PerfThreshold} from './PerfThreshold';
+
+/**
+ * Category for organizing perf tests.
+ *
+ * - 'core': Built-in RN components (View, Text, TextInput, Image, ScrollView)
+ * - 'extended': Higher-level RN components (FlatList, SectionList, RefreshControl)
+ * - 'custom': Community or app-specific components
+ */
+export type PerfTestCategory = 'core' | 'extended' | 'custom';
+
+/**
+ * Contract that all component performance tests must implement.
+ */
+export interface IComponentPerfTest {
+  readonly componentName: string;
+  readonly category: PerfTestCategory;
+  readonly testId: string;
+  readonly defaultThreshold: PerfThreshold;
+
+  measureMount(): Promise<PerfMetrics>;
+  measureUnmount(): Promise<PerfMetrics>;
+  measureRerender(): Promise<PerfMetrics>;
+
+  getCustomScenarios?(): IScenario[];
+}
+
+/**
+ * A single named test scenario that produces performance metrics.
+ */
+export interface IScenario {
+  name: string;
+  description: string;
+  run(): Promise<PerfMetrics>;
+}

--- a/packages/@react-native-windows/perf-testing/src/interfaces/PerfMetrics.ts
+++ b/packages/@react-native-windows/perf-testing/src/interfaces/PerfMetrics.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+/**
+ * Performance metrics collected from a single test scenario run.
+ *
+ * All duration values are in milliseconds.
+ */
+export interface PerfMetrics {
+  /** Test scenario name (e.g., 'View mount') */
+  name: string;
+
+  /** Mean duration across all runs (ms) */
+  meanDuration: number;
+
+  /** Median duration across all runs (ms) */
+  medianDuration: number;
+
+  /** Standard deviation of durations (ms) */
+  stdDev: number;
+
+  /** Average render count per run */
+  renderCount: number;
+
+  /** Number of test runs performed */
+  runs: number;
+
+  /** Raw durations from each run (ms), used for statistical comparison */
+  durations: number[];
+
+  /** ISO timestamp of when the measurement was taken */
+  timestamp: string;
+
+  /**
+   * Extension point for native timing data.
+   * Reserved for future integration with native perf markers.
+   */
+  nativeTimings?: Record<string, number>;
+
+  /**
+   * Extension point for memory measurements.
+   * Reserved for future memory tracking integration.
+   */
+  memoryDelta?: number;
+}

--- a/packages/@react-native-windows/perf-testing/src/interfaces/PerfThreshold.ts
+++ b/packages/@react-native-windows/perf-testing/src/interfaces/PerfThreshold.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+/**
+ * Thresholds for pass/fail determination of a performance test.
+ *
+ * When comparing against a baseline snapshot, these thresholds
+ * determine whether a regression has occurred.
+ */
+export interface PerfThreshold {
+  /** Max allowed duration increase from baseline (percentage). Default: 10 */
+  maxDurationIncrease?: number;
+
+  /** Absolute max duration (ms) — fails if exceeded regardless of baseline */
+  maxDuration?: number;
+
+  /**
+   * Minimum absolute duration change (ms) required to flag a regression.
+   * Even if the percentage threshold is exceeded, regressions below this
+   * absolute delta are treated as environmental noise. Default: 3
+   */
+  minAbsoluteDelta?: number;
+
+  /** Max allowed render count per measurement */
+  maxRenderCount?: number;
+
+  /** Minimum runs required for a valid measurement. Default: 10 */
+  minRuns?: number;
+
+  /**
+   * Max coefficient of variation (stdDev/mean) allowed for reliable comparison.
+   * Tests above this CV are too noisy to gate on — they warn instead of fail.
+   * Default: 0.5 (50%). Set lower for stricter noise filtering.
+   */
+  maxCV?: number;
+
+  /**
+   * 'gate' = fail CI on regression (default for stable tests).
+   * 'track' = warn only, never fail (for inherently noisy bulk scenarios).
+   */
+  mode?: 'gate' | 'track';
+}
+
+export const DEFAULT_THRESHOLD: Readonly<Required<PerfThreshold>> = {
+  maxDurationIncrease: 10,
+  maxDuration: Infinity,
+  minAbsoluteDelta: 3,
+  maxRenderCount: 5,
+  minRuns: 10,
+  maxCV: 0.5,
+  mode: 'gate',
+};

--- a/packages/@react-native-windows/perf-testing/src/interfaces/index.ts
+++ b/packages/@react-native-windows/perf-testing/src/interfaces/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+export type {PerfMetrics} from './PerfMetrics';
+export type {PerfThreshold} from './PerfThreshold';
+export {DEFAULT_THRESHOLD} from './PerfThreshold';
+export type {
+  IComponentPerfTest,
+  IScenario,
+  PerfTestCategory,
+} from './IComponentPerfTest';

--- a/packages/@react-native-windows/perf-testing/src/matchers/index.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+// Auto-register the toMatchPerfSnapshot matcher when this module is imported.
+import './toMatchPerfSnapshot';
+
+export {SnapshotManager} from './snapshotManager';
+export type {SnapshotEntry, SnapshotFile} from './snapshotManager';

--- a/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import fs from '@react-native-windows/fs';
+import * as path from 'path';
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import type {PerfThreshold} from '../interfaces/PerfThreshold';
+
+/**
+ * A single entry stored in a `.perf-baseline.json` file.
+ */
+export interface SnapshotEntry {
+  metrics: PerfMetrics;
+  threshold: PerfThreshold;
+  capturedAt: string;
+}
+
+/**
+ * A map of snapshot key → entry, representing one `.perf-baseline.json` file.
+ */
+export type SnapshotFile = Record<string, SnapshotEntry>;
+
+/**
+ * Manages reading and writing of perf snapshot files.
+ */
+export class SnapshotManager {
+  static getSnapshotPath(testFilePath: string): {
+    dir: string;
+    file: string;
+  } {
+    const testDir = path.dirname(testFilePath);
+    const snapshotDir = path.join(testDir, '__perf_snapshots__');
+    const snapshotFile = path.join(
+      snapshotDir,
+      `${path.basename(testFilePath)}.perf-baseline.json`,
+    );
+    return {dir: snapshotDir, file: snapshotFile};
+  }
+
+  static load(snapshotFilePath: string): SnapshotFile {
+    if (fs.existsSync(snapshotFilePath)) {
+      const content = fs.readFileSync(snapshotFilePath, 'utf-8');
+      const parsed = JSON.parse(content) as SnapshotFile;
+      // JSON.stringify turns Infinity into null — restore it on load
+      for (const entry of Object.values(parsed)) {
+        if ((entry.threshold.maxDuration as unknown) === null) {
+          (entry.threshold as {maxDuration: number}).maxDuration = Infinity;
+        }
+      }
+      return parsed;
+    }
+    return {};
+  }
+
+  static save(snapshotFilePath: string, snapshots: SnapshotFile): void {
+    const dir = path.dirname(snapshotFilePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, {recursive: true});
+    }
+    fs.writeFileSync(
+      snapshotFilePath,
+      JSON.stringify(snapshots, null, 2) + '\n',
+      'utf-8',
+    );
+  }
+
+  // Follows Jest's "test name 1" convention
+  static buildKey(testName: string): string {
+    return `${testName} 1`;
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
@@ -7,6 +7,7 @@
 
 import fs from '@react-native-windows/fs';
 import * as path from 'path';
+import * as os from 'os';
 import type {PerfMetrics} from '../interfaces/PerfMetrics';
 import type {PerfThreshold} from '../interfaces/PerfThreshold';
 
@@ -26,8 +27,63 @@ export type SnapshotFile = Record<string, SnapshotEntry>;
 
 /**
  * Manages reading and writing of perf snapshot files.
+ * Also writes live run metrics to a temp directory so the CI reporter
+ * (which runs in the Jest main process) can access fresh results
+ * from the worker process.
  */
 export class SnapshotManager {
+  /** Directory for live run metrics (cross-process via temp files). */
+  private static readonly _runMetricsDir =
+    process.env.PERF_RUN_METRICS_DIR ||
+    path.join(os.tmpdir(), 'rnw-perf-run-metrics');
+
+  /** Record a live metric entry for the current run (written to temp file). */
+  static recordRunMetric(
+    snapshotFilePath: string,
+    key: string,
+    entry: SnapshotEntry,
+  ): void {
+    const metricsFile = path.join(
+      SnapshotManager._runMetricsDir,
+      Buffer.from(snapshotFilePath).toString('base64url') + '.json',
+    );
+    let existing: SnapshotFile = {};
+    if (fs.existsSync(metricsFile)) {
+      existing = JSON.parse(
+        fs.readFileSync(metricsFile, 'utf-8'),
+      ) as SnapshotFile;
+    } else if (!fs.existsSync(SnapshotManager._runMetricsDir)) {
+      fs.mkdirSync(SnapshotManager._runMetricsDir, {recursive: true});
+    }
+    existing[key] = entry;
+    fs.writeFileSync(
+      metricsFile,
+      JSON.stringify(existing, null, 2) + '\n',
+      'utf-8',
+    );
+  }
+
+  /** Get live run metrics for a snapshot file, or null if none were recorded. */
+  static getRunMetrics(snapshotFilePath: string): SnapshotFile | null {
+    const metricsFile = path.join(
+      SnapshotManager._runMetricsDir,
+      Buffer.from(snapshotFilePath).toString('base64url') + '.json',
+    );
+    if (fs.existsSync(metricsFile)) {
+      return JSON.parse(fs.readFileSync(metricsFile, 'utf-8')) as SnapshotFile;
+    }
+    return null;
+  }
+
+  /** Clean up temp run metrics directory. */
+  static clearRunMetrics(): void {
+    if (fs.existsSync(SnapshotManager._runMetricsDir)) {
+      for (const f of fs.readdirSync(SnapshotManager._runMetricsDir)) {
+        fs.unlinkSync(path.join(SnapshotManager._runMetricsDir, f));
+      }
+    }
+  }
+
   static getSnapshotPath(testFilePath: string): {
     dir: string;
     file: string;

--- a/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import type {PerfThreshold} from '../interfaces/PerfThreshold';
+import {DEFAULT_THRESHOLD} from '../interfaces/PerfThreshold';
+import {SnapshotManager} from './snapshotManager';
+import type {SnapshotEntry} from './snapshotManager';
+import {coefficientOfVariation, mannWhitneyU} from '../core/statistics';
+
+interface CompareResult {
+  errors: string[];
+  warnings: string[];
+}
+
+function checkNoiseGates(
+  received: PerfMetrics,
+  baseline: SnapshotEntry,
+  threshold: PerfThreshold,
+): {tooNoisy: boolean; statSignificant: boolean; warnings: string[]} {
+  const warnings: string[] = [];
+
+  // CV gate
+  const cv =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    received.durations && received.durations.length >= 2
+      ? coefficientOfVariation(received.durations)
+      : 0;
+  const maxCV = threshold.maxCV ?? DEFAULT_THRESHOLD.maxCV;
+  const tooNoisy = cv > maxCV;
+
+  if (tooNoisy) {
+    warnings.push(
+      `High variance (CV=${(cv * 100).toFixed(1)}% > ${(maxCV * 100).toFixed(
+        0,
+      )}%) — skipping regression check`,
+    );
+  }
+
+  // Mann-Whitney U statistical significance
+  let statSignificant = true;
+  if (
+    !tooNoisy &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    received.durations &&
+    received.durations.length >= 2 &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    baseline.metrics.durations &&
+    baseline.metrics.durations.length >= 2
+  ) {
+    const mwResult = mannWhitneyU(
+      baseline.metrics.durations,
+      received.durations,
+    );
+    statSignificant = mwResult.significant;
+    if (!statSignificant) {
+      warnings.push(
+        `Not statistically significant (p=${mwResult.p.toFixed(
+          3,
+        )}) — difference may be noise`,
+      );
+    }
+  }
+
+  return {tooNoisy, statSignificant, warnings};
+}
+
+function compareAgainstBaseline(
+  received: PerfMetrics,
+  baseline: SnapshotEntry,
+  threshold: PerfThreshold,
+): CompareResult {
+  const {tooNoisy, statSignificant, warnings} = checkNoiseGates(
+    received,
+    baseline,
+    threshold,
+  );
+  const errors: string[] = [];
+
+  // Check duration regression using MEDIAN
+  if (!tooNoisy && threshold.maxDurationIncrease !== undefined) {
+    const pctChange =
+      ((received.medianDuration - baseline.metrics.medianDuration) /
+        baseline.metrics.medianDuration) *
+      100;
+    const absDelta = received.medianDuration - baseline.metrics.medianDuration;
+    const minDelta =
+      threshold.minAbsoluteDelta ?? DEFAULT_THRESHOLD.minAbsoluteDelta;
+
+    if (
+      pctChange > threshold.maxDurationIncrease &&
+      absDelta > minDelta &&
+      statSignificant
+    ) {
+      errors.push(
+        `Duration regression: +${pctChange.toFixed(1)}% / +${absDelta.toFixed(
+          2,
+        )}ms ` +
+          `(baseline median: ${baseline.metrics.medianDuration.toFixed(
+            2,
+          )}ms → ` +
+          `current median: ${received.medianDuration.toFixed(2)}ms, ` +
+          `threshold: ${threshold.maxDurationIncrease}% & ${minDelta}ms)`,
+      );
+    }
+  }
+
+  // Check absolute duration limit
+  if (
+    threshold.maxDuration !== undefined &&
+    threshold.maxDuration !== Infinity &&
+    received.medianDuration > threshold.maxDuration
+  ) {
+    errors.push(
+      `Duration exceeded: ${received.medianDuration.toFixed(2)}ms > ` +
+        `${threshold.maxDuration}ms (absolute limit)`,
+    );
+  }
+
+  // Check render count
+  if (
+    threshold.maxRenderCount !== undefined &&
+    received.renderCount > threshold.maxRenderCount
+  ) {
+    errors.push(
+      `Render count exceeded: ${received.renderCount} > ` +
+        `${threshold.maxRenderCount}`,
+    );
+  }
+
+  return {errors, warnings};
+}
+
+/**
+ * Extend Jest's Matchers interface so `toMatchPerfSnapshot` is recognized.
+ */
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toMatchPerfSnapshot(threshold?: Partial<PerfThreshold>): R;
+    }
+  }
+}
+
+expect.extend({
+  toMatchPerfSnapshot(
+    received: PerfMetrics,
+    customThreshold?: Partial<PerfThreshold>,
+  ) {
+    const testPath = expect.getState().testPath!;
+    const testName = expect.getState().currentTestName!;
+
+    // Resolve snapshot file location
+    const {file: snapshotFile} = SnapshotManager.getSnapshotPath(testPath);
+    const snapshotKey = SnapshotManager.buildKey(testName);
+
+    const isUpdateMode =
+      process.argv.includes('-u') || process.argv.includes('--updateSnapshot');
+
+    // Load existing snapshots
+    const snapshots = SnapshotManager.load(snapshotFile);
+    const baseline = snapshots[snapshotKey];
+
+    const threshold: PerfThreshold = {...DEFAULT_THRESHOLD, ...customThreshold};
+
+    // UPDATE MODE or FIRST RUN: write new baseline
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (isUpdateMode || !baseline) {
+      snapshots[snapshotKey] = {
+        metrics: received,
+        threshold,
+        capturedAt: new Date().toISOString(),
+      };
+
+      SnapshotManager.save(snapshotFile, snapshots);
+
+      return {
+        pass: true,
+        message: () =>
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          `✅ Perf snapshot ${baseline ? 'updated' : 'created'}: ${
+            received.name
+          }` +
+          ` (${received.meanDuration.toFixed(2)}ms, ${
+            received.renderCount
+          } renders)`,
+      };
+    }
+
+    // COMPARE MODE
+    const {errors, warnings} = compareAgainstBaseline(
+      received,
+      baseline,
+      threshold,
+    );
+    const isTrackMode = threshold.mode === 'track';
+    const warningText =
+      warnings.length > 0
+        ? '\n' + warnings.map(w => `  ℹ ${w}`).join('\n')
+        : '';
+
+    if (isTrackMode && errors.length > 0) {
+      return {
+        pass: true,
+        message: () =>
+          `⚠️ [TRACK] "${received.name}" would have failed:\n\n` +
+          errors.map(e => `  • ${e}`).join('\n') +
+          warningText +
+          `\n\n💡 Mode is 'track' — not blocking CI.`,
+      };
+    }
+
+    if (errors.length > 0) {
+      return {
+        pass: false,
+        message: () =>
+          `❌ Performance regression detected in "${received.name}":\n\n` +
+          errors.map(e => `  • ${e}`).join('\n') +
+          warningText +
+          `\n\n📊 Baseline captured: ${baseline.capturedAt}` +
+          `\n💡 Run with -u flag to update baseline if intentional.`,
+      };
+    }
+
+    // Calculate improvement for positive feedback
+    const improvement =
+      ((baseline.metrics.medianDuration - received.medianDuration) /
+        baseline.metrics.medianDuration) *
+      100;
+
+    return {
+      pass: true,
+      message: () =>
+        `✅ "${received.name}" within threshold ` +
+        `(median: ${received.medianDuration.toFixed(2)}ms, ` +
+        `${
+          improvement > 0 ? `-${improvement.toFixed(1)}% faster` : 'no change'
+        })`,
+    };
+  },
+});

--- a/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
@@ -168,6 +168,13 @@ expect.extend({
 
     const threshold: PerfThreshold = {...DEFAULT_THRESHOLD, ...customThreshold};
 
+    // Always record the live metrics for the CI reporter
+    SnapshotManager.recordRunMetric(snapshotFile, snapshotKey, {
+      metrics: received,
+      threshold,
+      capturedAt: new Date().toISOString(),
+    });
+
     // UPDATE MODE or FIRST RUN: write new baseline
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (isUpdateMode || !baseline) {

--- a/packages/@react-native-windows/perf-testing/src/reporters/ConsoleReporter.ts
+++ b/packages/@react-native-windows/perf-testing/src/reporters/ConsoleReporter.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+
+/**
+ * Outputs perf results to the console.
+ */
+export class ConsoleReporter {
+  static report(results: PerfMetrics[]): void {
+    console.log('\n⚡ Performance Test Results\n');
+    console.log('─'.repeat(72));
+    console.log(
+      padRight('Scenario', 30) +
+        padRight('Mean (ms)', 12) +
+        padRight('Median (ms)', 13) +
+        padRight('StdDev', 10) +
+        padRight('Renders', 8),
+    );
+    console.log('─'.repeat(72));
+
+    for (const result of results) {
+      console.log(
+        padRight(result.name, 30) +
+          padRight(result.meanDuration.toFixed(2), 12) +
+          padRight(result.medianDuration.toFixed(2), 13) +
+          padRight(result.stdDev.toFixed(2), 10) +
+          padRight(String(result.renderCount), 8),
+      );
+    }
+
+    console.log('─'.repeat(72));
+    console.log(`\nTotal scenarios: ${results.length}`);
+    console.log(`Timestamp: ${new Date().toISOString()}\n`);
+  }
+
+  static reportSingle(result: PerfMetrics): void {
+    console.log(
+      `  ${result.name}: ` +
+        `${result.meanDuration.toFixed(2)}ms (±${result.stdDev.toFixed(
+          2,
+        )}ms) ` +
+        `[${result.renderCount} renders, ${result.runs} runs]`,
+    );
+  }
+}
+
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str : str + ' '.repeat(len - str.length);
+}

--- a/packages/@react-native-windows/perf-testing/src/reporters/MarkdownReporter.ts
+++ b/packages/@react-native-windows/perf-testing/src/reporters/MarkdownReporter.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+
+/**
+ * Comparison info used when generating markdown reports.
+ */
+export interface ComparisonResult {
+  metrics: PerfMetrics;
+  baselineMetrics?: PerfMetrics;
+  percentChange?: number;
+  passed: boolean;
+  error?: string;
+}
+
+/**
+ * Generates Markdown-formatted perf results for CI.
+ */
+export class MarkdownReporter {
+  static generate(comparisons: ComparisonResult[]): string {
+    const passed = comparisons.filter(c => c.passed);
+    const failed = comparisons.filter(c => !c.passed);
+
+    let md = '';
+
+    if (failed.length > 0) {
+      md += '### ❌ Regressions\n\n';
+      md += '| Scenario | Baseline | Current | Change | Status |\n';
+      md += '|----------|----------|---------|--------|--------|\n';
+
+      for (const f of failed) {
+        const baseline = f.baselineMetrics
+          ? `${f.baselineMetrics.meanDuration.toFixed(2)}ms`
+          : 'N/A';
+        const current = `${f.metrics.meanDuration.toFixed(2)}ms`;
+        const change =
+          f.percentChange !== undefined
+            ? `+${f.percentChange.toFixed(1)}%`
+            : 'N/A';
+        md += `| ${f.metrics.name} | ${baseline} | ${current} | ${change} | ❌ |\n`;
+      }
+      md += '\n';
+    }
+
+    if (passed.length > 0) {
+      md += '### ✅ Passed\n\n';
+      md += `${passed.length} test(s) passed\n\n`;
+      md += '<details>\n<summary>Show details</summary>\n\n';
+      md += '| Scenario | Mean | Median | StdDev | Renders |\n';
+      md += '|----------|------|--------|--------|---------|\n';
+
+      for (const p of passed) {
+        md +=
+          `| ${p.metrics.name}` +
+          ` | ${p.metrics.meanDuration.toFixed(2)}ms` +
+          ` | ${p.metrics.medianDuration.toFixed(2)}ms` +
+          ` | ±${p.metrics.stdDev.toFixed(2)}ms` +
+          ` | ${p.metrics.renderCount} |\n`;
+      }
+      md += '\n</details>\n';
+    }
+
+    return md;
+  }
+
+  static summary(comparisons: ComparisonResult[]): string {
+    const passed = comparisons.filter(c => c.passed).length;
+    const failed = comparisons.filter(c => !c.passed).length;
+    const total = comparisons.length;
+
+    if (failed > 0) {
+      return `❌ ${failed}/${total} perf tests failed — performance regressions detected.`;
+    }
+    return `✅ All ${passed} perf tests passed.`;
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/reporters/index.ts
+++ b/packages/@react-native-windows/perf-testing/src/reporters/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+export {ConsoleReporter} from './ConsoleReporter';
+export {MarkdownReporter} from './MarkdownReporter';
+export type {ComparisonResult} from './MarkdownReporter';

--- a/packages/@react-native-windows/perf-testing/src/scenarios/MountScenario.ts
+++ b/packages/@react-native-windows/perf-testing/src/scenarios/MountScenario.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import type {IScenario} from '../interfaces/IComponentPerfTest';
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import {measurePerf} from '../core/measurePerf';
+
+/**
+ * Reusable scenario that measures component mount time.
+ */
+export class MountScenario implements IScenario {
+  readonly name: string;
+  readonly description: string;
+
+  constructor(
+    name: string,
+    private readonly component: React.ReactElement,
+    private readonly options: {runs?: number; warmupRuns?: number} = {},
+  ) {
+    this.name = name;
+    this.description = `Mount scenario for ${name}`;
+  }
+
+  async run(): Promise<PerfMetrics> {
+    return measurePerf(this.component, {
+      name: this.name,
+      runs: this.options.runs ?? 10,
+      warmupRuns: this.options.warmupRuns ?? 1,
+    });
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/scenarios/RerenderScenario.ts
+++ b/packages/@react-native-windows/perf-testing/src/scenarios/RerenderScenario.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import type {IScenario} from '../interfaces/IComponentPerfTest';
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import {measurePerf} from '../core/measurePerf';
+import type {RenderHelpers} from '../core/measurePerf';
+
+/**
+ * Reusable scenario that measures component re-render time.
+ */
+export class RerenderScenario implements IScenario {
+  readonly name: string;
+  readonly description: string;
+
+  constructor(
+    name: string,
+    private readonly component: React.ReactElement,
+    private readonly options: {
+      runs?: number;
+      warmupRuns?: number;
+      triggerRerender?: (helpers: RenderHelpers) => void | Promise<void>;
+    } = {},
+  ) {
+    this.name = name;
+    this.description = `Rerender scenario for ${name}`;
+  }
+
+  async run(): Promise<PerfMetrics> {
+    return measurePerf(this.component, {
+      name: this.name,
+      runs: this.options.runs ?? 10,
+      warmupRuns: this.options.warmupRuns ?? 1,
+      scenario: async helpers => {
+        if (this.options.triggerRerender) {
+          await this.options.triggerRerender(helpers);
+        } else {
+          // Default: re-render the same component (forces reconciliation)
+          helpers.rerender(this.component);
+        }
+      },
+    });
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/scenarios/UnmountScenario.ts
+++ b/packages/@react-native-windows/perf-testing/src/scenarios/UnmountScenario.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import type {IScenario} from '../interfaces/IComponentPerfTest';
+import type {PerfMetrics} from '../interfaces/PerfMetrics';
+import {measurePerf} from '../core/measurePerf';
+
+/**
+ * Reusable scenario that measures component unmount time.
+ */
+export class UnmountScenario implements IScenario {
+  readonly name: string;
+  readonly description: string;
+
+  constructor(
+    name: string,
+    private readonly component: React.ReactElement,
+    private readonly options: {runs?: number; warmupRuns?: number} = {},
+  ) {
+    this.name = name;
+    this.description = `Unmount scenario for ${name}`;
+  }
+
+  async run(): Promise<PerfMetrics> {
+    return measurePerf(this.component, {
+      name: this.name,
+      runs: this.options.runs ?? 10,
+      warmupRuns: this.options.warmupRuns ?? 1,
+      measureUnmount: true,
+    });
+  }
+}

--- a/packages/@react-native-windows/perf-testing/src/scenarios/index.ts
+++ b/packages/@react-native-windows/perf-testing/src/scenarios/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+export {MountScenario} from './MountScenario';
+export {UnmountScenario} from './UnmountScenario';
+export {RerenderScenario} from './RerenderScenario';

--- a/packages/@react-native-windows/perf-testing/tsconfig.json
+++ b/packages/@react-native-windows/perf-testing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@rnw-scripts/ts-config",
+  "compilerOptions": {
+    "outDir": "lib-commonjs",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativePerfBenchmark/NativePerfBenchmarkExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativePerfBenchmark/NativePerfBenchmarkExample.js
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+const React = require('react');
+const {
+  View,
+  Text,
+  TextInput,
+  Image,
+  ScrollView,
+  FlatList,
+  SectionList,
+  Switch,
+  ActivityIndicator,
+  Button,
+  Modal,
+  Pressable,
+  TouchableHighlight,
+  TouchableOpacity,
+  StyleSheet,
+} = require('react-native');
+
+const {useState, useRef, useCallback, useEffect} = React;
+
+const PHASE_IDLE = 'idle';
+const PHASE_CLEARING = 'clearing';
+const PHASE_MOUNTING = 'mounting';
+const PHASE_DONE = 'done';
+
+const COMPONENT_REGISTRY = {
+  View: () => <View style={styles.target} />,
+  Text: () => <Text style={styles.target}>Benchmark Text</Text>,
+  TextInput: () => (
+    <TextInput style={styles.targetInput} placeholder="Benchmark" />
+  ),
+  Image: () => (
+    <Image
+      style={styles.targetImage}
+      source={require('../../assets/uie_thumb_normal.png')}
+    />
+  ),
+  ScrollView: () => (
+    <ScrollView style={styles.target}>
+      {Array.from({length: 20}, (_, i) => (
+        <View key={i} style={styles.scrollItem} />
+      ))}
+    </ScrollView>
+  ),
+  FlatList: () => (
+    <FlatList
+      style={styles.target}
+      data={Array.from({length: 50}, (_, i) => ({key: String(i)}))}
+      renderItem={({item}) => <Text>{item.key}</Text>}
+    />
+  ),
+  SectionList: () => (
+    <SectionList
+      style={styles.target}
+      sections={[
+        {title: 'A', data: ['A1', 'A2', 'A3']},
+        {title: 'B', data: ['B1', 'B2', 'B3']},
+      ]}
+      renderItem={({item}) => <Text>{item}</Text>}
+      renderSectionHeader={({section}) => <Text>{section.title}</Text>}
+    />
+  ),
+  Switch: () => <Switch value={false} />,
+  ActivityIndicator: () => <ActivityIndicator size="large" />,
+  Button: () => <Button title="Benchmark" onPress={() => {}} />,
+  Modal: () => (
+    <Modal visible={false} transparent>
+      <View style={styles.target} />
+    </Modal>
+  ),
+  Pressable: () => (
+    <Pressable style={styles.target}>
+      <Text>Press</Text>
+    </Pressable>
+  ),
+  TouchableHighlight: () => (
+    <TouchableHighlight style={styles.target} onPress={() => {}}>
+      <Text>Highlight</Text>
+    </TouchableHighlight>
+  ),
+  TouchableOpacity: () => (
+    <TouchableOpacity style={styles.target} onPress={() => {}}>
+      <Text>Opacity</Text>
+    </TouchableOpacity>
+  ),
+};
+
+function BenchmarkRunner() {
+  const [componentName, setComponentName] = useState('View');
+  const [runsInput, setRunsInput] = useState('15');
+  const [phase, setPhase] = useState(PHASE_IDLE);
+  const [showTarget, setShowTarget] = useState(false);
+  const [resultsJson, setResultsJson] = useState('');
+
+  const durationsRef = useRef([]);
+  const runIndexRef = useRef(0);
+  const totalRunsRef = useRef(15);
+  const markNameRef = useRef('');
+
+  const finishRun = useCallback(() => {
+    const markEnd = `perf-end-${runIndexRef.current}`;
+    performance.mark(markEnd);
+    try {
+      const measure = performance.measure(
+        `perf-run-${runIndexRef.current}`,
+        markNameRef.current,
+        markEnd,
+      );
+      durationsRef.current.push(measure.duration);
+    } catch (_) {}
+    performance.clearMarks(markNameRef.current);
+    performance.clearMarks(markEnd);
+    performance.clearMeasures(`perf-run-${runIndexRef.current}`);
+
+    runIndexRef.current++;
+    if (runIndexRef.current < totalRunsRef.current) {
+      setPhase(PHASE_CLEARING);
+    } else {
+      setShowTarget(false);
+      setResultsJson(
+        JSON.stringify({
+          componentName,
+          runs: durationsRef.current.length,
+          durations: durationsRef.current,
+        }),
+      );
+      setPhase(PHASE_DONE);
+    }
+  }, [componentName]);
+
+  useEffect(() => {
+    if (phase === PHASE_CLEARING) {
+      setShowTarget(false);
+      requestAnimationFrame(() => {
+        setPhase(PHASE_MOUNTING);
+      });
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase === PHASE_MOUNTING) {
+      const markStart = `perf-start-${runIndexRef.current}`;
+      markNameRef.current = markStart;
+      performance.mark(markStart);
+      setShowTarget(true);
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase === PHASE_MOUNTING && showTarget) {
+      requestAnimationFrame(() => {
+        finishRun();
+      });
+    }
+  }, [phase, showTarget, finishRun]);
+
+  const handleRun = useCallback(() => {
+    const runs = parseInt(runsInput, 10) || 15;
+    totalRunsRef.current = runs;
+    runIndexRef.current = 0;
+    durationsRef.current = [];
+    setResultsJson('');
+    setPhase(PHASE_CLEARING);
+  }, [runsInput]);
+
+  const ComponentFactory = COMPONENT_REGISTRY[componentName];
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.controls}>
+        <TextInput
+          testID="perf-component-input"
+          style={styles.input}
+          value={componentName}
+          onChangeText={setComponentName}
+          placeholder="Component name"
+        />
+        <TextInput
+          testID="perf-runs-input"
+          style={styles.input}
+          value={runsInput}
+          onChangeText={setRunsInput}
+          keyboardType="numeric"
+          placeholder="Runs"
+        />
+        <Pressable
+          testID="perf-run-btn"
+          style={styles.button}
+          onPress={handleRun}
+          disabled={phase !== PHASE_IDLE && phase !== PHASE_DONE}>
+          <Text style={styles.buttonText}>Run Benchmark</Text>
+        </Pressable>
+      </View>
+
+      <Text testID="perf-status" style={styles.status}>
+        {phase}
+      </Text>
+
+      <View style={styles.targetContainer}>
+        {showTarget && ComponentFactory ? <ComponentFactory /> : null}
+      </View>
+
+      <Text testID="perf-results" style={styles.results}>
+        {resultsJson}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {flex: 1, padding: 8},
+  controls: {flexDirection: 'row', gap: 8, marginBottom: 8},
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 6,
+    minWidth: 100,
+    fontSize: 14,
+  },
+  button: {
+    backgroundColor: '#0078D4',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 4,
+    justifyContent: 'center',
+  },
+  buttonText: {color: 'white', fontWeight: 'bold'},
+  status: {fontSize: 12, color: '#666', marginBottom: 4},
+  targetContainer: {
+    minHeight: 100,
+    borderWidth: 1,
+    borderColor: '#eee',
+    marginBottom: 8,
+  },
+  target: {width: 80, height: 80, backgroundColor: '#f0f0f0'},
+  targetInput: {width: 200, height: 40, borderWidth: 1, borderColor: '#999'},
+  targetImage: {width: 80, height: 80},
+  scrollItem: {height: 20, backgroundColor: '#ddd', marginBottom: 2},
+  results: {fontSize: 10, fontFamily: 'monospace', color: '#333'},
+});
+
+exports.displayName = 'NativePerfBenchmarkExample';
+exports.framework = 'React';
+exports.category = 'Basic';
+exports.title = 'Native Perf Benchmark';
+exports.description =
+  'Measures native rendering pipeline via performance.mark/measure.';
+
+exports.examples = [
+  {
+    title: 'Benchmark Runner',
+    render: function () {
+      return <BenchmarkRunner />;
+    },
+  },
+];

--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -212,6 +212,11 @@ const Components: Array<RNTesterModuleInfo> = [
     category: 'Basic',
     module: require('../examples/Performance/PerformanceComparisonExample'),
   },
+  {
+    key: 'NativePerfBenchmark',
+    category: 'Basic',
+    module: require('../examples-win/NativePerfBenchmark/NativePerfBenchmarkExample'),
+  },
   ...RNTesterListFbInternal.Components,
 ];
 

--- a/packages/e2e-test-app-fabric/.gitignore
+++ b/packages/e2e-test-app-fabric/.gitignore
@@ -8,3 +8,4 @@
 /windows/RNTesterApp-Fabric/Bundle/
 msbuild.binlog
 /Bundle
+/.perf-results

--- a/packages/e2e-test-app-fabric/jest.native-perf.config.js
+++ b/packages/e2e-test-app-fabric/jest.native-perf.config.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ * @ts-check
+ */
+
+const assetTransform = 'react-native-windows/jest/assetFileTransformer.js';
+
+module.exports = {
+  preset: '@rnx-kit/jest-preset',
+
+  roots: ['<rootDir>/test/'],
+  testMatch: ['**/__native_perf__/**/*.native-perf-test.{ts,tsx}'],
+
+  testEnvironment: '@react-native-windows/automation',
+
+  testTimeout: 180000,
+
+  maxWorkers: 1,
+
+  setupFilesAfterEnv: [
+    'react-native-windows/jest/setup',
+    './jest.perf.setup.ts',
+  ],
+
+  testEnvironmentOptions: {
+    app: 'RNTesterApp-Fabric',
+    useRootSession: true,
+    rootLaunchApp: true,
+    enableAutomationChannel: true,
+  },
+
+  transform: {
+    '\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': assetTransform,
+    'node_modules\\\\@?react-native\\\\.*': 'babel-jest',
+    '@react-native-windows\\\\tester\\\\.*': 'babel-jest',
+    '@react-native-windows\\\\perf-testing\\\\.*': 'babel-jest',
+    'vnext\\\\.*': 'babel-jest',
+    '\\.[jt]sx?$': 'babel-jest',
+  },
+
+  transformIgnorePatterns: ['jest-runner', 'node_modules\\\\safe-buffer'],
+
+  moduleFileExtensions: [
+    'js',
+    'windows.js',
+    'android.js',
+    'mjs',
+    'cjs',
+    'jsx',
+    'ts',
+    'windows.ts',
+    'tsx',
+    'windows.tsx',
+    'json',
+    'node',
+  ],
+
+  verbose: true,
+
+  reporters: process.env.CI
+    ? [
+        'default',
+        [
+          '@react-native-windows/perf-testing/lib-commonjs/ci/PerfJsonReporter',
+          {outputFile: '.native-perf-results/results.json'},
+        ],
+      ]
+    : ['default'],
+};

--- a/packages/e2e-test-app-fabric/jest.perf.config.js
+++ b/packages/e2e-test-app-fabric/jest.perf.config.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Jest configuration for performance tests.
+ *
+ * These tests run in a lightweight node environment using react-test-renderer
+ * (NOT the full UIA automation environment used by E2E tests).
+ *
+ * Run: yarn perf
+ * Update baselines: yarn perf:update
+ *
+ * @format
+ * @ts-check
+ */
+
+// Ensure the rnx-kit preset picks up the windows platform
+// so react-native resolves correctly and __DEV__ is defined.
+process.env.RN_TARGET_PLATFORM = process.env.RN_TARGET_PLATFORM || 'windows';
+
+const assetTransform = 'react-native-windows/jest/assetFileTransformer.js';
+
+module.exports = {
+  preset: '@rnx-kit/jest-preset',
+
+  // Only run perf tests
+  roots: ['<rootDir>/test/'],
+  testMatch: ['**/__perf__/**/*.perf-test.{ts,tsx}'],
+
+  // Perf tests need more time for multiple measurement runs
+  testTimeout: 120000,
+
+  // Run sequentially for consistent measurements
+  maxWorkers: 1,
+
+  // Setup file registers perf matchers
+  setupFilesAfterEnv: ['./jest.perf.setup.ts'],
+
+  // Transform configuration — matches existing E2E config
+  transform: {
+    '\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': assetTransform,
+    'node_modules\\\\@?react-native\\\\.*': 'babel-jest',
+    '@react-native-windows\\\\tester\\\\.*': 'babel-jest',
+    '@react-native-windows\\\\perf-testing\\\\.*': 'babel-jest',
+    'vnext\\\\.*': 'babel-jest',
+    '\\.[jt]sx?$': 'babel-jest',
+  },
+
+  transformIgnorePatterns: ['jest-runner', 'node_modules\\\\safe-buffer'],
+
+  globals: {
+    __DEV__: true,
+  },
+
+  verbose: true,
+
+  // In CI, also emit a machine-readable JSON results file.
+  // The PerfJsonReporter collects all snapshot data after the run.
+  reporters: process.env.CI
+    ? [
+        'default',
+        [
+          '@react-native-windows/perf-testing/lib-commonjs/ci/PerfJsonReporter',
+          {outputFile: '.perf-results/results.json'},
+        ],
+      ]
+    : ['default'],
+};

--- a/packages/e2e-test-app-fabric/jest.perf.setup.ts
+++ b/packages/e2e-test-app-fabric/jest.perf.setup.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Setup file for performance tests.
+ * Registers the toMatchPerfSnapshot Jest matcher.
+ *
+ * @format
+ */
+
+// Import registers the `toMatchPerfSnapshot` matcher globally
+import '@react-native-windows/perf-testing';

--- a/packages/e2e-test-app-fabric/package.json
+++ b/packages/e2e-test-app-fabric/package.json
@@ -11,7 +11,15 @@
     "e2etest": "npx @react-native-community/cli rnx-test --platform windows",
     "e2etest:updateSnapshots": "npx @react-native-community/cli rnx-test --platform windows -u",
     "e2etest:debug": "npx @react-native-community/cli rnx-test --platform windows --config ./jest.debug.config.js",
-    "bundle:debug": "npx @react-native-community/cli bundle --entry-file index.js --bundle-output ./windows/x64/Debug/RNTesterApp-Fabric/Bundle/index.windows.bundle --assets-dest ./windows/x64/Debug/RNTesterApp-Fabric/Bundle --platform windows"
+    "bundle:debug": "npx @react-native-community/cli bundle --entry-file index.js --bundle-output ./windows/x64/Debug/RNTesterApp-Fabric/Bundle/index.windows.bundle --assets-dest ./windows/x64/Debug/RNTesterApp-Fabric/Bundle --platform windows",
+    "perf": "jest --config jest.perf.config.js",
+    "perf:update": "jest --config jest.perf.config.js -u",
+    "perf:core": "jest --config jest.perf.config.js --testPathPattern=__perf__/core",
+    "perf:extended": "jest --config jest.perf.config.js --testPathPattern=__perf__/extended",
+    "perf:ci": "jest --config jest.perf.config.js --ci --forceExit",
+    "perf:ci:compare": "node ../../vnext/Scripts/perf/compare-results.js",
+    "perf:ci:report": "node ../../vnext/Scripts/perf/post-pr-comment.js",
+    "perf:create": "node ../../vnext/Scripts/perf/create-perf-test.js"
   },
   "dependencies": {
     "@react-native-windows/automation-channel": "0.82.4",
@@ -32,6 +40,7 @@
     "@react-native-community/cli": "20.0.0",
     "@react-native-windows/automation": "0.82.4",
     "@react-native-windows/automation-commands": "0.82.4",
+    "@react-native-windows/perf-testing": "0.0.0-canary.1033",
     "@react-native/metro-config": "0.82.1",
     "@rnw-scripts/babel-node-config": "2.3.3",
     "@rnw-scripts/babel-react-native-config": "0.0.0",

--- a/packages/e2e-test-app-fabric/package.json
+++ b/packages/e2e-test-app-fabric/package.json
@@ -19,7 +19,10 @@
     "perf:ci": "jest --config jest.perf.config.js --ci --forceExit",
     "perf:ci:compare": "node ../../vnext/Scripts/perf/compare-results.js",
     "perf:ci:report": "node ../../vnext/Scripts/perf/post-pr-comment.js",
-    "perf:create": "node ../../vnext/Scripts/perf/create-perf-test.js"
+    "perf:create": "node ../../vnext/Scripts/perf/create-perf-test.js",
+    "perf:native": "jest --config jest.native-perf.config.js",
+    "perf:native:update": "jest --config jest.native-perf.config.js -u",
+    "perf:native:ci": "jest --config jest.native-perf.config.js --ci --forceExit"
   },
   "dependencies": {
     "@react-native-windows/automation-channel": "0.82.4",

--- a/packages/e2e-test-app-fabric/test/NativePerfHelpers.ts
+++ b/packages/e2e-test-app-fabric/test/NativePerfHelpers.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {goToComponentExample} from './RNTesterNavigation';
+import {
+  mean,
+  median,
+  standardDeviation,
+} from '@react-native-windows/perf-testing';
+import type {PerfMetrics} from '@react-native-windows/perf-testing';
+
+export interface NativePerfOptions {
+  runs?: number;
+  warmupRuns?: number;
+}
+
+const DEFAULT_RUNS = 15;
+const DEFAULT_WARMUP = 2;
+
+export async function navigateToBenchmarkPage(): Promise<void> {
+  const componentsTab = await app.findElementByTestID('components-tab');
+  await componentsTab.waitForDisplayed({timeout: 120000});
+
+  await goToComponentExample('Native Perf Benchmark');
+}
+
+export async function measureNativePerf(
+  componentName: string,
+  options?: NativePerfOptions,
+): Promise<PerfMetrics> {
+  const runs = options?.runs ?? DEFAULT_RUNS;
+  const warmupRuns = options?.warmupRuns ?? DEFAULT_WARMUP;
+  const totalRuns = runs + warmupRuns;
+
+  const componentInput = await app.findElementByTestID('perf-component-input');
+  await componentInput.waitForDisplayed({timeout: 5000});
+
+  await app.waitUntil(
+    async () => {
+      await componentInput.setValue(componentName);
+      return (await componentInput.getText()) === componentName;
+    },
+    {
+      interval: 500,
+      timeout: 5000,
+      timeoutMsg: `Failed to set component: ${componentName}`,
+    },
+  );
+
+  const runsInput = await app.findElementByTestID('perf-runs-input');
+  const runsStr = String(totalRuns);
+  await app.waitUntil(
+    async () => {
+      await runsInput.setValue(runsStr);
+      return (await runsInput.getText()) === runsStr;
+    },
+    {interval: 500, timeout: 5000, timeoutMsg: 'Failed to set run count'},
+  );
+
+  const runBtn = await app.findElementByTestID('perf-run-btn');
+  await runBtn.waitForDisplayed({timeout: 5000});
+  await runBtn.click();
+
+  const statusEl = await app.findElementByTestID('perf-status');
+  await app.waitUntil(
+    async () => {
+      const text = await statusEl.getText();
+      return text === 'done';
+    },
+    {
+      interval: 1000,
+      timeout: 180000,
+      timeoutMsg: `Benchmark timed out for ${componentName}`,
+    },
+  );
+
+  const resultsEl = await app.findElementByTestID('perf-results');
+  const rawJson = await resultsEl.getText();
+
+  let parsed: {componentName: string; runs: number; durations: number[]};
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    const snippet = rawJson ? rawJson.slice(0, 200) : '(empty)';
+    throw new Error(
+      `Failed to parse perf results for "${componentName}". ` +
+        `Raw text length=${rawJson.length}, snippet: ${snippet}`,
+    );
+  }
+
+  const durations = parsed.durations.slice(warmupRuns);
+
+  if (durations.length < runs) {
+    throw new Error(
+      `Expected ${runs} durations after discarding ${warmupRuns} warmup, got ${durations.length}`,
+    );
+  }
+
+  const meanDuration = mean(durations);
+  const medianDuration = median(durations);
+  const stdDev = standardDeviation(durations);
+
+  return {
+    name: `${componentName} native mount`,
+    meanDuration,
+    medianDuration,
+    stdDev,
+    renderCount: 1,
+    runs: durations.length,
+    durations,
+    timestamp: new Date().toISOString(),
+    nativeTimings: {fullPipeline: medianDuration},
+  };
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/ActivityIndicator.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/ActivityIndicator.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('ActivityIndicator native mount', async () => {
+    const perf = await measureNativePerf('ActivityIndicator', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Button.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Button.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Button native mount', async () => {
+    const perf = await measureNativePerf('Button', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Image.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Image.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Image native mount', async () => {
+    const perf = await measureNativePerf('Image', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Modal.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Modal.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Modal native mount', async () => {
+    const perf = await measureNativePerf('Modal', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/ScrollView.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/ScrollView.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('ScrollView native mount', async () => {
+    const perf = await measureNativePerf('ScrollView', {
+      runs: 10,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot({...NATIVE, maxCV: 0.6});
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Switch.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Switch.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Switch native mount', async () => {
+    const perf = await measureNativePerf('Switch', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Text.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Text.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Text native mount', async () => {
+    const perf = await measureNativePerf('Text', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/TextInput.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/TextInput.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('TextInput native mount', async () => {
+    const perf = await measureNativePerf('TextInput', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/View.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/View.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('View native mount', async () => {
+    const perf = await measureNativePerf('View', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ActivityIndicator.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ActivityIndicator.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline ActivityIndicator native mount 1": {
+    "metrics": {
+      "name": "ActivityIndicator native mount",
+      "meanDuration": 2.4800000031789144,
+      "medianDuration": 2.484100043773651,
+      "stdDev": 0.5289090397238356,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.568000018596649,
+        2.912999987602234,
+        2.0101999640464783,
+        1.866599977016449,
+        1.9577000141143799,
+        1.8373000025749207,
+        2.2786999940872192,
+        2.484100043773651,
+        2.536500036716461,
+        2.217199981212616,
+        3.1218000054359436,
+        2.221000015735626,
+        2.5859000086784363,
+        2.8073999881744385,
+        3.794600009918213
+      ],
+      "timestamp": "2026-03-25T09:12:07.260Z",
+      "nativeTimings": {
+        "fullPipeline": 2.484100043773651
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:07.262Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Button.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Button.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Button native mount 1": {
+    "metrics": {
+      "name": "Button native mount",
+      "meanDuration": 2.9556866606076557,
+      "medianDuration": 2.601099967956543,
+      "stdDev": 0.9540605755854736,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.457200050354004,
+        2.5554999709129333,
+        3.3740000128746033,
+        2.601099967956543,
+        2.444000005722046,
+        3.146499991416931,
+        2.1805999875068665,
+        6.153299987316132,
+        2.8115999698638916,
+        2.360199987888336,
+        2.432099997997284,
+        3.0877000093460083,
+        3.0518999695777893,
+        3.1615999937057495,
+        2.51800000667572
+      ],
+      "timestamp": "2026-03-25T09:12:32.621Z",
+      "nativeTimings": {
+        "fullPipeline": 2.601099967956543
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:32.623Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Image.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Image.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Image native mount 1": {
+    "metrics": {
+      "name": "Image native mount",
+      "meanDuration": 2.384059993426005,
+      "medianDuration": 2.26010000705719,
+      "stdDev": 0.585439113749715,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.26010000705719,
+        2.1991999745368958,
+        2.4451000094413757,
+        2.269699990749359,
+        2.214099943637848,
+        2.330900013446808,
+        2.5689000487327576,
+        1.9075999855995178,
+        2.264400005340576,
+        2.2530999779701233,
+        4.417899966239929,
+        2.332099974155426,
+        2.2284000515937805,
+        2.0417999625205994,
+        2.0275999903678894
+      ],
+      "timestamp": "2026-03-25T09:12:49.239Z",
+      "nativeTimings": {
+        "fullPipeline": 2.26010000705719
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:49.240Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Modal.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Modal.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Modal native mount 1": {
+    "metrics": {
+      "name": "Modal native mount",
+      "meanDuration": 1.3649799942970275,
+      "medianDuration": 1.217699944972992,
+      "stdDev": 0.23040005387861157,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.7878000140190125,
+        1.6008999943733215,
+        1.3690999746322632,
+        1.6188000440597534,
+        1.5525999665260315,
+        1.2020000219345093,
+        1.1894000172615051,
+        1.2010000348091125,
+        1.136900007724762,
+        1.1675999760627747,
+        1.2005999684333801,
+        1.217699944972992,
+        1.3144999742507935,
+        1.1704000234603882,
+        1.7453999519348145
+      ],
+      "timestamp": "2026-03-25T09:12:40.886Z",
+      "nativeTimings": {
+        "fullPipeline": 1.217699944972992
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:40.888Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ScrollView.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ScrollView.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,38 @@
+{
+  "Native Render Pipeline ScrollView native mount 1": {
+    "metrics": {
+      "name": "ScrollView native mount",
+      "meanDuration": 4.355050003528595,
+      "medianDuration": 4.049349993467331,
+      "stdDev": 0.675293113217565,
+      "renderCount": 1,
+      "runs": 10,
+      "durations": [
+        4.063799977302551,
+        4.669399976730347,
+        4.014200031757355,
+        4.600199997425079,
+        3.747600018978119,
+        4.034900009632111,
+        4.375600039958954,
+        6.084399998188019,
+        3.9986000061035156,
+        3.9617999792099
+      ],
+      "timestamp": "2026-03-25T09:11:58.989Z",
+      "nativeTimings": {
+        "fullPipeline": 4.049349993467331
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.6,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:58.991Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Switch.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Switch.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Switch native mount 1": {
+    "metrics": {
+      "name": "Switch native mount",
+      "meanDuration": 1.7548199892044067,
+      "medianDuration": 1.7342000007629395,
+      "stdDev": 0.14067122956094338,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.7342000007629395,
+        1.7372000217437744,
+        1.8542999625205994,
+        1.7226999998092651,
+        1.6146999597549438,
+        1.69159996509552,
+        1.8396000266075134,
+        1.8578999638557434,
+        1.54339998960495,
+        1.6279000043869019,
+        1.9399999976158142,
+        1.8633999824523926,
+        1.6168999671936035,
+        1.6345999836921692,
+        2.0439000129699707
+      ],
+      "timestamp": "2026-03-25T09:12:24.458Z",
+      "nativeTimings": {
+        "fullPipeline": 1.7342000007629395
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:24.460Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Text.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Text.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Text native mount 1": {
+    "metrics": {
+      "name": "Text native mount",
+      "meanDuration": 1.7626999974250794,
+      "medianDuration": 1.7395999431610107,
+      "stdDev": 0.17253066691776484,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.9889000058174133,
+        1.7633000016212463,
+        1.8330000042915344,
+        2.02839994430542,
+        1.661899983882904,
+        1.6473000049591064,
+        1.496500015258789,
+        1.5873000025749207,
+        1.6305000185966492,
+        1.8646000027656555,
+        1.7395999431610107,
+        1.684000015258789,
+        1.6638000011444092,
+        2.1093000173568726,
+        1.7421000003814697
+      ],
+      "timestamp": "2026-03-25T09:12:57.555Z",
+      "nativeTimings": {
+        "fullPipeline": 1.7395999431610107
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:57.556Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/TextInput.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/TextInput.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline TextInput native mount 1": {
+    "metrics": {
+      "name": "TextInput native mount",
+      "meanDuration": 4.421840000152588,
+      "medianDuration": 4.0867999792099,
+      "stdDev": 0.9135329076138601,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        3.6496999859809875,
+        4.015100002288818,
+        4.0867999792099,
+        4.2186999917030334,
+        4.2085999846458435,
+        3.800499975681305,
+        4.18560004234314,
+        5.862399995326996,
+        6.951799988746643,
+        3.925000011920929,
+        4.065899968147278,
+        3.9510000348091125,
+        5.296599984169006,
+        3.7587000131607056,
+        4.351200044155121
+      ],
+      "timestamp": "2026-03-25T09:12:15.920Z",
+      "nativeTimings": {
+        "fullPipeline": 4.0867999792099
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:15.922Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/View.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/View.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline View native mount 1": {
+    "metrics": {
+      "name": "View native mount",
+      "meanDuration": 1.4776333411534628,
+      "medianDuration": 1.428600013256073,
+      "stdDev": 0.22794729910741268,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.428600013256073,
+        1.3898000121116638,
+        1.5759000182151794,
+        1.572700023651123,
+        1.257099986076355,
+        1.438700020313263,
+        2.015500009059906,
+        1.3089999556541443,
+        1.47680002450943,
+        1.517300009727478,
+        1.3051999807357788,
+        1.9368000030517578,
+        1.365600049495697,
+        1.332099974155426,
+        1.2434000372886658
+      ],
+      "timestamp": "2026-03-25T09:13:05.775Z",
+      "nativeTimings": {
+        "fullPipeline": 1.428600013256073
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:13:05.794Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/Pressable.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/Pressable.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Interactive Components — Native Render Pipeline', () => {
+  test('Pressable native mount', async () => {
+    const perf = await measureNativePerf('Pressable', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableHighlight.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableHighlight.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Interactive Components — Native Render Pipeline', () => {
+  test('TouchableHighlight native mount', async () => {
+    const perf = await measureNativePerf('TouchableHighlight', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableOpacity.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableOpacity.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Interactive Components — Native Render Pipeline', () => {
+  test('TouchableOpacity native mount', async () => {
+    const perf = await measureNativePerf('TouchableOpacity', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/Pressable.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/Pressable.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Interactive Components — Native Render Pipeline Pressable native mount 1": {
+    "metrics": {
+      "name": "Pressable native mount",
+      "meanDuration": 2.492093336582184,
+      "medianDuration": 2.510699987411499,
+      "stdDev": 0.6735438561451192,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        3.245199978351593,
+        1.9694000482559204,
+        2.761300027370453,
+        1.8480000495910645,
+        1.9053000211715698,
+        2.147000014781952,
+        1.6363999843597412,
+        4.235000014305115,
+        2.4139999747276306,
+        1.856499969959259,
+        3.0816999673843384,
+        2.5519999861717224,
+        2.587000012397766,
+        2.6319000124931335,
+        2.510699987411499
+      ],
+      "timestamp": "2026-03-25T09:11:51.045Z",
+      "nativeTimings": {
+        "fullPipeline": 2.510699987411499
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:51.046Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableHighlight.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableHighlight.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Interactive Components — Native Render Pipeline TouchableHighlight native mount 1": {
+    "metrics": {
+      "name": "TouchableHighlight native mount",
+      "meanDuration": 2.22730667591095,
+      "medianDuration": 2.0885000228881836,
+      "stdDev": 0.569642348560873,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.189400017261505,
+        2.055299997329712,
+        2.143899977207184,
+        3.991699993610382,
+        2.5550000071525574,
+        2.0536999702453613,
+        2.0885000228881836,
+        2.524199962615967,
+        1.9000999927520752,
+        2.5004000067710876,
+        1.7630000114440918,
+        1.7075000405311584,
+        2.4169000387191772,
+        1.8182000517845154,
+        1.7018000483512878
+      ],
+      "timestamp": "2026-03-25T09:11:34.994Z",
+      "nativeTimings": {
+        "fullPipeline": 2.0885000228881836
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:34.996Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableOpacity.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableOpacity.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Interactive Components — Native Render Pipeline TouchableOpacity native mount 1": {
+    "metrics": {
+      "name": "TouchableOpacity native mount",
+      "meanDuration": 3.190453334649404,
+      "medianDuration": 3.1384999752044678,
+      "stdDev": 0.7568414883957973,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        3.0042999982833862,
+        2.795300006866455,
+        3.2402999997138977,
+        2.530400037765503,
+        3.032800018787384,
+        3.4493000507354736,
+        2.2537999749183655,
+        2.4357999563217163,
+        3.2348999977111816,
+        3.694700002670288,
+        3.1384999752044678,
+        3.163599967956543,
+        2.9884999990463257,
+        5.5409000515937805,
+        3.3536999821662903
+      ],
+      "timestamp": "2026-03-25T09:11:43.172Z",
+      "nativeTimings": {
+        "fullPipeline": 3.1384999752044678
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:43.174Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/FlatList.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/FlatList.native-perf-test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('List Components — Native Render Pipeline', () => {
+  test('FlatList native mount', async () => {
+    const perf = await measureNativePerf('FlatList', {
+      runs: 10,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot({
+      ...NATIVE,
+      maxDurationIncrease: 20,
+      maxCV: 0.6,
+    });
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/SectionList.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/SectionList.native-perf-test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('List Components — Native Render Pipeline', () => {
+  test('SectionList native mount', async () => {
+    const perf = await measureNativePerf('SectionList', {
+      runs: 10,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot({
+      ...NATIVE,
+      maxDurationIncrease: 20,
+      maxCV: 0.6,
+    });
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/FlatList.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/FlatList.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,38 @@
+{
+  "List Components — Native Render Pipeline FlatList native mount 1": {
+    "metrics": {
+      "name": "FlatList native mount",
+      "meanDuration": 9.108829998970032,
+      "medianDuration": 9.228249996900558,
+      "stdDev": 0.8543665552028276,
+      "renderCount": 1,
+      "runs": 10,
+      "durations": [
+        9.996599972248077,
+        7.9009000062942505,
+        8.30400002002716,
+        8.526000022888184,
+        9.10809999704361,
+        9.793299973011017,
+        9.348399996757507,
+        8.229200005531311,
+        9.370600044727325,
+        10.511199951171875
+      ],
+      "timestamp": "2026-03-25T09:11:26.174Z",
+      "nativeTimings": {
+        "fullPipeline": 9.228249996900558
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 20,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.6,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:26.176Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/SectionList.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/SectionList.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,38 @@
+{
+  "List Components — Native Render Pipeline SectionList native mount 1": {
+    "metrics": {
+      "name": "SectionList native mount",
+      "meanDuration": 6.658689999580384,
+      "medianDuration": 6.504900008440018,
+      "stdDev": 0.5578793185297047,
+      "renderCount": 1,
+      "runs": 10,
+      "durations": [
+        6.384400010108948,
+        7.875100016593933,
+        6.401300013065338,
+        6.394400000572205,
+        7.334999978542328,
+        6.771200001239777,
+        6.608500003814697,
+        6.627799987792969,
+        6.103399991989136,
+        6.085799992084503
+      ],
+      "timestamp": "2026-03-25T09:11:17.694Z",
+      "nativeTimings": {
+        "fullPipeline": 6.504900008440018
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 20,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.6,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:17.697Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/ActivityIndicator.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/ActivityIndicator.perf-test.tsx
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for ActivityIndicator component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {ActivityIndicator, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class ActivityIndicatorPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'ActivityIndicator';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-activity-indicator';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return <ActivityIndicator testID={this.testId} {...props} />;
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'size-large',
+        description: 'ActivityIndicator with size="large"',
+        run: () => this.measureSizeLarge(),
+      },
+      {
+        name: 'size-small',
+        description: 'ActivityIndicator with size="small"',
+        run: () => this.measureSizeSmall(),
+      },
+      {
+        name: 'with-color',
+        description: 'ActivityIndicator with custom color',
+        run: () => this.measureWithColor(),
+      },
+      {
+        name: 'not-animating',
+        description: 'ActivityIndicator with animating={false}',
+        run: () => this.measureNotAnimating(),
+      },
+      {
+        name: 'with-accessibility',
+        description: 'ActivityIndicator with accessibility props',
+        run: () => this.measureWithAccessibility(),
+      },
+      {
+        name: 'multiple-indicators-10',
+        description: 'Render 10 sibling ActivityIndicators',
+        run: () => this.measureMultiple(10),
+      },
+      {
+        name: 'multiple-indicators-50',
+        description: 'Render 50 sibling ActivityIndicators',
+        run: () => this.measureMultiple(50),
+      },
+      {
+        name: 'multiple-indicators-100',
+        description: 'Render 100 sibling ActivityIndicators (stress gate)',
+        run: () => this.measureMultiple(100),
+      },
+    ];
+  }
+
+  private async measureSizeLarge(): Promise<PerfMetrics> {
+    return measurePerf(
+      <ActivityIndicator testID={this.testId} size="large" />,
+      {
+        name: `${this.componentName} size-large`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureSizeSmall(): Promise<PerfMetrics> {
+    return measurePerf(
+      <ActivityIndicator testID={this.testId} size="small" />,
+      {
+        name: `${this.componentName} size-small`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithColor(): Promise<PerfMetrics> {
+    return measurePerf(
+      <ActivityIndicator testID={this.testId} size="large" color="#841584" />,
+      {
+        name: `${this.componentName} with-color`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureNotAnimating(): Promise<PerfMetrics> {
+    return measurePerf(
+      <ActivityIndicator testID={this.testId} animating={false} />,
+      {
+        name: `${this.componentName} not-animating`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithAccessibility(): Promise<PerfMetrics> {
+    return measurePerf(
+      <ActivityIndicator
+        testID={this.testId}
+        size="large"
+        accessibilityLabel="Loading content"
+        accessibilityHint="Please wait"
+        accessibilityRole="progressbar"
+      />,
+      {
+        name: `${this.componentName} with-accessibility`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultiple(count: number): Promise<PerfMetrics> {
+    const IndicatorList = () => (
+      <View style={styles.container}>
+        {Array.from({length: count}, (_, i) => (
+          <ActivityIndicator
+            key={i}
+            size={i % 2 === 0 ? 'small' : 'large'}
+            color={i % 3 === 0 ? '#841584' : undefined}
+          />
+        ))}
+      </View>
+    );
+
+    return measurePerf(<IndicatorList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const activityIndicatorPerfTest = new ActivityIndicatorPerfTest();
+
+describe('ActivityIndicator Performance', () => {
+  test('mount time', async () => {
+    const perf = await activityIndicatorPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await activityIndicatorPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await activityIndicatorPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('ActivityIndicator-Specific Scenarios', () => {
+    test('size-large', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('size-small', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-color', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('not-animating', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-accessibility', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-indicators-10', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('multiple-indicators-50', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[6];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('multiple-indicators-100', async () => {
+      const scenario = activityIndicatorPerfTest.getCustomScenarios()[7];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/Button.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/Button.perf-test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for Button component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {Button, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class ButtonPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'Button';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-button';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <Button
+        testID={this.testId}
+        title="Perf Test Button"
+        onPress={() => {}}
+        {...props}
+      />
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'disabled',
+        description: 'Button in disabled state',
+        run: () => this.measureDisabled(),
+      },
+      {
+        name: 'with-color',
+        description: 'Button with custom color prop',
+        run: () => this.measureWithColor(),
+      },
+      {
+        name: 'with-accessibility',
+        description: 'Button with full accessibility props',
+        run: () => this.measureWithAccessibility(),
+      },
+      {
+        name: 'multiple-buttons-10',
+        description: 'Render 10 sibling Buttons',
+        run: () => this.measureMultipleButtons(10),
+      },
+      {
+        name: 'multiple-buttons-50',
+        description: 'Render 50 sibling Buttons',
+        run: () => this.measureMultipleButtons(50),
+      },
+      {
+        name: 'multiple-buttons-100',
+        description: 'Render 100 sibling Buttons (stress gate)',
+        run: () => this.measureMultipleButtons(100),
+      },
+    ];
+  }
+
+  private async measureDisabled(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Button
+        testID={this.testId}
+        title="Disabled Button"
+        onPress={() => {}}
+        disabled={true}
+      />,
+      {
+        name: `${this.componentName} disabled`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithColor(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Button
+        testID={this.testId}
+        title="Colored Button"
+        onPress={() => {}}
+        color="#841584"
+      />,
+      {
+        name: `${this.componentName} with-color`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithAccessibility(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Button
+        testID={this.testId}
+        title="Accessible Button"
+        onPress={() => {}}
+        accessibilityLabel="Submit form"
+        accessibilityHint="Double tap to submit the form"
+        accessibilityState={{disabled: false}}
+      />,
+      {
+        name: `${this.componentName} with-accessibility`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultipleButtons(count: number): Promise<PerfMetrics> {
+    const ButtonList = () => (
+      <View style={styles.container}>
+        {Array.from({length: count}, (_, i) => (
+          <Button key={i} title={`Button ${i}`} onPress={() => {}} />
+        ))}
+      </View>
+    );
+
+    return measurePerf(<ButtonList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const buttonPerfTest = new ButtonPerfTest();
+
+describe('Button Performance', () => {
+  test('mount time', async () => {
+    const perf = await buttonPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await buttonPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await buttonPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('Button-Specific Scenarios', () => {
+    test('disabled', async () => {
+      const scenario = buttonPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-color', async () => {
+      const scenario = buttonPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-accessibility', async () => {
+      const scenario = buttonPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-buttons-10', async () => {
+      const scenario = buttonPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('multiple-buttons-50', async () => {
+      const scenario = buttonPerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('multiple-buttons-100', async () => {
+      const scenario = buttonPerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/Image.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/Image.perf-test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for Image component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {Image, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+const TEST_URI = 'https://example.com/img.png';
+
+class ImagePerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'Image';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-image';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <Image
+        testID={this.testId}
+        source={{uri: TEST_URI}}
+        style={styles.default}
+        {...props}
+      />
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'with-resize-mode',
+        description: 'Image with resizeMode="contain"',
+        run: () => this.measureWithResizeMode(),
+      },
+      {
+        name: 'with-border-radius',
+        description: 'Image with rounded corners',
+        run: () => this.measureWithBorderRadius(),
+      },
+      {
+        name: 'with-tint-color',
+        description: 'Image with tintColor applied',
+        run: () => this.measureWithTintColor(),
+      },
+      {
+        name: 'with-blur-radius',
+        description: 'Image with blurRadius',
+        run: () => this.measureWithBlurRadius(),
+      },
+      {
+        name: 'with-accessibility',
+        description: 'Image with full accessibility props',
+        run: () => this.measureWithAccessibility(),
+      },
+      {
+        name: 'multiple-images-10',
+        description: 'Render 10 sibling Images',
+        run: () => this.measureMultipleImages(10),
+      },
+      {
+        name: 'multiple-images-50',
+        description: 'Render 50 sibling Images',
+        run: () => this.measureMultipleImages(50),
+      },
+      {
+        name: 'multiple-images-100',
+        description: 'Render 100 sibling Images (stress gate)',
+        run: () => this.measureMultipleImages(100),
+      },
+    ];
+  }
+
+  private async measureWithResizeMode(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Image
+        testID={this.testId}
+        source={{uri: TEST_URI}}
+        style={styles.default}
+        resizeMode="contain"
+      />,
+      {
+        name: `${this.componentName} with-resize-mode`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithBorderRadius(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Image
+        testID={this.testId}
+        source={{uri: TEST_URI}}
+        style={[styles.default, styles.rounded]}
+      />,
+      {
+        name: `${this.componentName} with-border-radius`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithTintColor(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Image
+        testID={this.testId}
+        source={{uri: TEST_URI}}
+        style={[styles.default, styles.tinted]}
+      />,
+      {
+        name: `${this.componentName} with-tint-color`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithBlurRadius(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Image
+        testID={this.testId}
+        source={{uri: TEST_URI}}
+        style={styles.default}
+        blurRadius={5}
+      />,
+      {
+        name: `${this.componentName} with-blur-radius`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithAccessibility(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Image
+        testID={this.testId}
+        source={{uri: TEST_URI}}
+        style={styles.default}
+        accessible={true}
+        accessibilityLabel="Profile photo"
+        accessibilityRole="image"
+      />,
+      {
+        name: `${this.componentName} with-accessibility`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultipleImages(count: number): Promise<PerfMetrics> {
+    const ImageList = () => (
+      <View style={styles.container}>
+        {Array.from({length: count}, (_, i) => (
+          <Image
+            key={i}
+            source={{uri: `${TEST_URI}?i=${i}`}}
+            style={styles.thumbnail}
+          />
+        ))}
+      </View>
+    );
+
+    return measurePerf(<ImageList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const imagePerfTest = new ImagePerfTest();
+
+describe('Image Performance', () => {
+  test('mount time', async () => {
+    const perf = await imagePerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await imagePerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await imagePerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('Image-Specific Scenarios', () => {
+    test('with-resize-mode', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-border-radius', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-tint-color', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-blur-radius', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-accessibility', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-images-10', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('multiple-images-50', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[6];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('multiple-images-100', async () => {
+      const scenario = imagePerfTest.getCustomScenarios()[7];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  default: {
+    width: 100,
+    height: 100,
+  },
+  thumbnail: {
+    width: 50,
+    height: 50,
+    margin: 2,
+  },
+  rounded: {
+    borderRadius: 50,
+  },
+  tinted: {
+    tintColor: '#841584',
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/Modal.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/Modal.perf-test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for Modal component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {Modal, View, Text, Button, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class ModalPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'Modal';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-modal';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <Modal testID={this.testId} visible={true} {...props}>
+        <View style={styles.centeredView}>
+          <Text>Modal Content</Text>
+        </View>
+      </Modal>
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'slide-animation',
+        description: 'Modal with slide animation type',
+        run: () => this.measureSlideAnimation(),
+      },
+      {
+        name: 'fade-animation',
+        description: 'Modal with fade animation type',
+        run: () => this.measureFadeAnimation(),
+      },
+      {
+        name: 'transparent',
+        description: 'Modal with transparent background',
+        run: () => this.measureTransparent(),
+      },
+      {
+        name: 'with-callbacks',
+        description: 'Modal with onShow, onRequestClose, onDismiss handlers',
+        run: () => this.measureWithCallbacks(),
+      },
+      {
+        name: 'with-rich-content',
+        description: 'Modal with complex child content (form-like)',
+        run: () => this.measureWithRichContent(),
+      },
+      {
+        name: 'with-accessibility',
+        description: 'Modal with full accessibility props',
+        run: () => this.measureWithAccessibility(),
+      },
+    ];
+  }
+
+  private async measureSlideAnimation(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Modal testID={this.testId} visible={true} animationType="slide">
+        <View style={styles.centeredView}>
+          <Text>Slide Modal</Text>
+        </View>
+      </Modal>,
+      {
+        name: `${this.componentName} slide-animation`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureFadeAnimation(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Modal testID={this.testId} visible={true} animationType="fade">
+        <View style={styles.centeredView}>
+          <Text>Fade Modal</Text>
+        </View>
+      </Modal>,
+      {
+        name: `${this.componentName} fade-animation`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureTransparent(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Modal testID={this.testId} visible={true} transparent={true}>
+        <View style={styles.overlay}>
+          <View style={styles.dialog}>
+            <Text>Transparent Modal</Text>
+          </View>
+        </View>
+      </Modal>,
+      {
+        name: `${this.componentName} transparent`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithCallbacks(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Modal
+        testID={this.testId}
+        visible={true}
+        onShow={() => {}}
+        onRequestClose={() => {}}
+        onDismiss={() => {}}>
+        <View style={styles.centeredView}>
+          <Text>Modal with Callbacks</Text>
+        </View>
+      </Modal>,
+      {
+        name: `${this.componentName} with-callbacks`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithRichContent(): Promise<PerfMetrics> {
+    const RichModal = () => (
+      <Modal testID={this.testId} visible={true}>
+        <View style={styles.centeredView}>
+          <View style={styles.dialog}>
+            <Text style={styles.title}>Dialog Title</Text>
+            <Text style={styles.body}>
+              This is a longer description that simulates real modal content
+              with multiple lines of text.
+            </Text>
+            <View style={styles.buttonRow}>
+              <Button title="Cancel" onPress={() => {}} />
+              <Button title="Confirm" onPress={() => {}} />
+            </View>
+          </View>
+        </View>
+      </Modal>
+    );
+
+    return measurePerf(<RichModal />, {
+      name: `${this.componentName} rich-content`,
+      runs: 10,
+    });
+  }
+
+  private async measureWithAccessibility(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Modal
+        testID={this.testId}
+        visible={true}
+        accessibilityLabel="Confirmation dialog"
+        accessibilityViewIsModal={true}>
+        <View style={styles.centeredView}>
+          <Text>Accessible Modal</Text>
+        </View>
+      </Modal>,
+      {
+        name: `${this.componentName} with-accessibility`,
+        runs: 10,
+      },
+    );
+  }
+}
+
+const modalPerfTest = new ModalPerfTest();
+
+describe('Modal Performance', () => {
+  test('mount time', async () => {
+    const perf = await modalPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await modalPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await modalPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('Modal-Specific Scenarios', () => {
+    test('slide-animation', async () => {
+      const scenario = modalPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('fade-animation', async () => {
+      const scenario = modalPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('transparent', async () => {
+      const scenario = modalPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-callbacks', async () => {
+      const scenario = modalPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-rich-content', async () => {
+      const scenario = modalPerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-accessibility', async () => {
+      const scenario = modalPerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  dialog: {
+    backgroundColor: 'white',
+    borderRadius: 10,
+    padding: 20,
+    width: 300,
+    alignItems: 'center',
+    elevation: 5,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 10,
+  },
+  body: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/ScrollView.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/ScrollView.perf-test.tsx
@@ -1,0 +1,302 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for ScrollView component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {ScrollView, View, Text, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class ScrollViewPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'ScrollView';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-scroll-view';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <ScrollView testID={this.testId} style={styles.default} {...props}>
+        <Text>Sample Content</Text>
+      </ScrollView>
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'with-children-20',
+        description: 'ScrollView with 20 child items',
+        run: () => this.measureWithChildren(20),
+      },
+      {
+        name: 'with-children-100',
+        description: 'ScrollView with 100 child items',
+        run: () => this.measureWithChildren(100),
+      },
+      {
+        name: 'horizontal',
+        description: 'Horizontal ScrollView with children',
+        run: () => this.measureHorizontal(),
+      },
+      {
+        name: 'with-sticky-headers',
+        description: 'ScrollView with stickyHeaderIndices',
+        run: () => this.measureWithStickyHeaders(),
+      },
+      {
+        name: 'with-scroll-indicators',
+        description: 'ScrollView with indicator style and bar visibility',
+        run: () => this.measureWithScrollIndicators(),
+      },
+      {
+        name: 'nested-scroll-views',
+        description: 'ScrollView nested inside another ScrollView',
+        run: () => this.measureNestedScrollViews(),
+      },
+      {
+        name: 'with-content-container-style',
+        description: 'ScrollView with contentContainerStyle',
+        run: () => this.measureWithContentContainerStyle(),
+      },
+      {
+        name: 'with-children-500',
+        description: 'ScrollView with 500 child items (stress gate)',
+        run: () => this.measureWithChildren(500),
+      },
+    ];
+  }
+
+  private renderItems(count: number): React.ReactElement[] {
+    return Array.from({length: count}, (_, i) => (
+      <View key={i} style={styles.item}>
+        <Text>{`Item ${i}`}</Text>
+      </View>
+    ));
+  }
+
+  private async measureWithChildren(count: number): Promise<PerfMetrics> {
+    const ScrollList = () => (
+      <ScrollView testID={this.testId} style={styles.default}>
+        {this.renderItems(count)}
+      </ScrollView>
+    );
+
+    return measurePerf(<ScrollList />, {
+      name: `${this.componentName} children-${count}`,
+      runs: 15,
+    });
+  }
+
+  private async measureHorizontal(): Promise<PerfMetrics> {
+    const HorizontalScroll = () => (
+      <ScrollView
+        testID={this.testId}
+        style={styles.default}
+        horizontal={true}
+        showsHorizontalScrollIndicator={true}>
+        {Array.from({length: 20}, (_, i) => (
+          <View key={i} style={styles.horizontalItem}>
+            <Text>{`H${i}`}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    );
+
+    return measurePerf(<HorizontalScroll />, {
+      name: `${this.componentName} horizontal`,
+      runs: 10,
+    });
+  }
+
+  private async measureWithStickyHeaders(): Promise<PerfMetrics> {
+    const StickyScroll = () => (
+      <ScrollView
+        testID={this.testId}
+        style={styles.default}
+        stickyHeaderIndices={[0, 5, 10, 15]}>
+        {Array.from({length: 20}, (_, i) => (
+          <View
+            key={i}
+            style={[styles.item, i % 5 === 0 && styles.stickyHeader]}>
+            <Text>{i % 5 === 0 ? `Section ${i / 5}` : `Item ${i}`}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    );
+
+    return measurePerf(<StickyScroll />, {
+      name: `${this.componentName} sticky-headers`,
+      runs: 10,
+    });
+  }
+
+  private async measureWithScrollIndicators(): Promise<PerfMetrics> {
+    return measurePerf(
+      <ScrollView
+        testID={this.testId}
+        style={styles.default}
+        showsVerticalScrollIndicator={true}
+        showsHorizontalScrollIndicator={false}
+        scrollIndicatorInsets={{top: 10, bottom: 10}}>
+        {this.renderItems(20)}
+      </ScrollView>,
+      {
+        name: `${this.componentName} scroll-indicators`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureNestedScrollViews(): Promise<PerfMetrics> {
+    const NestedScroll = () => (
+      <ScrollView testID={this.testId} style={styles.default}>
+        <Text>Outer Header</Text>
+        <ScrollView horizontal={true} style={styles.innerScroll}>
+          {Array.from({length: 10}, (_, i) => (
+            <View key={i} style={styles.horizontalItem}>
+              <Text>{`Inner ${i}`}</Text>
+            </View>
+          ))}
+        </ScrollView>
+        {this.renderItems(10)}
+      </ScrollView>
+    );
+
+    return measurePerf(<NestedScroll />, {
+      name: `${this.componentName} nested`,
+      runs: 10,
+    });
+  }
+
+  private async measureWithContentContainerStyle(): Promise<PerfMetrics> {
+    return measurePerf(
+      <ScrollView
+        testID={this.testId}
+        style={styles.default}
+        contentContainerStyle={styles.contentContainer}>
+        {this.renderItems(20)}
+      </ScrollView>,
+      {
+        name: `${this.componentName} content-container-style`,
+        runs: 10,
+      },
+    );
+  }
+}
+
+const scrollViewPerfTest = new ScrollViewPerfTest();
+
+describe('ScrollView Performance', () => {
+  test('mount time', async () => {
+    const perf = await scrollViewPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await scrollViewPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await scrollViewPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('ScrollView-Specific Scenarios', () => {
+    test('with-children-20', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-children-100', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('horizontal', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-sticky-headers', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-scroll-indicators', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('nested-scroll-views', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-content-container-style', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[6];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-children-500', async () => {
+      const scenario = scrollViewPerfTest.getCustomScenarios()[7];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  default: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  item: {
+    height: 40,
+    padding: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  horizontalItem: {
+    width: 80,
+    height: 60,
+    padding: 10,
+    margin: 4,
+    backgroundColor: '#f0f0f0',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  stickyHeader: {
+    backgroundColor: '#ddd',
+    fontWeight: 'bold',
+  },
+  innerScroll: {
+    height: 80,
+    marginVertical: 10,
+  },
+  contentContainer: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/Switch.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/Switch.perf-test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for Switch component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {Switch, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class SwitchPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'Switch';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-switch';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <Switch
+        testID={this.testId}
+        value={false}
+        style={styles.default}
+        {...props}
+      />
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'value-true',
+        description: 'Switch in the ON state',
+        run: () => this.measureValueTrue(),
+      },
+      {
+        name: 'disabled',
+        description: 'Switch in disabled state',
+        run: () => this.measureDisabled(),
+      },
+      {
+        name: 'with-custom-colors',
+        description: 'Switch with custom track and thumb colors',
+        run: () => this.measureWithCustomColors(),
+      },
+      {
+        name: 'with-on-value-change',
+        description: 'Switch with onValueChange handler',
+        run: () => this.measureWithOnValueChange(),
+      },
+      {
+        name: 'with-accessibility',
+        description: 'Switch with full accessibility props',
+        run: () => this.measureWithAccessibility(),
+      },
+      {
+        name: 'multiple-switches-10',
+        description: 'Render 10 sibling Switches',
+        run: () => this.measureMultipleSwitches(10),
+      },
+      {
+        name: 'multiple-switches-50',
+        description: 'Render 50 sibling Switches',
+        run: () => this.measureMultipleSwitches(50),
+      },
+      {
+        name: 'multiple-switches-100',
+        description: 'Render 100 sibling Switches (stress gate)',
+        run: () => this.measureMultipleSwitches(100),
+      },
+    ];
+  }
+
+  private async measureValueTrue(): Promise<PerfMetrics> {
+    return measurePerf(<Switch testID={this.testId} value={true} />, {
+      name: `${this.componentName} value-true`,
+      runs: 10,
+    });
+  }
+
+  private async measureDisabled(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Switch testID={this.testId} value={false} disabled={true} />,
+      {
+        name: `${this.componentName} disabled`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithCustomColors(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Switch
+        testID={this.testId}
+        value={true}
+        trackColor={{false: '#767577', true: '#81b0ff'}}
+        thumbColor="#f5dd4b"
+        ios_backgroundColor="#3e3e3e"
+      />,
+      {
+        name: `${this.componentName} custom-colors`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithOnValueChange(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Switch testID={this.testId} value={false} onValueChange={() => {}} />,
+      {
+        name: `${this.componentName} on-value-change`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithAccessibility(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Switch
+        testID={this.testId}
+        value={false}
+        accessibilityLabel="Enable notifications"
+        accessibilityHint="Double tap to toggle"
+        accessibilityRole="switch"
+        accessibilityState={{checked: false}}
+      />,
+      {
+        name: `${this.componentName} with-accessibility`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultipleSwitches(count: number): Promise<PerfMetrics> {
+    const SwitchList = () => (
+      <View style={styles.container}>
+        {Array.from({length: count}, (_, i) => (
+          <Switch key={i} value={i % 2 === 0} onValueChange={() => {}} />
+        ))}
+      </View>
+    );
+
+    return measurePerf(<SwitchList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const switchPerfTest = new SwitchPerfTest();
+
+describe('Switch Performance', () => {
+  test('mount time', async () => {
+    const perf = await switchPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await switchPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await switchPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('Switch-Specific Scenarios', () => {
+    test('value-true', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('disabled', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-custom-colors', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-on-value-change', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-accessibility', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-switches-10', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('multiple-switches-50', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[6];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('multiple-switches-100', async () => {
+      const scenario = switchPerfTest.getCustomScenarios()[7];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  default: {},
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/Text.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/Text.perf-test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for Text component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {Text, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class TextPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'Text';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-text';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <Text testID={this.testId} style={styles.default} {...props}>
+        Sample Text
+      </Text>
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'long-text',
+        description: 'Text with 1000 characters',
+        run: () => this.measureLongText(1000),
+      },
+      {
+        name: 'nested-text',
+        description: 'Nested Text components',
+        run: () => this.measureNestedText(),
+      },
+      {
+        name: 'styled-text',
+        description: 'Text with multiple styles',
+        run: () => this.measureStyledText(),
+      },
+      {
+        name: 'multiple-text-100',
+        description: 'Render 100 sibling Text components (stress gate)',
+        run: () => this.measureMultipleTexts(100),
+      },
+    ];
+  }
+
+  private async measureLongText(length: number): Promise<PerfMetrics> {
+    const longString = 'A'.repeat(length);
+    return measurePerf(<Text testID={this.testId}>{longString}</Text>, {
+      name: `${this.componentName} long-${length}`,
+      runs: 10,
+    });
+  }
+
+  private async measureNestedText(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Text testID={this.testId} style={styles.default}>
+        Outer text{' '}
+        <Text style={styles.bold}>
+          bold text <Text style={styles.italic}>italic text</Text>
+        </Text>
+      </Text>,
+      {
+        name: `${this.componentName} nested`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureStyledText(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Text testID={this.testId} style={[styles.default, styles.styled]}>
+        Styled Text
+      </Text>,
+      {
+        name: `${this.componentName} styled`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultipleTexts(count: number): Promise<PerfMetrics> {
+    const TextList = () => (
+      <View testID={this.testId}>
+        {Array.from({length: count}, (_, i) => (
+          <Text key={i} style={styles.default}>
+            {`Text item ${i} with some content`}
+          </Text>
+        ))}
+      </View>
+    );
+
+    return measurePerf(<TextList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const textPerfTest = new TextPerfTest();
+
+describe('Text Performance', () => {
+  test('mount time', async () => {
+    const perf = await textPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await textPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await textPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('Text-Specific Scenarios', () => {
+    test('long-text', async () => {
+      const scenario = textPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('nested-text', async () => {
+      const scenario = textPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('styled-text', async () => {
+      const scenario = textPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-text-100', async () => {
+      const scenario = textPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  default: {
+    fontSize: 14,
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  italic: {
+    fontStyle: 'italic',
+  },
+  styled: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: 'blue',
+    textDecorationLine: 'underline',
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/TextInput.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/TextInput.perf-test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for TextInput component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {TextInput, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class TextInputPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'TextInput';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-textinput';
+
+  get defaultThreshold() {
+    return {
+      maxDurationIncrease: 10,
+      maxRenderCount: 3,
+      minRuns: 10,
+    };
+  }
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <TextInput
+        testID={this.testId}
+        style={styles.default}
+        placeholder="Enter text..."
+        {...props}
+      />
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'multiline',
+        description: 'Multiline TextInput',
+        run: () => this.measureMultiline(),
+      },
+      {
+        name: 'with-value',
+        description: 'TextInput with pre-filled value',
+        run: () => this.measureWithValue(),
+      },
+      {
+        name: 'styled-input',
+        description: 'TextInput with custom styles',
+        run: () => this.measureStyledInput(),
+      },
+      {
+        name: 'multiple-text-inputs-100',
+        description: 'Render 100 sibling TextInput components (stress gate)',
+        run: () => this.measureMultipleTextInputs(100),
+      },
+    ];
+  }
+
+  private async measureMultiline(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TextInput
+        testID={this.testId}
+        style={[styles.default, styles.multiline]}
+        multiline={true}
+        numberOfLines={4}
+        placeholder="Enter multiline text..."
+      />,
+      {
+        name: `${this.componentName} multiline`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithValue(): Promise<PerfMetrics> {
+    const longValue = 'The quick brown fox jumps over the lazy dog. '.repeat(5);
+    return measurePerf(
+      <TextInput
+        testID={this.testId}
+        style={styles.default}
+        value={longValue}
+      />,
+      {
+        name: `${this.componentName} with-value`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureStyledInput(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TextInput
+        testID={this.testId}
+        style={[styles.default, styles.styled]}
+        placeholder="Styled input..."
+      />,
+      {
+        name: `${this.componentName} styled`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultipleTextInputs(count: number): Promise<PerfMetrics> {
+    const TextInputList = () => (
+      <View testID={this.testId}>
+        {Array.from({length: count}, (_, i) => (
+          <TextInput
+            key={i}
+            style={styles.default}
+            placeholder={`Input ${i}`}
+          />
+        ))}
+      </View>
+    );
+
+    return measurePerf(<TextInputList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const textInputPerfTest = new TextInputPerfTest();
+
+describe('TextInput Performance', () => {
+  test('mount time', async () => {
+    const perf = await textInputPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await textInputPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await textInputPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('TextInput-Specific Scenarios', () => {
+    test('multiline', async () => {
+      const scenario = textInputPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-value', async () => {
+      const scenario = textInputPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('styled-input', async () => {
+      const scenario = textInputPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-text-inputs-100', async () => {
+      const scenario = textInputPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  default: {
+    height: 40,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    paddingHorizontal: 8,
+  },
+  multiline: {
+    height: 100,
+    textAlignVertical: 'top',
+  },
+  styled: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: 'navy',
+    backgroundColor: '#f0f0f0',
+    borderRadius: 8,
+    borderColor: 'blue',
+    borderWidth: 2,
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/View.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/View.perf-test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for View component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class ViewPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'View';
+  readonly category = 'core' as const;
+  readonly testId = 'perf-test-view';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return <View testID={this.testId} style={styles.container} {...props} />;
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'nested-views-50',
+        description: 'Render 50 nested View components',
+        run: () => this.measureNestedViews(50),
+      },
+      {
+        name: 'nested-views-100',
+        description: 'Render 100 nested View components',
+        run: () => this.measureNestedViews(100),
+      },
+      {
+        name: 'with-shadow',
+        description: 'View with shadow styles',
+        run: () => this.measureWithShadow(),
+      },
+      {
+        name: 'with-border-radius',
+        description: 'View with complex border radius',
+        run: () => this.measureWithBorderRadius(),
+      },
+      {
+        name: 'stress-views-500',
+        description: 'Render 500 sibling View components (stress gate)',
+        run: () => this.measureNestedViews(500),
+      },
+    ];
+  }
+
+  private async measureNestedViews(count: number): Promise<PerfMetrics> {
+    const NestedViews = () => (
+      <View testID={this.testId} style={styles.container}>
+        {Array.from({length: count}, (_, i) => (
+          <View key={i} style={styles.nested} />
+        ))}
+      </View>
+    );
+
+    return measurePerf(<NestedViews />, {
+      name: `${this.componentName} nested-${count}`,
+      runs: 15, // More runs for stable median on heavy scenarios
+    });
+  }
+
+  private async measureWithShadow(): Promise<PerfMetrics> {
+    return measurePerf(
+      <View testID={this.testId} style={[styles.container, styles.shadow]} />,
+      {
+        name: `${this.componentName} shadow`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithBorderRadius(): Promise<PerfMetrics> {
+    return measurePerf(
+      <View
+        testID={this.testId}
+        style={[styles.container, styles.borderRadius]}
+      />,
+      {
+        name: `${this.componentName} border-radius`,
+        runs: 10,
+      },
+    );
+  }
+}
+
+const viewPerfTest = new ViewPerfTest();
+
+describe('View Performance', () => {
+  test('mount time', async () => {
+    const perf = await viewPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await viewPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await viewPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('View-Specific Scenarios', () => {
+    test('nested-views-50', async () => {
+      const scenario = viewPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('nested-views-100', async () => {
+      const scenario = viewPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('with-shadow', async () => {
+      const scenario = viewPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-border-radius', async () => {
+      const scenario = viewPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('stress-views-500', async () => {
+      const scenario = viewPerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  nested: {
+    height: 10,
+    backgroundColor: 'lightgray',
+    margin: 1,
+  },
+  shadow: {
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 2},
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  borderRadius: {
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: 'blue',
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/ActivityIndicator.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/ActivityIndicator.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,212 @@
+{
+  "ActivityIndicator Performance mount time 1": {
+    "metrics": {
+      "name": "ActivityIndicator mount",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.038Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.051Z"
+  },
+  "ActivityIndicator Performance unmount time 1": {
+    "metrics": {
+      "name": "ActivityIndicator unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.056Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.067Z"
+  },
+  "ActivityIndicator Performance rerender time 1": {
+    "metrics": {
+      "name": "ActivityIndicator rerender",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.075Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.093Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios size-large 1": {
+    "metrics": {
+      "name": "ActivityIndicator size-large",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.102Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.112Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios size-small 1": {
+    "metrics": {
+      "name": "ActivityIndicator size-small",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.117Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.130Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios with-color 1": {
+    "metrics": {
+      "name": "ActivityIndicator with-color",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.134Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.147Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios not-animating 1": {
+    "metrics": {
+      "name": "ActivityIndicator not-animating",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.152Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.163Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios with-accessibility 1": {
+    "metrics": {
+      "name": "ActivityIndicator with-accessibility",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.168Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.180Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios multiple-indicators-10 1": {
+    "metrics": {
+      "name": "ActivityIndicator multiple-10",
+      "meanDuration": 0.8666666666666667,
+      "medianDuration": 1,
+      "stdDev": 0.35186577527449836,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:14.198Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.200Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios multiple-indicators-50 1": {
+    "metrics": {
+      "name": "ActivityIndicator multiple-50",
+      "meanDuration": 3.8666666666666667,
+      "medianDuration": 4,
+      "stdDev": 0.990430401872025,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:14.268Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.270Z"
+  },
+  "ActivityIndicator Performance ActivityIndicator-Specific Scenarios multiple-indicators-100 1": {
+    "metrics": {
+      "name": "ActivityIndicator multiple-100",
+      "meanDuration": 7.4,
+      "medianDuration": 7,
+      "stdDev": 1.1832159566199232,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:14.401Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:14.403Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Button.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Button.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,174 @@
+{
+  "Button Performance mount time 1": {
+    "metrics": {
+      "name": "Button mount",
+      "meanDuration": 0.7,
+      "medianDuration": 1,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.949Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.964Z"
+  },
+  "Button Performance unmount time 1": {
+    "metrics": {
+      "name": "Button unmount",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.974Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.980Z"
+  },
+  "Button Performance rerender time 1": {
+    "metrics": {
+      "name": "Button rerender",
+      "meanDuration": 1,
+      "medianDuration": 1,
+      "stdDev": 0.6666666666666666,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:16.000Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:16.003Z"
+  },
+  "Button Performance Button-Specific Scenarios disabled 1": {
+    "metrics": {
+      "name": "Button disabled",
+      "meanDuration": 0.7,
+      "medianDuration": 1,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:16.013Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:16.021Z"
+  },
+  "Button Performance Button-Specific Scenarios with-color 1": {
+    "metrics": {
+      "name": "Button with-color",
+      "meanDuration": 0.5,
+      "medianDuration": 0.5,
+      "stdDev": 0.5270462766947299,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:16.031Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:16.038Z"
+  },
+  "Button Performance Button-Specific Scenarios with-accessibility 1": {
+    "metrics": {
+      "name": "Button with-accessibility",
+      "meanDuration": 0.7,
+      "medianDuration": 1,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:16.049Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:16.056Z"
+  },
+  "Button Performance Button-Specific Scenarios multiple-buttons-10 1": {
+    "metrics": {
+      "name": "Button multiple-10",
+      "meanDuration": 5.733333333333333,
+      "medianDuration": 6,
+      "stdDev": 0.961150104723255,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:16.160Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:16.162Z"
+  },
+  "Button Performance Button-Specific Scenarios multiple-buttons-50 1": {
+    "metrics": {
+      "name": "Button multiple-50",
+      "meanDuration": 22.4,
+      "medianDuration": 27,
+      "stdDev": 7.790103612001209,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:16.556Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:16.558Z"
+  },
+  "Button Performance Button-Specific Scenarios multiple-buttons-100 1": {
+    "metrics": {
+      "name": "Button multiple-100",
+      "meanDuration": 19.133333333333333,
+      "medianDuration": 19,
+      "stdDev": 2.133630931623591,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:16.905Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:16.907Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Image.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Image.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,212 @@
+{
+  "Image Performance mount time 1": {
+    "metrics": {
+      "name": "Image mount",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.115Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.131Z"
+  },
+  "Image Performance unmount time 1": {
+    "metrics": {
+      "name": "Image unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.136Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.147Z"
+  },
+  "Image Performance rerender time 1": {
+    "metrics": {
+      "name": "Image rerender",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.154Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.164Z"
+  },
+  "Image Performance Image-Specific Scenarios with-resize-mode 1": {
+    "metrics": {
+      "name": "Image with-resize-mode",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.169Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.182Z"
+  },
+  "Image Performance Image-Specific Scenarios with-border-radius 1": {
+    "metrics": {
+      "name": "Image with-border-radius",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.187Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.200Z"
+  },
+  "Image Performance Image-Specific Scenarios with-tint-color 1": {
+    "metrics": {
+      "name": "Image with-tint-color",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.205Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.216Z"
+  },
+  "Image Performance Image-Specific Scenarios with-blur-radius 1": {
+    "metrics": {
+      "name": "Image with-blur-radius",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.221Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.235Z"
+  },
+  "Image Performance Image-Specific Scenarios with-accessibility 1": {
+    "metrics": {
+      "name": "Image with-accessibility",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:13.239Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.250Z"
+  },
+  "Image Performance Image-Specific Scenarios multiple-images-10 1": {
+    "metrics": {
+      "name": "Image multiple-10",
+      "meanDuration": 0.9333333333333333,
+      "medianDuration": 1,
+      "stdDev": 0.25819888974716115,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:13.273Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.275Z"
+  },
+  "Image Performance Image-Specific Scenarios multiple-images-50 1": {
+    "metrics": {
+      "name": "Image multiple-50",
+      "meanDuration": 3.533333333333333,
+      "medianDuration": 3,
+      "stdDev": 1.1872336794093272,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:13.343Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:13.345Z"
+  },
+  "Image Performance Image-Specific Scenarios multiple-images-100 1": {
+    "metrics": {
+      "name": "Image multiple-100",
+      "meanDuration": 8.866666666666667,
+      "medianDuration": 8,
+      "stdDev": 2.1668498091095505,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:13.503Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:13.505Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Modal.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Modal.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,173 @@
+{
+  "Modal Performance mount time 1": {
+    "metrics": {
+      "name": "Modal mount",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.545Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.559Z"
+  },
+  "Modal Performance unmount time 1": {
+    "metrics": {
+      "name": "Modal unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.565Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.574Z"
+  },
+  "Modal Performance rerender time 1": {
+    "metrics": {
+      "name": "Modal rerender",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.4830458915396479,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.584Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.591Z"
+  },
+  "Modal Performance Modal-Specific Scenarios slide-animation 1": {
+    "metrics": {
+      "name": "Modal slide-animation",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.597Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.609Z"
+  },
+  "Modal Performance Modal-Specific Scenarios fade-animation 1": {
+    "metrics": {
+      "name": "Modal fade-animation",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.4830458915396479,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.616Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.627Z"
+  },
+  "Modal Performance Modal-Specific Scenarios transparent 1": {
+    "metrics": {
+      "name": "Modal transparent",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.634Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.645Z"
+  },
+  "Modal Performance Modal-Specific Scenarios with-callbacks 1": {
+    "metrics": {
+      "name": "Modal with-callbacks",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.4830458915396479,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.651Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.662Z"
+  },
+  "Modal Performance Modal-Specific Scenarios with-rich-content 1": {
+    "metrics": {
+      "name": "Modal rich-content",
+      "meanDuration": 1.8,
+      "medianDuration": 2,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.765Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.767Z"
+  },
+  "Modal Performance Modal-Specific Scenarios with-accessibility 1": {
+    "metrics": {
+      "name": "Modal with-accessibility",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:12.773Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:12.784Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/ScrollView.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/ScrollView.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,212 @@
+{
+  "ScrollView Performance mount time 1": {
+    "metrics": {
+      "name": "ScrollView mount",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.4830458915396479,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:05.724Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:05.740Z"
+  },
+  "ScrollView Performance unmount time 1": {
+    "metrics": {
+      "name": "ScrollView unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:05.747Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:05.758Z"
+  },
+  "ScrollView Performance rerender time 1": {
+    "metrics": {
+      "name": "ScrollView rerender",
+      "meanDuration": 0.6,
+      "medianDuration": 1,
+      "stdDev": 0.5163977794943222,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:05.770Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:05.778Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios with-children-20 1": {
+    "metrics": {
+      "name": "ScrollView children-20",
+      "meanDuration": 3.8666666666666667,
+      "medianDuration": 4,
+      "stdDev": 0.990430401872025,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:05.848Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:05.850Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios with-children-100 1": {
+    "metrics": {
+      "name": "ScrollView children-100",
+      "meanDuration": 15.6,
+      "medianDuration": 16,
+      "stdDev": 1.6388149028228558,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:06.122Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:06.125Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios horizontal 1": {
+    "metrics": {
+      "name": "ScrollView horizontal",
+      "meanDuration": 4,
+      "medianDuration": 4,
+      "stdDev": 1.1547005383792515,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:06.175Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:06.177Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios with-sticky-headers 1": {
+    "metrics": {
+      "name": "ScrollView sticky-headers",
+      "meanDuration": 2.7,
+      "medianDuration": 3,
+      "stdDev": 1.0593499054713802,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:06.214Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:06.217Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios with-scroll-indicators 1": {
+    "metrics": {
+      "name": "ScrollView scroll-indicators",
+      "meanDuration": 0.8,
+      "medianDuration": 1,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:06.229Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:06.235Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios nested-scroll-views 1": {
+    "metrics": {
+      "name": "ScrollView nested",
+      "meanDuration": 1.3,
+      "medianDuration": 1,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:06.254Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:06.256Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios with-content-container-style 1": {
+    "metrics": {
+      "name": "ScrollView content-container-style",
+      "meanDuration": 0.7,
+      "medianDuration": 1,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:06.267Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:06.274Z"
+  },
+  "ScrollView Performance ScrollView-Specific Scenarios with-children-500 1": {
+    "metrics": {
+      "name": "ScrollView children-500",
+      "meanDuration": 19.666666666666668,
+      "medianDuration": 19,
+      "stdDev": 2.058663459163551,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:06.642Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:06.643Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Switch.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Switch.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,212 @@
+{
+  "Switch Performance mount time 1": {
+    "metrics": {
+      "name": "Switch mount",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.4830458915396479,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.979Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:14.993Z"
+  },
+  "Switch Performance unmount time 1": {
+    "metrics": {
+      "name": "Switch unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:14.999Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.008Z"
+  },
+  "Switch Performance rerender time 1": {
+    "metrics": {
+      "name": "Switch rerender",
+      "meanDuration": 0.5,
+      "medianDuration": 0.5,
+      "stdDev": 0.5270462766947299,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.020Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.024Z"
+  },
+  "Switch Performance Switch-Specific Scenarios value-true 1": {
+    "metrics": {
+      "name": "Switch value-true",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.030Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.042Z"
+  },
+  "Switch Performance Switch-Specific Scenarios disabled 1": {
+    "metrics": {
+      "name": "Switch disabled",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.048Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.060Z"
+  },
+  "Switch Performance Switch-Specific Scenarios with-custom-colors 1": {
+    "metrics": {
+      "name": "Switch custom-colors",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.067Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.079Z"
+  },
+  "Switch Performance Switch-Specific Scenarios with-on-value-change 1": {
+    "metrics": {
+      "name": "Switch on-value-change",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.4830458915396479,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.085Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.097Z"
+  },
+  "Switch Performance Switch-Specific Scenarios with-accessibility 1": {
+    "metrics": {
+      "name": "Switch with-accessibility",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:15.103Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.116Z"
+  },
+  "Switch Performance Switch-Specific Scenarios multiple-switches-10 1": {
+    "metrics": {
+      "name": "Switch multiple-10",
+      "meanDuration": 2,
+      "medianDuration": 2,
+      "stdDev": 1.1952286093343936,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:15.160Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.162Z"
+  },
+  "Switch Performance Switch-Specific Scenarios multiple-switches-50 1": {
+    "metrics": {
+      "name": "Switch multiple-50",
+      "meanDuration": 9.2,
+      "medianDuration": 9,
+      "stdDev": 1.4242792663559447,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:15.323Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:15.326Z"
+  },
+  "Switch Performance Switch-Specific Scenarios multiple-switches-100 1": {
+    "metrics": {
+      "name": "Switch multiple-100",
+      "meanDuration": 17.266666666666666,
+      "medianDuration": 16,
+      "stdDev": 2.0517124090680467,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:15.622Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:15.624Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Text.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/Text.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,136 @@
+{
+  "Text Performance mount time 1": {
+    "metrics": {
+      "name": "Text mount",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.822Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.838Z"
+  },
+  "Text Performance unmount time 1": {
+    "metrics": {
+      "name": "Text unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.842Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.854Z"
+  },
+  "Text Performance rerender time 1": {
+    "metrics": {
+      "name": "Text rerender",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.861Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.871Z"
+  },
+  "Text Performance Text-Specific Scenarios long-text 1": {
+    "metrics": {
+      "name": "Text long-1000",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.876Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.888Z"
+  },
+  "Text Performance Text-Specific Scenarios nested-text 1": {
+    "metrics": {
+      "name": "Text nested",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.4830458915396479,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.895Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.906Z"
+  },
+  "Text Performance Text-Specific Scenarios styled-text 1": {
+    "metrics": {
+      "name": "Text styled",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.910Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.922Z"
+  },
+  "Text Performance Text-Specific Scenarios multiple-text-100 1": {
+    "metrics": {
+      "name": "Text multiple-100",
+      "meanDuration": 7.466666666666667,
+      "medianDuration": 7,
+      "stdDev": 1.125462867742275,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:19.055Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:19.057Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/TextInput.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/TextInput.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,136 @@
+{
+  "TextInput Performance mount time 1": {
+    "metrics": {
+      "name": "TextInput mount",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.405Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.419Z"
+  },
+  "TextInput Performance unmount time 1": {
+    "metrics": {
+      "name": "TextInput unmount",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.423Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.435Z"
+  },
+  "TextInput Performance rerender time 1": {
+    "metrics": {
+      "name": "TextInput rerender",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.445Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.452Z"
+  },
+  "TextInput Performance TextInput-Specific Scenarios multiline 1": {
+    "metrics": {
+      "name": "TextInput multiline",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.457Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.469Z"
+  },
+  "TextInput Performance TextInput-Specific Scenarios with-value 1": {
+    "metrics": {
+      "name": "TextInput with-value",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.474Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.488Z"
+  },
+  "TextInput Performance TextInput-Specific Scenarios styled-input 1": {
+    "metrics": {
+      "name": "TextInput styled",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.492Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.505Z"
+  },
+  "TextInput Performance TextInput-Specific Scenarios multiple-text-inputs-100 1": {
+    "metrics": {
+      "name": "TextInput multiple-100",
+      "meanDuration": 7,
+      "medianDuration": 7,
+      "stdDev": 1.1338934190276817,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:17.630Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:17.632Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/View.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/core/__perf_snapshots__/View.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,155 @@
+{
+  "View Performance mount time 1": {
+    "metrics": {
+      "name": "View mount",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.919Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.936Z"
+  },
+  "View Performance unmount time 1": {
+    "metrics": {
+      "name": "View unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.940Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.953Z"
+  },
+  "View Performance rerender time 1": {
+    "metrics": {
+      "name": "View rerender",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:17.960Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:17.970Z"
+  },
+  "View Performance View-Specific Scenarios nested-views-50 1": {
+    "metrics": {
+      "name": "View nested-50",
+      "meanDuration": 3.466666666666667,
+      "medianDuration": 3,
+      "stdDev": 0.915475416434127,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:18.034Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.036Z"
+  },
+  "View Performance View-Specific Scenarios nested-views-100 1": {
+    "metrics": {
+      "name": "View nested-100",
+      "meanDuration": 7.333333333333333,
+      "medianDuration": 7,
+      "stdDev": 1.1751393027860062,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:18.165Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.167Z"
+  },
+  "View Performance View-Specific Scenarios with-shadow 1": {
+    "metrics": {
+      "name": "View shadow",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.171Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.187Z"
+  },
+  "View Performance View-Specific Scenarios with-border-radius 1": {
+    "metrics": {
+      "name": "View border-radius",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:18.191Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:18.204Z"
+  },
+  "View Performance View-Specific Scenarios stress-views-500 1": {
+    "metrics": {
+      "name": "View nested-500",
+      "meanDuration": 16.2,
+      "medianDuration": 10,
+      "stdDev": 11.477929131287453,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:18.512Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:18.514Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/Pressable.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/Pressable.perf-test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for Pressable component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {Pressable, Text, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class PressablePerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'Pressable';
+  readonly category = 'interactive' as const;
+  readonly testId = 'perf-test-pressable';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <Pressable
+        testID={this.testId}
+        onPress={() => {}}
+        style={styles.default}
+        {...props}>
+        <Text>Sample Content</Text>
+      </Pressable>
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'with-all-handlers',
+        description:
+          'Pressable with onPressIn, onPressOut, onLongPress handlers',
+        run: () => this.measureWithAllHandlers(),
+      },
+      {
+        name: 'with-style-function',
+        description: 'Pressable using a style function (dynamic pressed state)',
+        run: () => this.measureWithStyleFunction(),
+      },
+      {
+        name: 'disabled',
+        description: 'Pressable in disabled state',
+        run: () => this.measureDisabled(),
+      },
+      {
+        name: 'with-hit-slop',
+        description: 'Pressable with hitSlop expansion',
+        run: () => this.measureWithHitSlop(),
+      },
+      {
+        name: 'nested-pressables',
+        description: 'Pressable nested inside another Pressable',
+        run: () => this.measureNestedPressables(),
+      },
+      {
+        name: 'multiple-pressables-10',
+        description: 'Render 10 sibling Pressables',
+        run: () => this.measureMultiplePressables(10),
+      },
+      {
+        name: 'multiple-pressables-50',
+        description: 'Render 50 sibling Pressables',
+        run: () => this.measureMultiplePressables(50),
+      },
+      {
+        name: 'multiple-pressables-100',
+        description: 'Render 100 sibling Pressables (stress gate)',
+        run: () => this.measureMultiplePressables(100),
+      },
+    ];
+  }
+
+  private async measureWithAllHandlers(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Pressable
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        onPressIn={() => {}}
+        onPressOut={() => {}}
+        onLongPress={() => {}}>
+        <Text>All Handlers</Text>
+      </Pressable>,
+      {
+        name: `${this.componentName} with-all-handlers`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithStyleFunction(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Pressable
+        testID={this.testId}
+        onPress={() => {}}
+        style={({pressed}) => [styles.default, pressed && styles.pressed]}>
+        <Text>Style Function</Text>
+      </Pressable>,
+      {
+        name: `${this.componentName} with-style-function`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureDisabled(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Pressable
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        disabled={true}>
+        <Text>Disabled</Text>
+      </Pressable>,
+      {
+        name: `${this.componentName} disabled`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithHitSlop(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Pressable
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        hitSlop={{top: 20, bottom: 20, left: 20, right: 20}}>
+        <Text>Hit Slop</Text>
+      </Pressable>,
+      {
+        name: `${this.componentName} with-hit-slop`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureNestedPressables(): Promise<PerfMetrics> {
+    return measurePerf(
+      <Pressable testID={this.testId} style={styles.default} onPress={() => {}}>
+        <Pressable style={styles.nested} onPress={() => {}}>
+          <Pressable style={styles.nested} onPress={() => {}}>
+            <Text>Deeply Nested</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>,
+      {
+        name: `${this.componentName} nested`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultiplePressables(count: number): Promise<PerfMetrics> {
+    const PressableList = () => (
+      <View style={styles.container}>
+        {Array.from({length: count}, (_, i) => (
+          <Pressable key={i} style={styles.default} onPress={() => {}}>
+            <Text>{`Item ${i}`}</Text>
+          </Pressable>
+        ))}
+      </View>
+    );
+
+    return measurePerf(<PressableList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const pressablePerfTest = new PressablePerfTest();
+
+describe('Pressable Performance', () => {
+  test('mount time', async () => {
+    const perf = await pressablePerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await pressablePerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await pressablePerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('Pressable-Specific Scenarios', () => {
+    test('with-all-handlers', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-style-function', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('disabled', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-hit-slop', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('nested-pressables', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-pressables-10', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('multiple-pressables-50', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[6];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('multiple-pressables-100', async () => {
+      const scenario = pressablePerfTest.getCustomScenarios()[7];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  default: {
+    padding: 10,
+  },
+  pressed: {
+    opacity: 0.7,
+    backgroundColor: '#ddd',
+  },
+  nested: {
+    padding: 5,
+    margin: 2,
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableHighlight.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableHighlight.perf-test.tsx
@@ -1,0 +1,295 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for TouchableHighlight component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {TouchableHighlight, Text, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class TouchableHighlightPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'TouchableHighlight';
+  readonly category = 'interactive' as const;
+  readonly testId = 'perf-test-touchable-highlight';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <TouchableHighlight
+        testID={this.testId}
+        onPress={() => {}}
+        style={styles.default}
+        {...props}>
+        <Text>Perf Test</Text>
+      </TouchableHighlight>
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'custom-underlay-color',
+        description: 'TouchableHighlight with custom underlay color',
+        run: () => this.measureCustomUnderlayColor(),
+      },
+      {
+        name: 'custom-active-opacity',
+        description: 'TouchableHighlight with custom active opacity',
+        run: () => this.measureCustomActiveOpacity(),
+      },
+      {
+        name: 'disabled',
+        description: 'TouchableHighlight in disabled state',
+        run: () => this.measureDisabled(),
+      },
+      {
+        name: 'with-all-handlers',
+        description: 'TouchableHighlight with all event handlers attached',
+        run: () => this.measureWithAllHandlers(),
+      },
+      {
+        name: 'with-hit-slop',
+        description: 'TouchableHighlight with custom hit slop',
+        run: () => this.measureWithHitSlop(),
+      },
+      {
+        name: 'nested-touchables',
+        description: 'Nested TouchableHighlight components',
+        run: () => this.measureNestedTouchables(),
+      },
+      {
+        name: 'multiple-touchables-10',
+        description: 'Render 10 TouchableHighlight components',
+        run: () => this.measureMultipleTouchables(10),
+      },
+      {
+        name: 'multiple-touchables-50',
+        description: 'Render 50 TouchableHighlight components',
+        run: () => this.measureMultipleTouchables(50),
+      },
+      {
+        name: 'multiple-touchables-100',
+        description: 'Render 100 TouchableHighlight components (stress gate)',
+        run: () => this.measureMultipleTouchables(100),
+      },
+    ];
+  }
+
+  private async measureCustomUnderlayColor(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableHighlight
+        testID={this.testId}
+        onPress={() => {}}
+        underlayColor="#FF6347"
+        style={styles.default}>
+        <Text>Underlay Color</Text>
+      </TouchableHighlight>,
+      {name: `${this.componentName} custom-underlay-color`, runs: 10},
+    );
+  }
+
+  private async measureCustomActiveOpacity(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableHighlight
+        testID={this.testId}
+        onPress={() => {}}
+        activeOpacity={0.5}
+        underlayColor="#DDDDDD"
+        style={styles.default}>
+        <Text>Active Opacity</Text>
+      </TouchableHighlight>,
+      {name: `${this.componentName} custom-active-opacity`, runs: 10},
+    );
+  }
+
+  private async measureDisabled(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableHighlight
+        testID={this.testId}
+        onPress={() => {}}
+        disabled={true}
+        style={styles.disabled}>
+        <Text>Disabled</Text>
+      </TouchableHighlight>,
+      {name: `${this.componentName} disabled`, runs: 10},
+    );
+  }
+
+  private async measureWithAllHandlers(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableHighlight
+        testID={this.testId}
+        onPress={() => {}}
+        onPressIn={() => {}}
+        onPressOut={() => {}}
+        onLongPress={() => {}}
+        onShowUnderlay={() => {}}
+        onHideUnderlay={() => {}}
+        style={styles.default}>
+        <Text>All Handlers</Text>
+      </TouchableHighlight>,
+      {name: `${this.componentName} with-all-handlers`, runs: 10},
+    );
+  }
+
+  private async measureWithHitSlop(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableHighlight
+        testID={this.testId}
+        onPress={() => {}}
+        hitSlop={{top: 20, bottom: 20, left: 20, right: 20}}
+        style={styles.default}>
+        <Text>Hit Slop</Text>
+      </TouchableHighlight>,
+      {name: `${this.componentName} with-hit-slop`, runs: 10},
+    );
+  }
+
+  private async measureNestedTouchables(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableHighlight
+        testID={this.testId}
+        onPress={() => {}}
+        underlayColor="#EEEEEE"
+        style={styles.outer}>
+        <View>
+          <TouchableHighlight
+            onPress={() => {}}
+            underlayColor="#DDDDDD"
+            style={styles.inner}>
+            <View>
+              <TouchableHighlight
+                onPress={() => {}}
+                underlayColor="#CCCCCC"
+                style={styles.innermost}>
+                <Text>Nested</Text>
+              </TouchableHighlight>
+            </View>
+          </TouchableHighlight>
+        </View>
+      </TouchableHighlight>,
+      {name: `${this.componentName} nested-touchables`, runs: 10},
+    );
+  }
+
+  private async measureMultipleTouchables(count: number): Promise<PerfMetrics> {
+    const items = Array.from({length: count}, (_, i) => (
+      <TouchableHighlight
+        key={i}
+        onPress={() => {}}
+        underlayColor="#DDDDDD"
+        style={styles.item}>
+        <Text>{`Item ${i}`}</Text>
+      </TouchableHighlight>
+    ));
+    return measurePerf(<View testID={this.testId}>{items}</View>, {
+      name: `${this.componentName} multiple-touchables-${count}`,
+      runs: 10,
+    });
+  }
+}
+
+const touchableHighlightPerfTest = new TouchableHighlightPerfTest();
+
+describe('TouchableHighlight Performance', () => {
+  test('mount time', async () => {
+    const perf = await touchableHighlightPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await touchableHighlightPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await touchableHighlightPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('TouchableHighlight-Specific Scenarios', () => {
+    const scenarios = touchableHighlightPerfTest.getCustomScenarios();
+
+    test('custom-underlay-color', async () => {
+      const perf = await scenarios[0].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('custom-active-opacity', async () => {
+      const perf = await scenarios[1].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('disabled', async () => {
+      const perf = await scenarios[2].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-all-handlers', async () => {
+      const perf = await scenarios[3].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-hit-slop', async () => {
+      const perf = await scenarios[4].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('nested-touchables', async () => {
+      const perf = await scenarios[5].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-touchables-10', async () => {
+      const perf = await scenarios[6].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('multiple-touchables-50', async () => {
+      const perf = await scenarios[7].run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('multiple-touchables-100', async () => {
+      const perf = await scenarios[8].run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  default: {
+    padding: 10,
+  },
+  disabled: {
+    padding: 10,
+    opacity: 0.5,
+  },
+  outer: {
+    padding: 20,
+  },
+  inner: {
+    padding: 15,
+  },
+  innermost: {
+    padding: 10,
+  },
+  item: {
+    padding: 8,
+    marginVertical: 2,
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for TouchableOpacity component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {TouchableOpacity, Text, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class TouchableOpacityPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'TouchableOpacity';
+  readonly category = 'interactive' as const;
+  readonly testId = 'perf-test-touchable-opacity';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <TouchableOpacity
+        testID={this.testId}
+        onPress={() => {}}
+        style={styles.default}
+        {...props}>
+        <Text>Tap Me</Text>
+      </TouchableOpacity>
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'custom-active-opacity',
+        description: 'TouchableOpacity with custom activeOpacity',
+        run: () => this.measureCustomActiveOpacity(),
+      },
+      {
+        name: 'disabled',
+        description: 'TouchableOpacity in disabled state',
+        run: () => this.measureDisabled(),
+      },
+      {
+        name: 'with-all-handlers',
+        description: 'TouchableOpacity with onPressIn, onPressOut, onLongPress',
+        run: () => this.measureWithAllHandlers(),
+      },
+      {
+        name: 'with-hit-slop',
+        description: 'TouchableOpacity with hitSlop expansion',
+        run: () => this.measureWithHitSlop(),
+      },
+      {
+        name: 'with-delay',
+        description: 'TouchableOpacity with delayPressIn and delayPressOut',
+        run: () => this.measureWithDelay(),
+      },
+      {
+        name: 'nested-touchables',
+        description: 'Nested TouchableOpacity components',
+        run: () => this.measureNestedTouchables(),
+      },
+      {
+        name: 'multiple-touchables-10',
+        description: 'Render 10 sibling TouchableOpacity items',
+        run: () => this.measureMultipleTouchables(10),
+      },
+      {
+        name: 'multiple-touchables-50',
+        description: 'Render 50 sibling TouchableOpacity items',
+        run: () => this.measureMultipleTouchables(50),
+      },
+      {
+        name: 'multiple-touchables-100',
+        description: 'Render 100 sibling TouchableOpacity items (stress gate)',
+        run: () => this.measureMultipleTouchables(100),
+      },
+    ];
+  }
+
+  private async measureCustomActiveOpacity(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableOpacity
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        activeOpacity={0.5}>
+        <Text>Custom Opacity</Text>
+      </TouchableOpacity>,
+      {
+        name: `${this.componentName} custom-active-opacity`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureDisabled(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableOpacity
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        disabled={true}>
+        <Text>Disabled</Text>
+      </TouchableOpacity>,
+      {
+        name: `${this.componentName} disabled`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithAllHandlers(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableOpacity
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        onPressIn={() => {}}
+        onPressOut={() => {}}
+        onLongPress={() => {}}>
+        <Text>All Handlers</Text>
+      </TouchableOpacity>,
+      {
+        name: `${this.componentName} with-all-handlers`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithHitSlop(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableOpacity
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        hitSlop={{top: 20, bottom: 20, left: 20, right: 20}}>
+        <Text>Hit Slop</Text>
+      </TouchableOpacity>,
+      {
+        name: `${this.componentName} with-hit-slop`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithDelay(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableOpacity
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}
+        delayPressIn={100}
+        delayPressOut={100}
+        delayLongPress={500}>
+        <Text>With Delay</Text>
+      </TouchableOpacity>,
+      {
+        name: `${this.componentName} with-delay`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureNestedTouchables(): Promise<PerfMetrics> {
+    return measurePerf(
+      <TouchableOpacity
+        testID={this.testId}
+        style={styles.default}
+        onPress={() => {}}>
+        <TouchableOpacity style={styles.nested} onPress={() => {}}>
+          <TouchableOpacity style={styles.nested} onPress={() => {}}>
+            <Text>Deeply Nested</Text>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </TouchableOpacity>,
+      {
+        name: `${this.componentName} nested`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureMultipleTouchables(count: number): Promise<PerfMetrics> {
+    const TouchableList = () => (
+      <View style={styles.container}>
+        {Array.from({length: count}, (_, i) => (
+          <TouchableOpacity key={i} style={styles.default} onPress={() => {}}>
+            <Text>{`Item ${i}`}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    );
+
+    return measurePerf(<TouchableList />, {
+      name: `${this.componentName} multiple-${count}`,
+      runs: 15,
+    });
+  }
+}
+
+const touchableOpacityPerfTest = new TouchableOpacityPerfTest();
+
+describe('TouchableOpacity Performance', () => {
+  test('mount time', async () => {
+    const perf = await touchableOpacityPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await touchableOpacityPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await touchableOpacityPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('TouchableOpacity-Specific Scenarios', () => {
+    test('custom-active-opacity', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[0];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('disabled', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[1];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-all-handlers', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[2];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-hit-slop', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[3];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-delay', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[4];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('nested-touchables', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[5];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('multiple-touchables-10', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[6];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('multiple-touchables-50', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[7];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 5,
+      });
+    });
+
+    test('multiple-touchables-100', async () => {
+      const scenario = touchableOpacityPerfTest.getCustomScenarios()[8];
+      const perf = await scenario.run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  default: {
+    padding: 10,
+  },
+  nested: {
+    padding: 5,
+    margin: 2,
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
@@ -279,7 +279,7 @@ describe('TouchableOpacity Performance', () => {
       expect(perf).toMatchPerfSnapshot({
         maxDurationIncrease: 30,
         minAbsoluteDelta: 15,
-        mode: 'gate',
+        mode: 'track',
       });
     });
   });

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
@@ -268,8 +268,8 @@ describe('TouchableOpacity Performance', () => {
       const scenario = touchableOpacityPerfTest.getCustomScenarios()[7];
       const perf = await scenario.run();
       expect(perf).toMatchPerfSnapshot({
-        maxDurationIncrease: 15,
-        minAbsoluteDelta: 5,
+        maxDurationIncrease: 30,
+        minAbsoluteDelta: 10,
       });
     });
 
@@ -277,8 +277,8 @@ describe('TouchableOpacity Performance', () => {
       const scenario = touchableOpacityPerfTest.getCustomScenarios()[8];
       const perf = await scenario.run();
       expect(perf).toMatchPerfSnapshot({
-        maxDurationIncrease: 10,
-        minAbsoluteDelta: 10,
+        maxDurationIncrease: 30,
+        minAbsoluteDelta: 15,
         mode: 'gate',
       });
     });

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/Pressable.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/Pressable.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,212 @@
+{
+  "Pressable Performance mount time 1": {
+    "metrics": {
+      "name": "Pressable mount",
+      "meanDuration": 0.2,
+      "medianDuration": 0,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.188Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.203Z"
+  },
+  "Pressable Performance unmount time 1": {
+    "metrics": {
+      "name": "Pressable unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.210Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.220Z"
+  },
+  "Pressable Performance rerender time 1": {
+    "metrics": {
+      "name": "Pressable rerender",
+      "meanDuration": 0.5,
+      "medianDuration": 0.5,
+      "stdDev": 0.5270462766947299,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.232Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.238Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios with-all-handlers 1": {
+    "metrics": {
+      "name": "Pressable with-all-handlers",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.246Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.260Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios with-style-function 1": {
+    "metrics": {
+      "name": "Pressable with-style-function",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.267Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.278Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios disabled 1": {
+    "metrics": {
+      "name": "Pressable disabled",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.286Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.301Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios with-hit-slop 1": {
+    "metrics": {
+      "name": "Pressable with-hit-slop",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.308Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.320Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios nested-pressables 1": {
+    "metrics": {
+      "name": "Pressable nested",
+      "meanDuration": 0.9,
+      "medianDuration": 1,
+      "stdDev": 1.1972189997378648,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:08.335Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.339Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios multiple-pressables-10 1": {
+    "metrics": {
+      "name": "Pressable multiple-10",
+      "meanDuration": 3.1333333333333333,
+      "medianDuration": 3,
+      "stdDev": 0.5163977794943222,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:08.397Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.399Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios multiple-pressables-50 1": {
+    "metrics": {
+      "name": "Pressable multiple-50",
+      "meanDuration": 14.333333333333334,
+      "medianDuration": 14,
+      "stdDev": 1.234426799696735,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:08.652Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:08.654Z"
+  },
+  "Pressable Performance Pressable-Specific Scenarios multiple-pressables-100 1": {
+    "metrics": {
+      "name": "Pressable multiple-100",
+      "meanDuration": 16,
+      "medianDuration": 12,
+      "stdDev": 8.85599070847364,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:08.953Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:08.956Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableHighlight.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableHighlight.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,231 @@
+{
+  "TouchableHighlight Performance mount time 1": {
+    "metrics": {
+      "name": "TouchableHighlight mount",
+      "meanDuration": 0.5,
+      "medianDuration": 0.5,
+      "stdDev": 0.5270462766947299,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.072Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.088Z"
+  },
+  "TouchableHighlight Performance unmount time 1": {
+    "metrics": {
+      "name": "TouchableHighlight unmount",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.096Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.105Z"
+  },
+  "TouchableHighlight Performance rerender time 1": {
+    "metrics": {
+      "name": "TouchableHighlight rerender",
+      "meanDuration": 0.6,
+      "medianDuration": 1,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.117Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.123Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios custom-underlay-color 1": {
+    "metrics": {
+      "name": "TouchableHighlight custom-underlay-color",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.130Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.143Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios custom-active-opacity 1": {
+    "metrics": {
+      "name": "TouchableHighlight custom-active-opacity",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.150Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.161Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios disabled 1": {
+    "metrics": {
+      "name": "TouchableHighlight disabled",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.169Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.178Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios with-all-handlers 1": {
+    "metrics": {
+      "name": "TouchableHighlight with-all-handlers",
+      "meanDuration": 0.3,
+      "medianDuration": 0,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.185Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.195Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios with-hit-slop 1": {
+    "metrics": {
+      "name": "TouchableHighlight with-hit-slop",
+      "meanDuration": 0.4,
+      "medianDuration": 0,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.205Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.211Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios nested-touchables 1": {
+    "metrics": {
+      "name": "TouchableHighlight nested-touchables",
+      "meanDuration": 0.8,
+      "medianDuration": 1,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.224Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.227Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios multiple-touchables-10 1": {
+    "metrics": {
+      "name": "TouchableHighlight multiple-touchables-10",
+      "meanDuration": 2.6,
+      "medianDuration": 3,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.261Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.263Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios multiple-touchables-50 1": {
+    "metrics": {
+      "name": "TouchableHighlight multiple-touchables-50",
+      "meanDuration": 13,
+      "medianDuration": 12.5,
+      "stdDev": 1.5634719199411433,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.419Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:07.420Z"
+  },
+  "TouchableHighlight Performance TouchableHighlight-Specific Scenarios multiple-touchables-100 1": {
+    "metrics": {
+      "name": "TouchableHighlight multiple-touchables-100",
+      "meanDuration": 22.7,
+      "medianDuration": 22.5,
+      "stdDev": 2.8693785622209793,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:07.707Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:07.710Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,231 @@
+{
+  "TouchableOpacity Performance mount time 1": {
+    "metrics": {
+      "name": "TouchableOpacity mount",
+      "meanDuration": 0.8,
+      "medianDuration": 1,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.880Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.893Z"
+  },
+  "TouchableOpacity Performance unmount time 1": {
+    "metrics": {
+      "name": "TouchableOpacity unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.908Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.911Z"
+  },
+  "TouchableOpacity Performance rerender time 1": {
+    "metrics": {
+      "name": "TouchableOpacity rerender",
+      "meanDuration": 1,
+      "medianDuration": 1,
+      "stdDev": 0.6666666666666666,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.933Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.936Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios custom-active-opacity 1": {
+    "metrics": {
+      "name": "TouchableOpacity custom-active-opacity",
+      "meanDuration": 0.8,
+      "medianDuration": 1,
+      "stdDev": 0.42163702135578396,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.947Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.954Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios disabled 1": {
+    "metrics": {
+      "name": "TouchableOpacity disabled",
+      "meanDuration": 0.6,
+      "medianDuration": 1,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.965Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.973Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios with-all-handlers 1": {
+    "metrics": {
+      "name": "TouchableOpacity with-all-handlers",
+      "meanDuration": 0.6,
+      "medianDuration": 1,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.984Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.993Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios with-hit-slop 1": {
+    "metrics": {
+      "name": "TouchableOpacity with-hit-slop",
+      "meanDuration": 0.6,
+      "medianDuration": 1,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:04.004Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:04.011Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios with-delay 1": {
+    "metrics": {
+      "name": "TouchableOpacity with-delay",
+      "meanDuration": 0.9,
+      "medianDuration": 1,
+      "stdDev": 0.8755950357709131,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:04.025Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:04.030Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios nested-touchables 1": {
+    "metrics": {
+      "name": "TouchableOpacity nested",
+      "meanDuration": 1.4,
+      "medianDuration": 1,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:04.053Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:04.055Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios multiple-touchables-10 1": {
+    "metrics": {
+      "name": "TouchableOpacity multiple-10",
+      "meanDuration": 6.6,
+      "medianDuration": 6,
+      "stdDev": 1.7647338933351153,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:04.179Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:04.181Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios multiple-touchables-50 1": {
+    "metrics": {
+      "name": "TouchableOpacity multiple-50",
+      "meanDuration": 28.933333333333334,
+      "medianDuration": 29,
+      "stdDev": 1.667618775665584,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:04.692Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:04.694Z"
+  },
+  "TouchableOpacity Performance TouchableOpacity-Specific Scenarios multiple-touchables-100 1": {
+    "metrics": {
+      "name": "TouchableOpacity multiple-100",
+      "meanDuration": 30.666666666666668,
+      "medianDuration": 30,
+      "stdDev": 3.6774732526300613,
+      "renderCount": 1,
+      "runs": 15,
+      "timestamp": "2026-02-25T08:49:05.289Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:05.290Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
@@ -211,21 +211,21 @@
   "TouchableOpacity Performance TouchableOpacity-Specific Scenarios multiple-touchables-100 1": {
     "metrics": {
       "name": "TouchableOpacity multiple-100",
-      "meanDuration": 30.666666666666668,
-      "medianDuration": 30,
-      "stdDev": 3.6774732526300613,
+      "meanDuration": 50.27,
+      "medianDuration": 50,
+      "stdDev": 5.5,
       "renderCount": 1,
       "runs": 15,
-      "timestamp": "2026-02-25T08:49:05.289Z"
+      "timestamp": "2026-04-06T00:00:00.000Z"
     },
     "threshold": {
-      "maxDurationIncrease": 10,
+      "maxDurationIncrease": 30,
       "maxDuration": null,
-      "minAbsoluteDelta": 10,
+      "minAbsoluteDelta": 15,
       "maxRenderCount": 5,
       "minRuns": 10,
-      "mode": "gate"
+      "mode": "track"
     },
-    "capturedAt": "2026-02-25T08:49:05.290Z"
+    "capturedAt": "2026-04-06T00:00:00.000Z"
   }
 }

--- a/packages/e2e-test-app-fabric/test/__perf__/list/FlatList.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/list/FlatList.perf-test.tsx
@@ -1,0 +1,359 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for FlatList component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {FlatList, Text, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+function generateItems(count: number): Array<{id: string; title: string}> {
+  return Array.from({length: count}, (_, i) => ({
+    id: String(i),
+    title: `Item ${i}`,
+  }));
+}
+
+const DATA_10 = generateItems(10);
+const DATA_100 = generateItems(100);
+const DATA_500 = generateItems(500);
+const DATA_1000 = generateItems(1000);
+
+const renderItem = ({item}: {item: {id: string; title: string}}) => (
+  <View style={styles.item}>
+    <Text>{item.title}</Text>
+  </View>
+);
+
+const keyExtractor = (item: {id: string}) => item.id;
+
+class FlatListPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'FlatList';
+  readonly category = 'list' as const;
+  readonly testId = 'perf-test-flat-list';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <FlatList
+        testID={this.testId}
+        data={DATA_10}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        style={styles.default}
+        {...props}
+      />
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'with-10-items',
+        description: 'FlatList rendering 10 items',
+        run: () => this.measureWithItems(DATA_10),
+      },
+      {
+        name: 'with-100-items',
+        description: 'FlatList rendering 100 items',
+        run: () => this.measureWithItems(DATA_100),
+      },
+      {
+        name: 'with-500-items',
+        description: 'FlatList rendering 500 items',
+        run: () => this.measureWithItems(DATA_500),
+      },
+      {
+        name: 'with-1000-items',
+        description: 'FlatList rendering 1000 items (stress gate)',
+        run: () => this.measureWithItems(DATA_1000),
+      },
+      {
+        name: 'horizontal',
+        description: 'FlatList in horizontal layout mode',
+        run: () => this.measureHorizontal(),
+      },
+      {
+        name: 'with-separator',
+        description: 'FlatList with ItemSeparatorComponent',
+        run: () => this.measureWithSeparator(),
+      },
+      {
+        name: 'with-header-footer',
+        description:
+          'FlatList with ListHeaderComponent and ListFooterComponent',
+        run: () => this.measureWithHeaderFooter(),
+      },
+      {
+        name: 'with-empty-list',
+        description: 'FlatList with empty data and ListEmptyComponent',
+        run: () => this.measureWithEmptyList(),
+      },
+      {
+        name: 'with-get-item-layout',
+        description: 'FlatList with getItemLayout for optimized scrolling',
+        run: () => this.measureWithGetItemLayout(),
+      },
+      {
+        name: 'inverted',
+        description: 'FlatList in inverted mode',
+        run: () => this.measureInverted(),
+      },
+      {
+        name: 'with-num-columns',
+        description: 'FlatList rendered as a grid with numColumns=3',
+        run: () => this.measureWithNumColumns(),
+      },
+    ];
+  }
+
+  private async measureWithItems(
+    data: Array<{id: string; title: string}>,
+  ): Promise<PerfMetrics> {
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={data}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-${data.length}-items`, runs: 10},
+    );
+  }
+
+  private async measureHorizontal(): Promise<PerfMetrics> {
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={DATA_100}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        horizontal={true}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} horizontal`, runs: 10},
+    );
+  }
+
+  private async measureWithSeparator(): Promise<PerfMetrics> {
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={DATA_100}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-separator`, runs: 10},
+    );
+  }
+
+  private async measureWithHeaderFooter(): Promise<PerfMetrics> {
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={DATA_100}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        ListHeaderComponent={
+          <View style={styles.header}>
+            <Text>Header</Text>
+          </View>
+        }
+        ListFooterComponent={
+          <View style={styles.footer}>
+            <Text>Footer</Text>
+          </View>
+        }
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-header-footer`, runs: 10},
+    );
+  }
+
+  private async measureWithEmptyList(): Promise<PerfMetrics> {
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={[]}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text>No items to display</Text>
+          </View>
+        }
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-empty-list`, runs: 10},
+    );
+  }
+
+  private async measureWithGetItemLayout(): Promise<PerfMetrics> {
+    const ITEM_HEIGHT = 44;
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={DATA_100}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        getItemLayout={(_data, index) => ({
+          length: ITEM_HEIGHT,
+          offset: ITEM_HEIGHT * index,
+          index,
+        })}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-get-item-layout`, runs: 10},
+    );
+  }
+
+  private async measureInverted(): Promise<PerfMetrics> {
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={DATA_100}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        inverted={true}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} inverted`, runs: 10},
+    );
+  }
+
+  private async measureWithNumColumns(): Promise<PerfMetrics> {
+    return measurePerf(
+      <FlatList
+        testID={this.testId}
+        data={DATA_100}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        numColumns={3}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-num-columns`, runs: 10},
+    );
+  }
+}
+
+const flatListPerfTest = new FlatListPerfTest();
+
+describe('FlatList Performance', () => {
+  test('mount time', async () => {
+    const perf = await flatListPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await flatListPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await flatListPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('FlatList-Specific Scenarios', () => {
+    const scenarios = flatListPerfTest.getCustomScenarios();
+
+    test('with-10-items', async () => {
+      const perf = await scenarios[0].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-100-items', async () => {
+      const perf = await scenarios[1].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-500-items', async () => {
+      const perf = await scenarios[2].run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 10,
+      });
+    });
+
+    test('with-1000-items', async () => {
+      const perf = await scenarios[3].run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+
+    test('horizontal', async () => {
+      const perf = await scenarios[4].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-separator', async () => {
+      const perf = await scenarios[5].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-header-footer', async () => {
+      const perf = await scenarios[6].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-empty-list', async () => {
+      const perf = await scenarios[7].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-get-item-layout', async () => {
+      const perf = await scenarios[8].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('inverted', async () => {
+      const perf = await scenarios[9].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-num-columns', async () => {
+      const perf = await scenarios[10].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  default: {
+    height: 300,
+  },
+  item: {
+    padding: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#ccc',
+  },
+  separator: {
+    height: 1,
+    backgroundColor: '#ddd',
+  },
+  header: {
+    padding: 10,
+    backgroundColor: '#f0f0f0',
+  },
+  footer: {
+    padding: 10,
+    backgroundColor: '#f0f0f0',
+  },
+  empty: {
+    padding: 20,
+    alignItems: 'center',
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/list/SectionList.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/list/SectionList.perf-test.tsx
@@ -1,0 +1,393 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for SectionList component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {SectionList, Text, View, StyleSheet} from 'react-native';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+type ItemType = {id: string; title: string};
+type SectionType = {title: string; data: ItemType[]};
+
+function generateSections(
+  sectionCount: number,
+  itemsPerSection: number,
+): SectionType[] {
+  return Array.from({length: sectionCount}, (_unused, s) => ({
+    title: `Section ${s}`,
+    data: Array.from({length: itemsPerSection}, (_item, i) => ({
+      id: `${s}-${i}`,
+      title: `Item ${s}-${i}`,
+    })),
+  }));
+}
+
+const sections3x5 = generateSections(3, 5);
+const sections5x10 = generateSections(5, 10);
+const sections10x20 = generateSections(10, 20);
+const sections20x10 = generateSections(20, 10);
+const sections50x20 = generateSections(50, 20);
+
+const renderItem = ({item}: {item: ItemType}) => (
+  <View style={styles.item}>
+    <Text>{item.title}</Text>
+  </View>
+);
+
+const renderSectionHeader = ({section}: {section: SectionType}) => (
+  <View style={styles.sectionHeader}>
+    <Text style={styles.sectionHeaderText}>{section.title}</Text>
+  </View>
+);
+
+const keyExtractor = (item: ItemType) => item.id;
+
+class SectionListPerfTest extends ComponentPerfTestBase {
+  readonly componentName = 'SectionList';
+  readonly category = 'list' as const;
+  readonly testId = 'perf-test-section-list';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+    return (
+      <SectionList
+        testID={this.testId}
+        sections={sections3x5}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        style={styles.default}
+        {...props}
+      />
+    );
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [
+      {
+        name: 'with-3-sections-5-items',
+        description: 'SectionList with 3 sections × 5 items each',
+        run: () => this.measureWithSections(sections3x5),
+      },
+      {
+        name: 'with-5-sections-10-items',
+        description: 'SectionList with 5 sections × 10 items each',
+        run: () => this.measureWithSections(sections5x10),
+      },
+      {
+        name: 'with-10-sections-20-items',
+        description: 'SectionList with 10 sections × 20 items each (200 total)',
+        run: () => this.measureWithSections(sections10x20),
+      },
+      {
+        name: 'with-20-sections-10-items',
+        description: 'SectionList with 20 sections × 10 items each (200 total)',
+        run: () => this.measureWithSections(sections20x10),
+      },
+      {
+        name: 'with-section-separator',
+        description: 'SectionList with SectionSeparatorComponent',
+        run: () => this.measureWithSectionSeparator(),
+      },
+      {
+        name: 'with-item-separator',
+        description: 'SectionList with ItemSeparatorComponent',
+        run: () => this.measureWithItemSeparator(),
+      },
+      {
+        name: 'with-header-footer',
+        description:
+          'SectionList with ListHeaderComponent and ListFooterComponent',
+        run: () => this.measureWithHeaderFooter(),
+      },
+      {
+        name: 'with-section-footer',
+        description: 'SectionList with renderSectionFooter',
+        run: () => this.measureWithSectionFooter(),
+      },
+      {
+        name: 'with-sticky-section-headers',
+        description: 'SectionList with stickySectionHeadersEnabled',
+        run: () => this.measureWithStickySectionHeaders(),
+      },
+      {
+        name: 'with-empty-list',
+        description: 'SectionList with empty sections and ListEmptyComponent',
+        run: () => this.measureWithEmptyList(),
+      },
+      {
+        name: 'with-50-sections-20-items',
+        description:
+          'SectionList with 50 sections × 20 items each (1000 total, stress gate)',
+        run: () => this.measureWithSections(sections50x20),
+      },
+    ];
+  }
+
+  private async measureWithSections(
+    sections: SectionType[],
+  ): Promise<PerfMetrics> {
+    const totalItems = sections.reduce((sum, s) => sum + s.data.length, 0);
+    return measurePerf(
+      <SectionList
+        testID={this.testId}
+        sections={sections}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        style={styles.default}
+      />,
+      {
+        name: `${this.componentName} with-${sections.length}-sections-${totalItems}-items`,
+        runs: 10,
+      },
+    );
+  }
+
+  private async measureWithSectionSeparator(): Promise<PerfMetrics> {
+    return measurePerf(
+      <SectionList
+        testID={this.testId}
+        sections={sections5x10}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        SectionSeparatorComponent={() => (
+          <View style={styles.sectionSeparator} />
+        )}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-section-separator`, runs: 10},
+    );
+  }
+
+  private async measureWithItemSeparator(): Promise<PerfMetrics> {
+    return measurePerf(
+      <SectionList
+        testID={this.testId}
+        sections={sections5x10}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-item-separator`, runs: 10},
+    );
+  }
+
+  private async measureWithHeaderFooter(): Promise<PerfMetrics> {
+    return measurePerf(
+      <SectionList
+        testID={this.testId}
+        sections={sections5x10}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        ListHeaderComponent={
+          <View style={styles.listHeader}>
+            <Text>List Header</Text>
+          </View>
+        }
+        ListFooterComponent={
+          <View style={styles.listFooter}>
+            <Text>List Footer</Text>
+          </View>
+        }
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-header-footer`, runs: 10},
+    );
+  }
+
+  private async measureWithSectionFooter(): Promise<PerfMetrics> {
+    return measurePerf(
+      <SectionList
+        testID={this.testId}
+        sections={sections5x10}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        renderSectionFooter={({section}) => (
+          <View style={styles.sectionFooter}>
+            <Text>{`${section.data.length} items`}</Text>
+          </View>
+        )}
+        keyExtractor={keyExtractor}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-section-footer`, runs: 10},
+    );
+  }
+
+  private async measureWithStickySectionHeaders(): Promise<PerfMetrics> {
+    return measurePerf(
+      <SectionList
+        testID={this.testId}
+        sections={sections5x10}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        stickySectionHeadersEnabled={true}
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-sticky-section-headers`, runs: 10},
+    );
+  }
+
+  private async measureWithEmptyList(): Promise<PerfMetrics> {
+    return measurePerf(
+      <SectionList
+        testID={this.testId}
+        sections={[]}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        keyExtractor={keyExtractor}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text>No sections to display</Text>
+          </View>
+        }
+        style={styles.default}
+      />,
+      {name: `${this.componentName} with-empty-list`, runs: 10},
+    );
+  }
+}
+
+const sectionListPerfTest = new SectionListPerfTest();
+
+describe('SectionList Performance', () => {
+  test('mount time', async () => {
+    const perf = await sectionListPerfTest.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await sectionListPerfTest.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await sectionListPerfTest.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  describe('SectionList-Specific Scenarios', () => {
+    const scenarios = sectionListPerfTest.getCustomScenarios();
+
+    test('with-3-sections-5-items', async () => {
+      const perf = await scenarios[0].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-5-sections-10-items', async () => {
+      const perf = await scenarios[1].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-10-sections-20-items', async () => {
+      const perf = await scenarios[2].run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 10,
+      });
+    });
+
+    test('with-20-sections-10-items', async () => {
+      const perf = await scenarios[3].run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 15,
+        minAbsoluteDelta: 10,
+      });
+    });
+
+    test('with-section-separator', async () => {
+      const perf = await scenarios[4].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-item-separator', async () => {
+      const perf = await scenarios[5].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-header-footer', async () => {
+      const perf = await scenarios[6].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-section-footer', async () => {
+      const perf = await scenarios[7].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-sticky-section-headers', async () => {
+      const perf = await scenarios[8].run();
+      expect(perf).toMatchPerfSnapshot({minAbsoluteDelta: 5});
+    });
+
+    test('with-empty-list', async () => {
+      const perf = await scenarios[9].run();
+      expect(perf).toMatchPerfSnapshot();
+    });
+
+    test('with-50-sections-20-items', async () => {
+      const perf = await scenarios[10].run();
+      expect(perf).toMatchPerfSnapshot({
+        maxDurationIncrease: 10,
+        minAbsoluteDelta: 10,
+        mode: 'gate',
+      });
+    });
+  });
+});
+
+const styles = StyleSheet.create({
+  default: {
+    height: 300,
+  },
+  item: {
+    padding: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#ccc',
+  },
+  sectionHeader: {
+    padding: 8,
+    backgroundColor: '#f0f0f0',
+  },
+  sectionHeaderText: {
+    fontWeight: 'bold',
+  },
+  sectionFooter: {
+    padding: 6,
+    backgroundColor: '#fafafa',
+  },
+  sectionSeparator: {
+    height: 2,
+    backgroundColor: '#999',
+  },
+  itemSeparator: {
+    height: 1,
+    backgroundColor: '#ddd',
+  },
+  listHeader: {
+    padding: 10,
+    backgroundColor: '#e0e0e0',
+  },
+  listFooter: {
+    padding: 10,
+    backgroundColor: '#e0e0e0',
+  },
+  empty: {
+    padding: 20,
+    alignItems: 'center',
+  },
+});

--- a/packages/e2e-test-app-fabric/test/__perf__/list/__perf_snapshots__/FlatList.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/list/__perf_snapshots__/FlatList.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,269 @@
+{
+  "FlatList Performance mount time 1": {
+    "metrics": {
+      "name": "FlatList mount",
+      "meanDuration": 4.1,
+      "medianDuration": 4,
+      "stdDev": 0.7378647873726218,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:02.646Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:02.665Z"
+  },
+  "FlatList Performance unmount time 1": {
+    "metrics": {
+      "name": "FlatList unmount",
+      "meanDuration": 0,
+      "medianDuration": 0,
+      "stdDev": 0,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:02.723Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:02.725Z"
+  },
+  "FlatList Performance rerender time 1": {
+    "metrics": {
+      "name": "FlatList rerender",
+      "meanDuration": 9.5,
+      "medianDuration": 9,
+      "stdDev": 1.5811388300841898,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:02.839Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:02.842Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-10-items 1": {
+    "metrics": {
+      "name": "FlatList with-10-items",
+      "meanDuration": 4.6,
+      "medianDuration": 4,
+      "stdDev": 1.2649110640673518,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:02.902Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:02.905Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-100-items 1": {
+    "metrics": {
+      "name": "FlatList with-100-items",
+      "meanDuration": 4.7,
+      "medianDuration": 5,
+      "stdDev": 0.6749485577105528,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:02.964Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:02.966Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-500-items 1": {
+    "metrics": {
+      "name": "FlatList with-500-items",
+      "meanDuration": 4.3,
+      "medianDuration": 4,
+      "stdDev": 0.6749485577105528,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.026Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.029Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios horizontal 1": {
+    "metrics": {
+      "name": "FlatList horizontal",
+      "meanDuration": 4.8,
+      "medianDuration": 5,
+      "stdDev": 1.7511900715418263,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.149Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.151Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-separator 1": {
+    "metrics": {
+      "name": "FlatList with-separator",
+      "meanDuration": 1.6,
+      "medianDuration": 2,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.179Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.181Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-header-footer 1": {
+    "metrics": {
+      "name": "FlatList with-header-footer",
+      "meanDuration": 1.9,
+      "medianDuration": 2,
+      "stdDev": 1.1972189997378648,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.210Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.212Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-empty-list 1": {
+    "metrics": {
+      "name": "FlatList with-empty-list",
+      "meanDuration": 0.5,
+      "medianDuration": 0.5,
+      "stdDev": 0.5270462766947299,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.222Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.235Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-get-item-layout 1": {
+    "metrics": {
+      "name": "FlatList with-get-item-layout",
+      "meanDuration": 1.3,
+      "medianDuration": 1,
+      "stdDev": 0.48304589153964794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.259Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.262Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios inverted 1": {
+    "metrics": {
+      "name": "FlatList inverted",
+      "meanDuration": 1.9,
+      "medianDuration": 1.5,
+      "stdDev": 1.5238839267549946,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.288Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.290Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-num-columns 1": {
+    "metrics": {
+      "name": "FlatList with-num-columns",
+      "meanDuration": 2.8,
+      "medianDuration": 3,
+      "stdDev": 0.9189365834726815,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.331Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:03.333Z"
+  },
+  "FlatList Performance FlatList-Specific Scenarios with-1000-items 1": {
+    "metrics": {
+      "name": "FlatList with-1000-items",
+      "meanDuration": 4.5,
+      "medianDuration": 4,
+      "stdDev": 0.7071067811865476,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:03.088Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:03.090Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/list/__perf_snapshots__/SectionList.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/list/__perf_snapshots__/SectionList.perf-test.tsx.perf-baseline.json
@@ -1,0 +1,269 @@
+{
+  "SectionList Performance mount time 1": {
+    "metrics": {
+      "name": "SectionList mount",
+      "meanDuration": 4.9,
+      "medianDuration": 5,
+      "stdDev": 0.5676462121975466,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.236Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.260Z"
+  },
+  "SectionList Performance unmount time 1": {
+    "metrics": {
+      "name": "SectionList unmount",
+      "meanDuration": 0.1,
+      "medianDuration": 0,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 0,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.332Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.335Z"
+  },
+  "SectionList Performance rerender time 1": {
+    "metrics": {
+      "name": "SectionList rerender",
+      "meanDuration": 11.6,
+      "medianDuration": 10.5,
+      "stdDev": 2.8751811537130436,
+      "renderCount": 2,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.486Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.488Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-3-sections-5-items 1": {
+    "metrics": {
+      "name": "SectionList with-3-sections-15-items",
+      "meanDuration": 5.7,
+      "medianDuration": 5.5,
+      "stdDev": 1.3374935098492586,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.560Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.563Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-5-sections-10-items 1": {
+    "metrics": {
+      "name": "SectionList with-5-sections-50-items",
+      "meanDuration": 6.1,
+      "medianDuration": 6,
+      "stdDev": 1.1972189997378648,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.639Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.643Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-10-sections-20-items 1": {
+    "metrics": {
+      "name": "SectionList with-10-sections-200-items",
+      "meanDuration": 5.5,
+      "medianDuration": 5.5,
+      "stdDev": 0.5270462766947299,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.714Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.716Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-20-sections-10-items 1": {
+    "metrics": {
+      "name": "SectionList with-20-sections-200-items",
+      "meanDuration": 4.6,
+      "medianDuration": 5,
+      "stdDev": 1.6465452046971292,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.778Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.780Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-section-separator 1": {
+    "metrics": {
+      "name": "SectionList with-section-separator",
+      "meanDuration": 2,
+      "medianDuration": 2,
+      "stdDev": 0.4714045207910317,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.808Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.810Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-item-separator 1": {
+    "metrics": {
+      "name": "SectionList with-item-separator",
+      "meanDuration": 2.5,
+      "medianDuration": 2,
+      "stdDev": 0.97182531580755,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.845Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.848Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-header-footer 1": {
+    "metrics": {
+      "name": "SectionList with-header-footer",
+      "meanDuration": 2.1,
+      "medianDuration": 2,
+      "stdDev": 0.31622776601683794,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.878Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.880Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-section-footer 1": {
+    "metrics": {
+      "name": "SectionList with-section-footer",
+      "meanDuration": 2.1,
+      "medianDuration": 2,
+      "stdDev": 0.5676462121975469,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.909Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.911Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-sticky-section-headers 1": {
+    "metrics": {
+      "name": "SectionList with-sticky-section-headers",
+      "meanDuration": 2.4,
+      "medianDuration": 2,
+      "stdDev": 1.2649110640673518,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.942Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.945Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-empty-list 1": {
+    "metrics": {
+      "name": "SectionList with-empty-list",
+      "meanDuration": 0.6,
+      "medianDuration": 1,
+      "stdDev": 0.5163977794943223,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.954Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 3,
+      "maxRenderCount": 5,
+      "minRuns": 10
+    },
+    "capturedAt": "2026-02-25T08:49:01.964Z"
+  },
+  "SectionList Performance SectionList-Specific Scenarios with-50-sections-20-items 1": {
+    "metrics": {
+      "name": "SectionList with-50-sections-1000-items",
+      "meanDuration": 1.8,
+      "medianDuration": 2,
+      "stdDev": 0.4216370213557839,
+      "renderCount": 1,
+      "runs": 10,
+      "timestamp": "2026-02-25T08:49:01.990Z"
+    },
+    "threshold": {
+      "maxDurationIncrease": 10,
+      "maxDuration": null,
+      "minAbsoluteDelta": 10,
+      "maxRenderCount": 5,
+      "minRuns": 10,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-02-25T08:49:01.992Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
@@ -4142,6 +4142,87 @@ exports[`Home UIA Tree Dump Native Animated Example 1`] = `
 }
 `;
 
+exports[`Home UIA Tree Dump Native Perf Benchmark 1`] = `
+{
+  "Automation Tree": {
+    "AutomationId": "Native Perf Benchmark",
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Native Perf Benchmark Measures native rendering pipeline via performance.mark/measure.",
+    "__Children": [
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "LocalizedControlType": "text",
+        "Name": "Native Perf Benchmark",
+        "TextRangePattern.GetText": "Native Perf Benchmark",
+      },
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "LocalizedControlType": "text",
+        "Name": "Measures native rendering pipeline via performance.mark/measure.",
+        "TextRangePattern.GetText": "Measures native rendering pipeline via performance.mark/measure.",
+      },
+    ],
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Native Perf Benchmark Measures native rendering pipeline via performance.mark/measure.",
+      "TestId": "Native Perf Benchmark",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
+  },
+  "Visual Tree": {
+    "Brush": {
+      "Brush Type": "ColorBrush",
+      "Color": "rgba(255, 255, 255, 255)",
+    },
+    "Comment": "Native Perf Benchmark",
+    "Offset": "0, 0, 0",
+    "Size": "966, 77",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "16, 16, 0",
+        "Size": "180, 25",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "180, 25",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "16, 45, 0",
+        "Size": "934, 17",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "934, 17",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`Home UIA Tree Dump New App Screen 1`] = `
 {
   "Automation Tree": {

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -34199,6 +34199,150 @@ exports[`snapshotAllPages Native Animated Example 14`] = `
 </View>
 `;
 
+exports[`snapshotAllPages Native Perf Benchmark 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+      "padding": 8,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "gap": 8,
+        "marginBottom": 8,
+      }
+    }
+  >
+    <TextInput
+      onChangeText={[Function]}
+      placeholder="Component name"
+      style={
+        {
+          "borderColor": "#ccc",
+          "borderWidth": 1,
+          "fontSize": 14,
+          "minWidth": 100,
+          "padding": 6,
+        }
+      }
+      testID="perf-component-input"
+      value="View"
+    />
+    <TextInput
+      keyboardType="numeric"
+      onChangeText={[Function]}
+      placeholder="Runs"
+      style={
+        {
+          "borderColor": "#ccc",
+          "borderWidth": 1,
+          "fontSize": 14,
+          "minWidth": 100,
+          "padding": 6,
+        }
+      }
+      testID="perf-runs-input"
+      value="15"
+    />
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "multiselectable": undefined,
+          "readOnly": undefined,
+          "required": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      disabled={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "backgroundColor": "#0078D4",
+          "borderRadius": 4,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        }
+      }
+      testID="perf-run-btn"
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontWeight": "bold",
+          }
+        }
+      >
+        Run Benchmark
+      </Text>
+    </View>
+  </View>
+  <Text
+    style={
+      {
+        "color": "#666",
+        "fontSize": 12,
+        "marginBottom": 4,
+      }
+    }
+    testID="perf-status"
+  >
+    idle
+  </Text>
+  <View
+    style={
+      {
+        "borderColor": "#eee",
+        "borderWidth": 1,
+        "marginBottom": 8,
+        "minHeight": 100,
+      }
+    }
+  />
+  <Text
+    style={
+      {
+        "color": "#333",
+        "fontFamily": "monospace",
+        "fontSize": 10,
+      }
+    }
+    testID="perf-results"
+  />
+</View>
+`;
+
 exports[`snapshotAllPages PanResponder Sample 1`] = `
 <View
   style={

--- a/packages/e2e-test-app-fabric/tsconfig.json
+++ b/packages/e2e-test-app-fabric/tsconfig.json
@@ -5,7 +5,9 @@
   },
   "include": [
     "app",
-    "test", "index.js",
+    "test",
+    "index.js",
+    "jest.perf.setup.ts"
   ],
   "exclude": [
     "node_modules"

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -1,0 +1,357 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Compare perf test results from the current (head) run against
+ * committed baselines from the base branch. Produces a markdown
+ * comparison report and exits with non-zero if regressions detected.
+ *
+ * Usage:
+ *   node vnext/Scripts/perf/compare-results.js [options]
+ *
+ * Options:
+ *   --results <path>    Path to CI results JSON (default: .perf-results/results.json)
+ *   --baselines <dir>   Path to base branch perf snapshots directory
+ *   --output <path>     Path to write markdown report (default: .perf-results/report.md)
+ *   --fail-on-regression  Exit 1 if regressions found (default: true in CI)
+ *
+ * @format
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = {
+    results: '.perf-results/results.json',
+    baselines: null, // auto-detect from test file paths
+    output: '.perf-results/report.md',
+    failOnRegression: !!process.env.CI,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--results':
+        opts.results = args[++i];
+        break;
+      case '--baselines':
+        opts.baselines = args[++i];
+        break;
+      case '--output':
+        opts.output = args[++i];
+        break;
+      case '--fail-on-regression':
+        opts.failOnRegression = true;
+        break;
+      case '--no-fail-on-regression':
+        opts.failOnRegression = false;
+        break;
+    }
+  }
+  return opts;
+}
+
+function getSnapshotPath(testFilePath) {
+  const dir = path.dirname(testFilePath);
+  const basename = path.basename(testFilePath);
+  return path.join(dir, '__perf_snapshots__', `${basename}.perf-baseline.json`);
+}
+
+function loadSnapshot(filePath) {
+  if (fs.existsSync(filePath)) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  }
+  return {};
+}
+
+const DEFAULT_THRESHOLD = {
+  maxDurationIncrease: 10,
+  maxDuration: Infinity,
+  minAbsoluteDelta: 3,
+  maxRenderCount: 5,
+  minRuns: 10,
+};
+
+function resolveThreshold(threshold) {
+  return {
+    ...DEFAULT_THRESHOLD,
+    ...threshold,
+    // JSON.stringify(Infinity) === 'null', so restore it
+    maxDuration:
+      threshold.maxDuration === null || threshold.maxDuration === undefined
+        ? Infinity
+        : threshold.maxDuration,
+  };
+}
+
+function compareEntry(head, base, threshold) {
+  // median for comparison
+  const percentChange =
+    base.medianDuration > 0
+      ? ((head.medianDuration - base.medianDuration) / base.medianDuration) *
+        100
+      : head.medianDuration > 0
+        ? Infinity
+        : 0;
+
+  const errors = [];
+
+  const absoluteDelta = head.medianDuration - base.medianDuration;
+  const minAbsoluteDelta =
+    threshold.minAbsoluteDelta ?? DEFAULT_THRESHOLD.minAbsoluteDelta;
+  if (
+    percentChange > threshold.maxDurationIncrease &&
+    absoluteDelta > minAbsoluteDelta
+  ) {
+    errors.push(
+      `Duration increased by ${percentChange.toFixed(1)}% / +${absoluteDelta.toFixed(2)}ms (threshold: ${threshold.maxDurationIncrease}% & ${minAbsoluteDelta}ms)`,
+    );
+  }
+  if (head.medianDuration > threshold.maxDuration) {
+    errors.push(
+      `Duration ${head.medianDuration.toFixed(2)}ms exceeds max ${threshold.maxDuration}ms`,
+    );
+  }
+  if (head.renderCount > threshold.maxRenderCount) {
+    errors.push(
+      `Render count ${head.renderCount} exceeds max ${threshold.maxRenderCount}`,
+    );
+  }
+
+  return {
+    name: head.name,
+    head,
+    base,
+    percentChange,
+    passed: errors.length === 0,
+    errors,
+  };
+}
+
+function compareSuite(suiteName, headSnaps, baseSnaps) {
+  const results = [];
+
+  for (const [key, headEntry] of Object.entries(headSnaps)) {
+    const baseEntry = baseSnaps[key];
+    const threshold = resolveThreshold({
+      ...DEFAULT_THRESHOLD,
+      ...(headEntry.threshold || {}),
+    });
+
+    if (!baseEntry) {
+      results.push({
+        name: headEntry.metrics.name,
+        head: headEntry.metrics,
+        base: null,
+        percentChange: null,
+        passed: true,
+        errors: [],
+        isNew: true,
+      });
+      continue;
+    }
+
+    results.push(compareEntry(headEntry.metrics, baseEntry.metrics, threshold));
+  }
+
+  // Detect removed scenarios
+  for (const key of Object.keys(baseSnaps)) {
+    if (!headSnaps[key]) {
+      results.push({
+        name: `[REMOVED] ${baseSnaps[key].metrics.name}`,
+        head: null,
+        base: baseSnaps[key].metrics,
+        percentChange: null,
+        passed: true,
+        errors: [],
+        isRemoved: true,
+      });
+    }
+  }
+
+  return {suiteName, results, hasRegressions: results.some(r => !r.passed)};
+}
+
+function generateMarkdown(suiteComparisons, ciResults) {
+  let md = '## ⚡ Performance Test Results\n\n';
+
+  md += `**Branch:** \`${ciResults.branch}\`  \n`;
+  md += `**Commit:** \`${ciResults.commitSha.slice(0, 8)}\`  \n`;
+  md += `**Time:** ${ciResults.timestamp}  \n`;
+  md += `**Tests:** ${ciResults.summary.passed}/${ciResults.summary.totalTests} passed  \n\n`;
+
+  const allRegressions = suiteComparisons.filter(s => s.hasRegressions);
+  if (allRegressions.length > 0) {
+    md += '### ❌ Regressions Detected\n\n';
+    for (const suite of allRegressions) {
+      md += `#### ${suite.suiteName}\n\n`;
+      md += '| Scenario | Baseline | Current | Change | Status |\n';
+      md += '|----------|----------|---------|--------|--------|\n';
+      for (const r of suite.results.filter(x => !x.passed)) {
+        const baseline = r.base ? `${r.base.meanDuration.toFixed(2)}ms` : 'N/A';
+        const current = r.head ? `${r.head.meanDuration.toFixed(2)}ms` : 'N/A';
+        const change =
+          r.percentChange != null ? `+${r.percentChange.toFixed(1)}%` : 'N/A';
+        md += `| ${r.name} | ${baseline} | ${current} | ${change} | ❌ |\n`;
+      }
+      md += '\n';
+      for (const r of suite.results.filter(x => !x.passed)) {
+        if (r.errors.length > 0) {
+          md += `> **${r.name}:** ${r.errors.join('; ')}  \n`;
+        }
+      }
+      md += '\n';
+    }
+  }
+
+  // Passed suites
+  const passedSuites = suiteComparisons.filter(s => !s.hasRegressions);
+  if (passedSuites.length > 0) {
+    md += '### ✅ Passed\n\n';
+    md += '<details>\n<summary>';
+    const totalPassed = passedSuites.reduce(
+      (acc, s) => acc + s.results.length,
+      0,
+    );
+    md += `${totalPassed} scenario(s) across ${passedSuites.length} suite(s) — no regressions`;
+    md += '</summary>\n\n';
+
+    for (const suite of passedSuites) {
+      md += `#### ${suite.suiteName}\n\n`;
+      md += '| Scenario | Mean | Median | StdDev | Renders | vs Baseline |\n';
+      md += '|----------|------|--------|--------|---------|-------------|\n';
+      for (const r of suite.results) {
+        if (!r.head) continue;
+        const change =
+          r.percentChange != null
+            ? `${r.percentChange >= 0 ? '+' : ''}${r.percentChange.toFixed(1)}%`
+            : 'new';
+        md +=
+          `| ${r.name}` +
+          ` | ${r.head.meanDuration.toFixed(2)}ms` +
+          ` | ${r.head.medianDuration.toFixed(2)}ms` +
+          ` | ±${r.head.stdDev.toFixed(2)}ms` +
+          ` | ${r.head.renderCount}` +
+          ` | ${change} |\n`;
+      }
+      md += '\n';
+    }
+    md += '</details>\n';
+  }
+
+  // New scenarios
+  const allNew = suiteComparisons.flatMap(s => s.results.filter(r => r.isNew));
+  if (allNew.length > 0) {
+    md += '\n### 🆕 New Scenarios\n\n';
+    md += `${allNew.length} new scenario(s) added (no baseline comparison).  \n`;
+    md +=
+      'These will become baselines after merge. Run `yarn perf:update` to capture locally.\n';
+  }
+
+  return md;
+}
+
+function main() {
+  const opts = parseArgs();
+
+  // 1. Load CI results JSON
+  if (!fs.existsSync(opts.results)) {
+    console.error(`❌ Results file not found: ${opts.results}`);
+    console.error('Run perf tests with CI=true first: CI=true yarn perf:ci');
+    process.exit(1);
+  }
+
+  const ciResults = JSON.parse(fs.readFileSync(opts.results, 'utf-8'));
+  console.log(
+    `📊 Loaded ${ciResults.suites.length} suite(s) from ${opts.results}`,
+  );
+
+  // 2. Compare each suite against its committed baseline
+  const suiteComparisons = [];
+
+  for (const suite of ciResults.suites) {
+    // Head snapshots come from the CI run
+    const headSnaps = suite.snapshots || {};
+
+    // Base snapshots come from the committed .perf.snap files
+    // In CI, the base branch is checked out into a separate dir,
+    // or we read the committed snapshots from the test file path
+    let baseSnapPath;
+    if (opts.baselines) {
+      // Explicit baseline directory — look for matching snap file
+      const relPath = path.relative(process.cwd(), suite.testFilePath);
+      baseSnapPath = path.join(
+        opts.baselines,
+        path.dirname(relPath),
+        '__perf_snapshots__',
+        `${path.basename(suite.testFilePath)}.perf.snap`,
+      );
+    } else {
+      // Default: baselines live adjacent to test files (committed in repo)
+      baseSnapPath = getSnapshotPath(suite.testFilePath);
+    }
+
+    const baseSnaps = loadSnapshot(baseSnapPath);
+    console.log(
+      `  📋 ${suite.suiteName}: ${Object.keys(headSnaps).length} head / ${Object.keys(baseSnaps).length} base snapshots`,
+    );
+
+    suiteComparisons.push(compareSuite(suite.suiteName, headSnaps, baseSnaps));
+  }
+
+  // 3. Generate markdown report
+  const markdown = generateMarkdown(suiteComparisons, ciResults);
+
+  const outputDir = path.dirname(opts.output);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true});
+  }
+  fs.writeFileSync(opts.output, markdown, 'utf-8');
+  console.log(`\n📝 Report written to ${opts.output}`);
+
+  // 4. Also write a machine-readable summary
+  const summaryPath = opts.output.replace(/\.md$/, '.json');
+  const summaryData = {
+    hasRegressions: suiteComparisons.some(s => s.hasRegressions),
+    totalSuites: suiteComparisons.length,
+    totalScenarios: suiteComparisons.reduce(
+      (acc, s) => acc + s.results.length,
+      0,
+    ),
+    regressions: suiteComparisons.flatMap(s =>
+      s.results
+        .filter(r => !r.passed)
+        .map(r => ({
+          suite: s.suiteName,
+          scenario: r.name,
+          percentChange: r.percentChange,
+          errors: r.errors,
+        })),
+    ),
+  };
+  fs.writeFileSync(summaryPath, JSON.stringify(summaryData, null, 2) + '\n');
+
+  // 5. Print summary
+  const hasRegressions = suiteComparisons.some(s => s.hasRegressions);
+  if (hasRegressions) {
+    const count = summaryData.regressions.length;
+    console.error(`\n❌ ${count} regression(s) detected!`);
+    for (const reg of summaryData.regressions) {
+      console.error(
+        `  - ${reg.suite} / ${reg.scenario}: ${reg.errors.join('; ')}`,
+      );
+    }
+    if (opts.failOnRegression) {
+      process.exit(1);
+    }
+  } else {
+    console.log(
+      `\n✅ All ${summaryData.totalScenarios} scenarios passed — no regressions.`,
+    );
+  }
+}
+
+main();

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -176,7 +176,7 @@ function compareSuite(suiteName, headSnaps, baseSnaps) {
 }
 
 function generateMarkdown(suiteComparisons, ciResults) {
-  let md = '## ⚡ Performance Test Results\n\n';
+  let md = '## Performance Test Results\n\n';
 
   md += `**Branch:** \`${ciResults.branch}\`  \n`;
   md += `**Commit:** \`${ciResults.commitSha.slice(0, 8)}\`  \n`;

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -10,7 +10,7 @@
  *   node vnext/Scripts/perf/compare-results.js [options]
  *
  * Options:
- *   --results <path>    Path to CI results JSON (default: .perf-results/results.json)
+ *   --results <path>    Path to CI results JSON (repeatable, default: .perf-results/results.json)
  *   --baselines <dir>   Path to base branch perf snapshots directory
  *   --output <path>     Path to write markdown report (default: .perf-results/report.md)
  *   --fail-on-regression  Exit 1 if regressions found (default: true in CI)
@@ -25,17 +25,29 @@ const path = require('path');
 
 function parseArgs() {
   const args = process.argv.slice(2);
+
+  // Auto-discover results files: JS perf + native perf
+  const defaultResults = [
+    '.perf-results/results.json',
+    '.native-perf-results/results.json',
+  ].filter(p => fs.existsSync(p));
+
   const opts = {
-    results: '.perf-results/results.json',
+    results: defaultResults,
     baselines: null, // auto-detect from test file paths
     output: '.perf-results/report.md',
     failOnRegression: !!process.env.CI,
   };
 
+  let explicitResults = false;
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case '--results':
-        opts.results = args[++i];
+        if (!explicitResults) {
+          opts.results = [];
+          explicitResults = true;
+        }
+        opts.results.push(args[++i]);
         break;
       case '--baselines':
         opts.baselines = args[++i];
@@ -257,17 +269,41 @@ function generateMarkdown(suiteComparisons, ciResults) {
 function main() {
   const opts = parseArgs();
 
-  // 1. Load CI results JSON
-  if (!fs.existsSync(opts.results)) {
-    console.error(`❌ Results file not found: ${opts.results}`);
+  // 1. Load CI results JSON (supports multiple --results paths)
+  const ciResults = {
+    suites: [],
+    branch: '',
+    commitSha: '',
+    timestamp: '',
+    summary: {
+      totalSuites: 0,
+      totalTests: 0,
+      passed: 0,
+      failed: 0,
+      durationMs: 0,
+    },
+  };
+  const resultsPaths = opts.results.filter(p => fs.existsSync(p));
+  if (resultsPaths.length === 0) {
+    console.error(`❌ No results files found: ${opts.results.join(', ')}`);
     console.error('Run perf tests with CI=true first: CI=true yarn perf:ci');
     process.exit(1);
   }
-
-  const ciResults = JSON.parse(fs.readFileSync(opts.results, 'utf-8'));
-  console.log(
-    `📊 Loaded ${ciResults.suites.length} suite(s) from ${opts.results}`,
-  );
+  for (const resultsPath of resultsPaths) {
+    const partial = JSON.parse(fs.readFileSync(resultsPath, 'utf-8'));
+    ciResults.suites.push(...(partial.suites || []));
+    ciResults.branch = ciResults.branch || partial.branch;
+    ciResults.commitSha = ciResults.commitSha || partial.commitSha;
+    ciResults.timestamp = ciResults.timestamp || partial.timestamp;
+    ciResults.summary.totalSuites += partial.summary?.totalSuites || 0;
+    ciResults.summary.totalTests += partial.summary?.totalTests || 0;
+    ciResults.summary.passed += partial.summary?.passed || 0;
+    ciResults.summary.failed += partial.summary?.failed || 0;
+    ciResults.summary.durationMs += partial.summary?.durationMs || 0;
+    console.log(
+      `📊 Loaded ${partial.suites.length} suite(s) from ${resultsPath}`,
+    );
+  }
 
   // 2. Compare each suite against its committed baseline
   const suiteComparisons = [];

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -110,6 +110,7 @@ function compareEntry(head, base, threshold) {
         : 0;
 
   const errors = [];
+  const isTrackMode = threshold.mode === 'track';
 
   const absoluteDelta = head.medianDuration - base.medianDuration;
   const minAbsoluteDelta =
@@ -138,8 +139,9 @@ function compareEntry(head, base, threshold) {
     head,
     base,
     percentChange,
-    passed: errors.length === 0,
+    passed: isTrackMode || errors.length === 0,
     errors,
+    isTrackMode,
   };
 }
 
@@ -217,6 +219,24 @@ function generateMarkdown(suiteComparisons, ciResults) {
       }
       md += '\n';
     }
+  }
+
+  // Track-mode warnings (not blocking)
+  const trackedWarnings = suiteComparisons.flatMap(s =>
+    s.results.filter(r => r.isTrackMode && r.errors.length > 0),
+  );
+  if (trackedWarnings.length > 0) {
+    md += '### ⚠️ Tracked (not blocking)\n\n';
+    md += '| Scenario | Baseline | Current | Change |\n';
+    md += '|----------|----------|---------|--------|\n';
+    for (const r of trackedWarnings) {
+      const baseline = r.base ? `${r.base.meanDuration.toFixed(2)}ms` : 'N/A';
+      const current = r.head ? `${r.head.meanDuration.toFixed(2)}ms` : 'N/A';
+      const change =
+        r.percentChange != null ? `+${r.percentChange.toFixed(1)}%` : 'N/A';
+      md += `| ${r.name} | ${baseline} | ${current} | ${change} |\n`;
+    }
+    md += '\n';
   }
 
   // Passed suites

--- a/vnext/Scripts/perf/create-perf-test.js
+++ b/vnext/Scripts/perf/create-perf-test.js
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Interactive CLI to scaffold a new component performance test.
+ *
+ * Usage:
+ *   node vnext/Scripts/perf/create-perf-test.js
+ *   yarn perf:create           (from e2e-test-app-fabric)
+ *
+ * Generates a `.perf-test.tsx` file with:
+ *   - Class extending ComponentPerfTestBase
+ *   - Standard mount / unmount / rerender tests
+ *   - Placeholder for custom scenarios
+ *   - Correct imports, test ID, and category
+ *
+ * @format
+ */
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+function ask(rl, question, defaultValue) {
+  const suffix = defaultValue ? ` (${defaultValue})` : '';
+  return new Promise(resolve => {
+    rl.question(`${question}${suffix}: `, answer => {
+      resolve(answer.trim() || defaultValue || '');
+    });
+  });
+}
+
+function choose(rl, question, options, defaultIndex = 0) {
+  return new Promise(resolve => {
+    console.log(`\n${question}`);
+    options.forEach((opt, i) => {
+      const marker = i === defaultIndex ? ' (default)' : '';
+      console.log(`  ${i + 1}. ${opt}${marker}`);
+    });
+    rl.question(`Choice [${defaultIndex + 1}]: `, answer => {
+      const idx = parseInt(answer, 10) - 1;
+      resolve(
+        idx >= 0 && idx < options.length ? options[idx] : options[defaultIndex],
+      );
+    });
+  });
+}
+
+function toPascalCase(str) {
+  return str
+    .replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
+    .replace(/^(.)/, (_, c) => c.toUpperCase());
+}
+
+function toKebabCase(str) {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+/**
+ * Split a props string into individual prop tokens,
+ * correctly handling nested braces like onPress={() => {}}.
+ */
+function splitProps(propsStr) {
+  const props = [];
+  let current = '';
+  let braceDepth = 0;
+  let inString = null; // '"' or "'"
+
+  for (let i = 0; i < propsStr.length; i++) {
+    const ch = propsStr[i];
+
+    // Track string boundaries
+    if ((ch === '"' || ch === "'") && !inString) {
+      inString = ch;
+    } else if (ch === inString) {
+      inString = null;
+    }
+
+    if (!inString) {
+      if (ch === '{') braceDepth++;
+      if (ch === '}') braceDepth--;
+    }
+
+    // Split on whitespace only when outside braces/strings
+    if (ch === ' ' && braceDepth === 0 && !inString) {
+      if (current.trim()) props.push(current.trim());
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) props.push(current.trim());
+  return props;
+}
+
+const CATEGORIES = ['core', 'extended', 'interactive', 'list', 'community'];
+
+const PERF_TEST_ROOT = path.resolve(
+  __dirname,
+  '../../..',
+  'packages/e2e-test-app-fabric/test/__perf__',
+);
+
+// Known required props for common RN components.
+// These are auto-applied so the generated test works out of the box.
+const KNOWN_REQUIRED_PROPS = {
+  Button: 'title="Perf Test" onPress={() => {}}',
+  Switch: 'value={false}',
+  Image: 'source={{uri: "https://example.com/img.png"}}',
+  FlatList: 'data={[]} renderItem={() => null}',
+  SectionList: 'sections={[]} renderItem={() => null}',
+  Modal: 'visible={true}',
+  TouchableHighlight: 'onPress={() => {}}',
+  TouchableOpacity: 'onPress={() => {}}',
+  Pressable: 'onPress={() => {}}',
+};
+
+function generateTestFile({
+  componentName,
+  pascalName,
+  kebabName,
+  importPath,
+  category,
+  hasChildren,
+  childrenText,
+  requiredProps,
+}) {
+  const testId = `perf-test-${kebabName}`;
+  const instanceName = `${pascalName.charAt(0).toLowerCase() + pascalName.slice(1)}PerfTest`;
+
+  const allProps = [`testID={this.testId}`];
+  if (requiredProps) {
+    // Parse individual JSX props, handling nested braces like {() => {}}
+    allProps.push(...splitProps(requiredProps));
+  }
+  allProps.push('style={styles.default}', '{...props}');
+
+  let createComponentBody;
+  if (hasChildren) {
+    const propLines = allProps.map(p => `        ${p}`).join('\n');
+    createComponentBody = `    return (\n      <${componentName}\n${propLines}>\n        ${childrenText}\n      </${componentName}>\n    );`;
+  } else if (allProps.length > 3) {
+    const propLines = allProps.map(p => `        ${p}`).join('\n');
+    createComponentBody = `    return (\n      <${componentName}\n${propLines}\n      />\n    );`;
+  } else {
+    createComponentBody = `    return <${componentName} ${allProps.join(' ')} />;`;
+  }
+
+  return `/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Performance tests for ${componentName} component.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {${componentName}, StyleSheet} from '${importPath}';
+import {
+  ComponentPerfTestBase,
+  measurePerf,
+} from '@react-native-windows/perf-testing';
+import type {IScenario, PerfMetrics} from '@react-native-windows/perf-testing';
+
+class ${pascalName}PerfTest extends ComponentPerfTestBase {
+  readonly componentName = '${componentName}';
+  readonly category = '${category}' as const;
+  readonly testId = '${testId}';
+
+  createComponent(props?: Record<string, unknown>): React.ReactElement {
+${createComponentBody}
+  }
+
+  getCustomScenarios(): IScenario[] {
+    return [];
+  }
+}
+
+const ${instanceName} = new ${pascalName}PerfTest();
+
+describe('${componentName} Performance', () => {
+  test('mount time', async () => {
+    const perf = await ${instanceName}.measureMount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('unmount time', async () => {
+    const perf = await ${instanceName}.measureUnmount();
+    expect(perf).toMatchPerfSnapshot();
+  });
+
+  test('rerender time', async () => {
+    const perf = await ${instanceName}.measureRerender();
+    expect(perf).toMatchPerfSnapshot();
+  });
+});
+
+const styles = StyleSheet.create({
+  default: {
+});
+`;
+}
+
+async function main() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  console.log('\n🧪  React Native Windows — Performance Test Generator\n');
+  console.log('This will create a new .perf-test.tsx file with mount,');
+  console.log('unmount, and rerender tests for your component.\n');
+  console.log('Examples:');
+  console.log(
+    '  Component: ScrollView   | Import: react-native | Category: core     | Children: yes',
+  );
+  console.log(
+    '  Component: Button       | Import: react-native | Category: core     | Children: no',
+  );
+  console.log(
+    '  Component: Image        | Import: react-native | Category: core     | Children: no',
+  );
+  console.log(
+    '  Component: Pressable    | Import: react-native | Category: interactive | Children: yes',
+  );
+  console.log(
+    '  Component: Slider       | Import: @react-native-community/slider | Category: community | Children: no',
+  );
+  console.log('');
+
+  const rawName = await ask(
+    rl,
+    'Component name (e.g. ScrollView, Image, Pressable)',
+  );
+  if (!rawName) {
+    console.error('❌  Component name is required.');
+    rl.close();
+    process.exit(1);
+  }
+
+  const pascalName = toPascalCase(rawName);
+  const kebabName = toKebabCase(rawName);
+
+  const importPath = await ask(
+    rl,
+    'Import path for the component',
+    'react-native',
+  );
+
+  const category = await choose(
+    rl,
+    'Select component category:',
+    CATEGORIES,
+    0,
+  );
+
+  const hasChildrenAnswer = await ask(
+    rl,
+    'Does this component render children? (y/N)',
+    'N',
+  );
+  const hasChildren = hasChildrenAnswer.toLowerCase() === 'y';
+  let childrenText = 'Sample Content';
+  if (hasChildren) {
+    const customChildren = await ask(
+      rl,
+      'Children text/content',
+      'Sample Content',
+    );
+    childrenText = customChildren;
+  }
+
+  let requiredProps = KNOWN_REQUIRED_PROPS[rawName] || '';
+  if (requiredProps) {
+    console.log(`\n  Auto-detected required props: ${requiredProps}`);
+    const override = await ask(
+      rl,
+      'Required props (Enter to accept, or type custom)',
+      requiredProps,
+    );
+    requiredProps = override;
+  } else {
+    const customProps = await ask(
+      rl,
+      'Required props (e.g. title="Test" onPress={() => {}}) – leave blank if none',
+      '',
+    );
+    requiredProps = customProps;
+  }
+
+  rl.close();
+
+  const categoryDir = path.join(PERF_TEST_ROOT, category);
+  if (!fs.existsSync(categoryDir)) {
+    fs.mkdirSync(categoryDir, {recursive: true});
+    console.log(
+      `\n📁  Created directory: ${path.relative(process.cwd(), categoryDir)}`,
+    );
+  }
+
+  const outputFile = path.join(categoryDir, `${pascalName}.perf-test.tsx`);
+  if (fs.existsSync(outputFile)) {
+    console.error(
+      `\n❌  File already exists: ${path.relative(process.cwd(), outputFile)}`,
+    );
+    console.error('    Delete it first or choose a different name.');
+    process.exit(1);
+  }
+
+  const content = generateTestFile({
+    componentName: rawName,
+    pascalName,
+    kebabName,
+    importPath,
+    category,
+    hasChildren,
+    childrenText,
+    requiredProps,
+  });
+
+  fs.writeFileSync(outputFile, content, 'utf8');
+
+  const relPath = path.relative(process.cwd(), outputFile);
+  console.log(`\n✅  Created: ${relPath}`);
+  console.log(`\nNext steps:`);
+  console.log(`  1. Review and customize the generated test file`);
+  console.log(`  2. Add any component-specific custom scenarios`);
+  console.log(`  3. Run:  yarn perf --testPathPattern=${pascalName}`);
+  console.log(
+    `  4. Generate baseline:  yarn perf:update --testPathPattern=${pascalName}`,
+  );
+  console.log('');
+}
+
+main().catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/vnext/Scripts/perf/post-pr-comment.js
+++ b/vnext/Scripts/perf/post-pr-comment.js
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * Post perf test results as a GitHub PR comment.
+ *
+ * Uses the GitHub API to find/update an existing perf comment on the PR,
+ * or create a new one. Designed to be called from GitHub Actions.
+ *
+ * Usage:
+ *   node vnext/Scripts/perf/post-pr-comment.js [options]
+ *
+ * Options:
+ *   --report <path>     Path to markdown report (default: .perf-results/report.md)
+ *   --summary <path>    Path to JSON summary (default: .perf-results/report.json)
+ *   --pr <number>       PR number (default: from GITHUB_EVENT)
+ *   --dry-run           Print the comment but don't post it
+ *
+ * Environment:
+ *   GITHUB_TOKEN        Required for posting comments
+ *   GITHUB_REPOSITORY   e.g. microsoft/react-native-windows
+ *   GITHUB_EVENT_PATH   Path to event.json (auto-set in GH Actions)
+ *
+ * @format
+ */
+
+'use strict';
+
+const fs = require('fs');
+const https = require('https');
+const path = require('path');
+
+const COMMENT_MARKER = '<!-- rnw-perf-results -->';
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = {
+    report: '.perf-results/report.md',
+    summary: '.perf-results/report.json',
+    pr: null,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--report':
+        opts.report = args[++i];
+        break;
+      case '--summary':
+        opts.summary = args[++i];
+        break;
+      case '--pr':
+        opts.pr = parseInt(args[++i], 10);
+        break;
+      case '--dry-run':
+        opts.dryRun = true;
+        break;
+    }
+  }
+
+  // Attempt to detect PR number from GH Actions event
+  if (!opts.pr && process.env.GITHUB_EVENT_PATH) {
+    try {
+      const event = JSON.parse(
+        fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf-8'),
+      );
+      if (event.pull_request) {
+        opts.pr = event.pull_request.number;
+      } else if (event.number) {
+        opts.pr = event.number;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return opts;
+}
+
+function githubRequest(method, apiPath, body) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error('GITHUB_TOKEN environment variable is required');
+  }
+
+  const repo =
+    process.env.GITHUB_REPOSITORY || 'microsoft/react-native-windows';
+
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.github.com',
+      port: 443,
+      path: `/repos/${repo}${apiPath}`,
+      method,
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'rnw-perf-tests',
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const req = https.request(options, res => {
+      let data = '';
+      res.on('data', chunk => (data += chunk));
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(data ? JSON.parse(data) : null);
+        } else {
+          reject(
+            new Error(
+              `GitHub API ${method} ${apiPath} returned ${res.statusCode}: ${data}`,
+            ),
+          );
+        }
+      });
+    });
+
+    req.on('error', reject);
+
+    if (body) {
+      req.write(JSON.stringify(body));
+    }
+    req.end();
+  });
+}
+
+async function findExistingComment(prNumber) {
+  let page = 1;
+  while (true) {
+    const comments = await githubRequest(
+      'GET',
+      `/issues/${prNumber}/comments?per_page=100&page=${page}`,
+    );
+    if (!comments || comments.length === 0) break;
+
+    const existing = comments.find(
+      c => c.body && c.body.includes(COMMENT_MARKER),
+    );
+    if (existing) return existing;
+
+    if (comments.length < 100) break;
+    page++;
+  }
+  return null;
+}
+
+async function main() {
+  const opts = parseArgs();
+
+  // Load markdown report
+  if (!fs.existsSync(opts.report)) {
+    console.error(`❌ Report not found: ${opts.report}`);
+    console.error('Run compare-results.js first.');
+    process.exit(1);
+  }
+
+  const markdown = fs.readFileSync(opts.report, 'utf-8');
+
+  // Load summary for status message
+  let summary = {hasRegressions: false};
+  if (fs.existsSync(opts.summary)) {
+    summary = JSON.parse(fs.readFileSync(opts.summary, 'utf-8'));
+  }
+
+  // Build comment body with hidden marker for idempotent updates
+  const commentBody = `${COMMENT_MARKER}\n${markdown}`;
+
+  if (opts.dryRun) {
+    console.log('=== DRY RUN — would post the following comment ===\n');
+    console.log(commentBody);
+    console.log('\n=== End of comment ===');
+    process.exit(summary.hasRegressions ? 1 : 0);
+  }
+
+  if (!opts.pr) {
+    console.error('❌ Could not determine PR number.');
+    console.error('Use --pr <number> or ensure GITHUB_EVENT_PATH is set.');
+    process.exit(1);
+  }
+
+  console.log(`📤 Posting perf results to PR #${opts.pr}...`);
+
+  try {
+    // Try to update existing comment
+    const existing = await findExistingComment(opts.pr);
+    if (existing) {
+      await githubRequest('PATCH', `/issues/comments/${existing.id}`, {
+        body: commentBody,
+      });
+      console.log(`✅ Updated existing comment (id: ${existing.id})`);
+    } else {
+      await githubRequest('POST', `/issues/${opts.pr}/comments`, {
+        body: commentBody,
+      });
+      console.log('✅ Created new comment');
+    }
+  } catch (err) {
+    console.error(`❌ Failed to post comment: ${err.message}`);
+    // Don't fail the build if commenting fails — the results are in artifacts
+    console.log('Results are still available as workflow artifacts.');
+  }
+
+  process.exit(summary.hasRegressions ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,6 +2078,14 @@
     find-up "^4.1.0"
     minimatch "^10.0.3"
 
+"@react-native-windows/fs@0.82.0-preview.1":
+  version "0.82.0-preview.1"
+  resolved "https://registry.yarnpkg.com/@react-native-windows/fs/-/fs-0.82.0-preview.1.tgz#78dc306c0877807b3c0a6f06bcb377ae7bfc7887"
+  integrity sha512-8nUWpFeLY7vGrsD4Xxroy7EvSkaeDC/YXcvqILBBsoTipiQX4kmtPYGPWJpWOvEGVCLicb3m1U7/0MEpmfZOHA==
+  dependencies:
+    graceful-fs "^4.2.8"
+    minimatch "^10.0.3"
+
 "@react-native-windows/fs@^0.0.0-canary.70":
   version "0.0.0-canary.70"
   resolved "https://registry.yarnpkg.com/@react-native-windows/fs/-/fs-0.0.0-canary.70.tgz#53165cc8f0310be7aebb1bda669ff54ae2298ada"


### PR DESCRIPTION
## Description
Cherry-picks the perf testing infrastructure to 0.82-stable:

86e6a03 — [Fabric]: Performance Tests for React Native Windows (#15666)
464f5bc — Enable perf results PR comment on CI runs (#15748)
e357f62 — Update performance test results markdown header (#15752)
5af19ab — fix(ci): Use workflow_run for perf PR comments to support fork PRs (#15758)
9074f9d — Native perf benchmarking infra for Fabric components (#15772)
855a194 — fix: resolve artifact path mismatch in perf-comment workflow (#15883)
9430a12 — fix: include hidden files in perf artifact upload to restore PR comments (#15893)
ecef157 — fix: respect track mode in compare-results to avoid false regression (#15933)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15992)