### PR TITLE
Port perf tests to 0.83-stable

### DIFF
--- a/.github/workflows/perf-comment.yml
+++ b/.github/workflows/perf-comment.yml
@@ -32,24 +32,27 @@ jobs:
       - name: Read PR number
         id: pr
         run: |
-          if [ ! -f perf-results/pr-number.txt ]; then
+          PR_FILE=$(find perf-results -name pr-number.txt -type f | head -1)
+          if [ -z "$PR_FILE" ]; then
             echo "No PR number file found — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PR_NUMBER=$(cat perf-results/pr-number.txt | tr -d '[:space:]')
+          PR_NUMBER=$(cat "$PR_FILE" | tr -d '[:space:]')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Read markdown report
-        if: steps.pr.outputs.skip != 'true'
         id: report
+        if: steps.pr.outputs.skip != 'true'
         run: |
-          if [ ! -f perf-results/report.md ]; then
+          REPORT_FILE=$(find perf-results -name report.md -type f | head -1)
+          if [ -z "$REPORT_FILE" ]; then
             echo "No report.md found — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "path=$REPORT_FILE" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Post or update PR comment
@@ -59,7 +62,7 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- rnw-perf-results -->';
-            const reportPath = 'perf-results/report.md';
+            const reportPath = '${{ steps.report.outputs.path }}';
             const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
 
             const markdown = fs.readFileSync(reportPath, 'utf-8');

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -27,7 +27,7 @@ jobs:
   perf-tests:
     name: Component Performance Tests
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     permissions:
       contents: read
@@ -49,8 +49,28 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Detect preinstalled Windows SDK
+        id: winsdk
+        shell: pwsh
+        run: |
+          # Find the latest SDK version already installed on the runner
+          $sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\Include"
+          $versions = Get-ChildItem $sdkRoot -Directory | Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } | Sort-Object { [version]$_.Name } -Descending
+          if ($versions.Count -eq 0) {
+            echo "::error::No Windows SDK found on runner"
+            exit 1
+          }
+          $sdk = $versions[0].Name
+          echo "version=$sdk" >> $env:GITHUB_OUTPUT
+          echo "::notice::Using preinstalled Windows SDK $sdk"
+
       - name: Build perf-testing package
         run: yarn workspace @react-native-windows/perf-testing build
+
+      # ── Build & Deploy RNTesterApp-Fabric (for native perf tests) ──
+      - name: Build and deploy RNTesterApp-Fabric
+        working-directory: packages/e2e-test-app-fabric
+        run: yarn windows --release --no-launch --logging --msbuildprops WindowsTargetPlatformVersion=${{ steps.winsdk.outputs.version }}
 
       # ── Run Tests ──────────────────────────────────────────
       - name: Run perf tests
@@ -61,7 +81,14 @@ jobs:
           RN_TARGET_PLATFORM: windows
         run: yarn perf:ci
         continue-on-error: true   # Don't fail here — let comparison decide
-
+      - name: Run native perf tests
+        id: native-perf-run
+        working-directory: packages/e2e-test-app-fabric
+        env:
+          CI: 'true'
+          RN_TARGET_PLATFORM: windows
+        run: yarn perf:native:ci
+        continue-on-error: true
       # ── Compare & Report ───────────────────────────────────
       - name: Compare against baselines
         id: compare
@@ -80,7 +107,9 @@ jobs:
           name: perf-results
           path: |
             packages/e2e-test-app-fabric/.perf-results/
+            packages/e2e-test-app-fabric/.native-perf-results/
             packages/e2e-test-app-fabric/test/__perf__/**/__perf_snapshots__/
+            packages/e2e-test-app-fabric/test/__native_perf__/**/__perf_snapshots__/
           retention-days: 30
 
       # ── Status Gate ────────────────────────────────────────

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: perf-results
+          include-hidden-files: true
           path: |
             packages/e2e-test-app-fabric/.perf-results/
             packages/e2e-test-app-fabric/.native-perf-results/

--- a/change/@react-native-windows-automation-78164800-9ca8-4247-80db-488d96ee93bf.json
+++ b/change/@react-native-windows-automation-78164800-9ca8-4247-80db-488d96ee93bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-a4bcc22f-ba9f-409b-baeb-eac0e646b9d6.json
+++ b/change/@react-native-windows-automation-a4bcc22f-ba9f-409b-baeb-eac0e646b9d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add native perf benchmarking infrastructure for Fabric components",
+  "packageName": "@react-native-windows/automation",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-66589478-9bd2-42e2-ab34-98bbf1e1af38.json
+++ b/change/@react-native-windows-automation-channel-66589478-9bd2-42e2-ab34-98bbf1e1af38.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-commands-f8e5375a-d777-4ae0-a076-d79c397c6d13.json
+++ b/change/@react-native-windows-automation-commands-f8e5375a-d777-4ae0-a076-d79c397c6d13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-60591a59-c0f3-421d-93ab-c50b80733ce4.json
+++ b/change/@react-native-windows-codegen-60591a59-c0f3-421d-93ab-c50b80733ce4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: capture live run metrics in PerfJsonReporter instead of re-reading baselines",
+  "packageName": "@react-native-windows/codegen",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-220b4fd8-6fce-4f20-bbc0-ba50f2f89d15.json
+++ b/change/@react-native-windows-perf-testing-220b4fd8-6fce-4f20-bbc0-ba50f2f89d15.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: capture live run metrics in PerfJsonReporter instead of re-reading baselines",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-4734971c-72bb-4389-b990-27e212a15295.json
+++ b/change/@react-native-windows-perf-testing-4734971c-72bb-4389-b990-27e212a15295.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add native perf benchmarking infrastructure for Fabric components",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-f0fab0f1-4984-4664-b8af-b24ff2f15cd7.json
+++ b/change/@react-native-windows-perf-testing-f0fab0f1-4984-4664-b8af-b24ff2f15cd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Performance tests for react native windows(Fabric)",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-1f753cb4-5264-49b2-a35d-47fd9d986207.json
+++ b/change/react-native-windows-1f753cb4-5264-49b2-a35d-47fd9d986207.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Performance tests for react native windows(Fabric)",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-3a2f7870-03db-4287-b76f-b81c75d05ee8.json
+++ b/change/react-native-windows-3a2f7870-03db-4287-b76f-b81c75d05ee8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: respect track mode in compare-results to avoid false regression failures",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-995b7359-8f60-46fd-9939-5497cea09515.json
+++ b/change/react-native-windows-995b7359-8f60-46fd-9939-5497cea09515.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
+++ b/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
@@ -209,16 +209,24 @@ export default class AutomationEnvironment extends NodeEnvironment {
       // Set up the "Desktop" or Root session
       const rootBrowser = await webdriverio.remote(this.rootWebDriverOptions);
 
-      // Get the list of windows
-      const allWindows = await rootBrowser.$$('//Window');
-
-      // Find our target window
+      // Poll for the app window with timeout (cold starts can be slow)
+      const windowTimeout = 300000; // 5 minutes
+      const pollInterval = 2000;
+      const deadline = Date.now() + windowTimeout;
       let appWindow: webdriverio.Element | undefined;
-      for (const window of allWindows) {
-        if ((await window.getAttribute('Name')) === appName) {
-          appWindow = window;
+
+      while (Date.now() < deadline) {
+        const allWindows = await rootBrowser.$$('//Window');
+        for (const window of allWindows) {
+          if ((await window.getAttribute('Name')) === appName) {
+            appWindow = window;
+            break;
+          }
+        }
+        if (appWindow) {
           break;
         }
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
       }
 
       if (!appWindow) {

--- a/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
+++ b/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
@@ -78,11 +78,11 @@ export class PerfJsonReporter {
     const suites: SuiteResult[] = [];
 
     for (const suite of results.testResults) {
-      // Load the snapshot file for this test suite (written by toMatchPerfSnapshot)
+      // Use live run metrics captured during the test run
       const {file: snapshotFilePath} = SnapshotManager.getSnapshotPath(
         suite.testFilePath,
       );
-      const snapshots = SnapshotManager.load(snapshotFilePath);
+      const snapshots = SnapshotManager.getRunMetrics(snapshotFilePath) ?? {};
 
       const passed = suite.testResults.filter(
         t => t.status === 'passed',

--- a/packages/@react-native-windows/perf-testing/src/config/thresholdPresets.ts
+++ b/packages/@react-native-windows/perf-testing/src/config/thresholdPresets.ts
@@ -56,4 +56,14 @@ export const ThresholdPresets: Readonly<
     maxCV: 0.6,
     mode: 'track',
   },
+
+  native: {
+    maxDurationIncrease: 15,
+    maxDuration: Infinity,
+    minAbsoluteDelta: 5,
+    maxRenderCount: 1,
+    minRuns: 10,
+    maxCV: 0.5,
+    mode: 'gate',
+  },
 };

--- a/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
@@ -7,6 +7,7 @@
 
 import fs from '@react-native-windows/fs';
 import * as path from 'path';
+import * as os from 'os';
 import type {PerfMetrics} from '../interfaces/PerfMetrics';
 import type {PerfThreshold} from '../interfaces/PerfThreshold';
 
@@ -26,8 +27,63 @@ export type SnapshotFile = Record<string, SnapshotEntry>;
 
 /**
  * Manages reading and writing of perf snapshot files.
+ * Also writes live run metrics to a temp directory so the CI reporter
+ * (which runs in the Jest main process) can access fresh results
+ * from the worker process.
  */
 export class SnapshotManager {
+  /** Directory for live run metrics (cross-process via temp files). */
+  private static readonly _runMetricsDir =
+    process.env.PERF_RUN_METRICS_DIR ||
+    path.join(os.tmpdir(), 'rnw-perf-run-metrics');
+
+  /** Record a live metric entry for the current run (written to temp file). */
+  static recordRunMetric(
+    snapshotFilePath: string,
+    key: string,
+    entry: SnapshotEntry,
+  ): void {
+    const metricsFile = path.join(
+      SnapshotManager._runMetricsDir,
+      Buffer.from(snapshotFilePath).toString('base64url') + '.json',
+    );
+    let existing: SnapshotFile = {};
+    if (fs.existsSync(metricsFile)) {
+      existing = JSON.parse(
+        fs.readFileSync(metricsFile, 'utf-8'),
+      ) as SnapshotFile;
+    } else if (!fs.existsSync(SnapshotManager._runMetricsDir)) {
+      fs.mkdirSync(SnapshotManager._runMetricsDir, {recursive: true});
+    }
+    existing[key] = entry;
+    fs.writeFileSync(
+      metricsFile,
+      JSON.stringify(existing, null, 2) + '\n',
+      'utf-8',
+    );
+  }
+
+  /** Get live run metrics for a snapshot file, or null if none were recorded. */
+  static getRunMetrics(snapshotFilePath: string): SnapshotFile | null {
+    const metricsFile = path.join(
+      SnapshotManager._runMetricsDir,
+      Buffer.from(snapshotFilePath).toString('base64url') + '.json',
+    );
+    if (fs.existsSync(metricsFile)) {
+      return JSON.parse(fs.readFileSync(metricsFile, 'utf-8')) as SnapshotFile;
+    }
+    return null;
+  }
+
+  /** Clean up temp run metrics directory. */
+  static clearRunMetrics(): void {
+    if (fs.existsSync(SnapshotManager._runMetricsDir)) {
+      for (const f of fs.readdirSync(SnapshotManager._runMetricsDir)) {
+        fs.unlinkSync(path.join(SnapshotManager._runMetricsDir, f));
+      }
+    }
+  }
+
   static getSnapshotPath(testFilePath: string): {
     dir: string;
     file: string;

--- a/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
@@ -168,6 +168,13 @@ expect.extend({
 
     const threshold: PerfThreshold = {...DEFAULT_THRESHOLD, ...customThreshold};
 
+    // Always record the live metrics for the CI reporter
+    SnapshotManager.recordRunMetric(snapshotFile, snapshotKey, {
+      metrics: received,
+      threshold,
+      capturedAt: new Date().toISOString(),
+    });
+
     // UPDATE MODE or FIRST RUN: write new baseline
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (isUpdateMode || !baseline) {

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativePerfBenchmark/NativePerfBenchmarkExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativePerfBenchmark/NativePerfBenchmarkExample.js
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+const React = require('react');
+const {
+  View,
+  Text,
+  TextInput,
+  Image,
+  ScrollView,
+  FlatList,
+  SectionList,
+  Switch,
+  ActivityIndicator,
+  Button,
+  Modal,
+  Pressable,
+  TouchableHighlight,
+  TouchableOpacity,
+  StyleSheet,
+} = require('react-native');
+
+const {useState, useRef, useCallback, useEffect} = React;
+
+const PHASE_IDLE = 'idle';
+const PHASE_CLEARING = 'clearing';
+const PHASE_MOUNTING = 'mounting';
+const PHASE_DONE = 'done';
+
+const COMPONENT_REGISTRY = {
+  View: () => <View style={styles.target} />,
+  Text: () => <Text style={styles.target}>Benchmark Text</Text>,
+  TextInput: () => (
+    <TextInput style={styles.targetInput} placeholder="Benchmark" />
+  ),
+  Image: () => (
+    <Image
+      style={styles.targetImage}
+      source={require('../../assets/uie_thumb_normal.png')}
+    />
+  ),
+  ScrollView: () => (
+    <ScrollView style={styles.target}>
+      {Array.from({length: 20}, (_, i) => (
+        <View key={i} style={styles.scrollItem} />
+      ))}
+    </ScrollView>
+  ),
+  FlatList: () => (
+    <FlatList
+      style={styles.target}
+      data={Array.from({length: 50}, (_, i) => ({key: String(i)}))}
+      renderItem={({item}) => <Text>{item.key}</Text>}
+    />
+  ),
+  SectionList: () => (
+    <SectionList
+      style={styles.target}
+      sections={[
+        {title: 'A', data: ['A1', 'A2', 'A3']},
+        {title: 'B', data: ['B1', 'B2', 'B3']},
+      ]}
+      renderItem={({item}) => <Text>{item}</Text>}
+      renderSectionHeader={({section}) => <Text>{section.title}</Text>}
+    />
+  ),
+  Switch: () => <Switch value={false} />,
+  ActivityIndicator: () => <ActivityIndicator size="large" />,
+  Button: () => <Button title="Benchmark" onPress={() => {}} />,
+  Modal: () => (
+    <Modal visible={false} transparent>
+      <View style={styles.target} />
+    </Modal>
+  ),
+  Pressable: () => (
+    <Pressable style={styles.target}>
+      <Text>Press</Text>
+    </Pressable>
+  ),
+  TouchableHighlight: () => (
+    <TouchableHighlight style={styles.target} onPress={() => {}}>
+      <Text>Highlight</Text>
+    </TouchableHighlight>
+  ),
+  TouchableOpacity: () => (
+    <TouchableOpacity style={styles.target} onPress={() => {}}>
+      <Text>Opacity</Text>
+    </TouchableOpacity>
+  ),
+};
+
+function BenchmarkRunner() {
+  const [componentName, setComponentName] = useState('View');
+  const [runsInput, setRunsInput] = useState('15');
+  const [phase, setPhase] = useState(PHASE_IDLE);
+  const [showTarget, setShowTarget] = useState(false);
+  const [resultsJson, setResultsJson] = useState('');
+
+  const durationsRef = useRef([]);
+  const runIndexRef = useRef(0);
+  const totalRunsRef = useRef(15);
+  const markNameRef = useRef('');
+
+  const finishRun = useCallback(() => {
+    const markEnd = `perf-end-${runIndexRef.current}`;
+    performance.mark(markEnd);
+    try {
+      const measure = performance.measure(
+        `perf-run-${runIndexRef.current}`,
+        markNameRef.current,
+        markEnd,
+      );
+      durationsRef.current.push(measure.duration);
+    } catch (_) {}
+    performance.clearMarks(markNameRef.current);
+    performance.clearMarks(markEnd);
+    performance.clearMeasures(`perf-run-${runIndexRef.current}`);
+
+    runIndexRef.current++;
+    if (runIndexRef.current < totalRunsRef.current) {
+      setPhase(PHASE_CLEARING);
+    } else {
+      setShowTarget(false);
+      setResultsJson(
+        JSON.stringify({
+          componentName,
+          runs: durationsRef.current.length,
+          durations: durationsRef.current,
+        }),
+      );
+      setPhase(PHASE_DONE);
+    }
+  }, [componentName]);
+
+  useEffect(() => {
+    if (phase === PHASE_CLEARING) {
+      setShowTarget(false);
+      requestAnimationFrame(() => {
+        setPhase(PHASE_MOUNTING);
+      });
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase === PHASE_MOUNTING) {
+      const markStart = `perf-start-${runIndexRef.current}`;
+      markNameRef.current = markStart;
+      performance.mark(markStart);
+      setShowTarget(true);
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase === PHASE_MOUNTING && showTarget) {
+      requestAnimationFrame(() => {
+        finishRun();
+      });
+    }
+  }, [phase, showTarget, finishRun]);
+
+  const handleRun = useCallback(() => {
+    const runs = parseInt(runsInput, 10) || 15;
+    totalRunsRef.current = runs;
+    runIndexRef.current = 0;
+    durationsRef.current = [];
+    setResultsJson('');
+    setPhase(PHASE_CLEARING);
+  }, [runsInput]);
+
+  const ComponentFactory = COMPONENT_REGISTRY[componentName];
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.controls}>
+        <TextInput
+          testID="perf-component-input"
+          style={styles.input}
+          value={componentName}
+          onChangeText={setComponentName}
+          placeholder="Component name"
+        />
+        <TextInput
+          testID="perf-runs-input"
+          style={styles.input}
+          value={runsInput}
+          onChangeText={setRunsInput}
+          keyboardType="numeric"
+          placeholder="Runs"
+        />
+        <Pressable
+          testID="perf-run-btn"
+          style={styles.button}
+          onPress={handleRun}
+          disabled={phase !== PHASE_IDLE && phase !== PHASE_DONE}>
+          <Text style={styles.buttonText}>Run Benchmark</Text>
+        </Pressable>
+      </View>
+
+      <Text testID="perf-status" style={styles.status}>
+        {phase}
+      </Text>
+
+      <View style={styles.targetContainer}>
+        {showTarget && ComponentFactory ? <ComponentFactory /> : null}
+      </View>
+
+      <Text testID="perf-results" style={styles.results}>
+        {resultsJson}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {flex: 1, padding: 8},
+  controls: {flexDirection: 'row', gap: 8, marginBottom: 8},
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 6,
+    minWidth: 100,
+    fontSize: 14,
+  },
+  button: {
+    backgroundColor: '#0078D4',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 4,
+    justifyContent: 'center',
+  },
+  buttonText: {color: 'white', fontWeight: 'bold'},
+  status: {fontSize: 12, color: '#666', marginBottom: 4},
+  targetContainer: {
+    minHeight: 100,
+    borderWidth: 1,
+    borderColor: '#eee',
+    marginBottom: 8,
+  },
+  target: {width: 80, height: 80, backgroundColor: '#f0f0f0'},
+  targetInput: {width: 200, height: 40, borderWidth: 1, borderColor: '#999'},
+  targetImage: {width: 80, height: 80},
+  scrollItem: {height: 20, backgroundColor: '#ddd', marginBottom: 2},
+  results: {fontSize: 10, fontFamily: 'monospace', color: '#333'},
+});
+
+exports.displayName = 'NativePerfBenchmarkExample';
+exports.framework = 'React';
+exports.category = 'Basic';
+exports.title = 'Native Perf Benchmark';
+exports.description =
+  'Measures native rendering pipeline via performance.mark/measure.';
+
+exports.examples = [
+  {
+    title: 'Benchmark Runner',
+    render: function () {
+      return <BenchmarkRunner />;
+    },
+  },
+];

--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -212,6 +212,11 @@ const Components: Array<RNTesterModuleInfo> = [
     category: 'Basic',
     module: require('../examples/Performance/PerformanceComparisonExample'),
   },
+  {
+    key: 'NativePerfBenchmark',
+    category: 'Basic',
+    module: require('../examples-win/NativePerfBenchmark/NativePerfBenchmarkExample'),
+  },
   ...RNTesterListFbInternal.Components,
 ];
 

--- a/packages/e2e-test-app-fabric/jest.native-perf.config.js
+++ b/packages/e2e-test-app-fabric/jest.native-perf.config.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ * @ts-check
+ */
+
+const assetTransform = 'react-native-windows/jest/assetFileTransformer.js';
+
+module.exports = {
+  preset: '@rnx-kit/jest-preset',
+
+  roots: ['<rootDir>/test/'],
+  testMatch: ['**/__native_perf__/**/*.native-perf-test.{ts,tsx}'],
+
+  testEnvironment: '@react-native-windows/automation',
+
+  testTimeout: 180000,
+
+  maxWorkers: 1,
+
+  setupFilesAfterEnv: [
+    'react-native-windows/jest/setup',
+    './jest.perf.setup.ts',
+  ],
+
+  testEnvironmentOptions: {
+    app: 'RNTesterApp-Fabric',
+    useRootSession: true,
+    rootLaunchApp: true,
+    enableAutomationChannel: true,
+  },
+
+  transform: {
+    '\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': assetTransform,
+    'node_modules\\\\@?react-native\\\\.*': 'babel-jest',
+    '@react-native-windows\\\\tester\\\\.*': 'babel-jest',
+    '@react-native-windows\\\\perf-testing\\\\.*': 'babel-jest',
+    'vnext\\\\.*': 'babel-jest',
+    '\\.[jt]sx?$': 'babel-jest',
+  },
+
+  transformIgnorePatterns: ['jest-runner', 'node_modules\\\\safe-buffer'],
+
+  moduleFileExtensions: [
+    'js',
+    'windows.js',
+    'android.js',
+    'mjs',
+    'cjs',
+    'jsx',
+    'ts',
+    'windows.ts',
+    'tsx',
+    'windows.tsx',
+    'json',
+    'node',
+  ],
+
+  verbose: true,
+
+  reporters: process.env.CI
+    ? [
+        'default',
+        [
+          '@react-native-windows/perf-testing/lib-commonjs/ci/PerfJsonReporter',
+          {outputFile: '.native-perf-results/results.json'},
+        ],
+      ]
+    : ['default'],
+};

--- a/packages/e2e-test-app-fabric/package.json
+++ b/packages/e2e-test-app-fabric/package.json
@@ -19,7 +19,10 @@
     "perf:ci": "jest --config jest.perf.config.js --ci --forceExit",
     "perf:ci:compare": "node ../../vnext/Scripts/perf/compare-results.js",
     "perf:ci:report": "node ../../vnext/Scripts/perf/post-pr-comment.js",
-    "perf:create": "node ../../vnext/Scripts/perf/create-perf-test.js"
+    "perf:create": "node ../../vnext/Scripts/perf/create-perf-test.js",
+    "perf:native": "jest --config jest.native-perf.config.js",
+    "perf:native:update": "jest --config jest.native-perf.config.js -u",
+    "perf:native:ci": "jest --config jest.native-perf.config.js --ci --forceExit"
   },
   "dependencies": {
     "@react-native-windows/automation-channel": "0.83.0-preview.2",

--- a/packages/e2e-test-app-fabric/test/NativePerfHelpers.ts
+++ b/packages/e2e-test-app-fabric/test/NativePerfHelpers.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {goToComponentExample} from './RNTesterNavigation';
+import {
+  mean,
+  median,
+  standardDeviation,
+} from '@react-native-windows/perf-testing';
+import type {PerfMetrics} from '@react-native-windows/perf-testing';
+
+export interface NativePerfOptions {
+  runs?: number;
+  warmupRuns?: number;
+}
+
+const DEFAULT_RUNS = 15;
+const DEFAULT_WARMUP = 2;
+
+export async function navigateToBenchmarkPage(): Promise<void> {
+  const componentsTab = await app.findElementByTestID('components-tab');
+  await componentsTab.waitForDisplayed({timeout: 120000});
+
+  await goToComponentExample('Native Perf Benchmark');
+}
+
+export async function measureNativePerf(
+  componentName: string,
+  options?: NativePerfOptions,
+): Promise<PerfMetrics> {
+  const runs = options?.runs ?? DEFAULT_RUNS;
+  const warmupRuns = options?.warmupRuns ?? DEFAULT_WARMUP;
+  const totalRuns = runs + warmupRuns;
+
+  const componentInput = await app.findElementByTestID('perf-component-input');
+  await componentInput.waitForDisplayed({timeout: 5000});
+
+  await app.waitUntil(
+    async () => {
+      await componentInput.setValue(componentName);
+      return (await componentInput.getText()) === componentName;
+    },
+    {
+      interval: 500,
+      timeout: 5000,
+      timeoutMsg: `Failed to set component: ${componentName}`,
+    },
+  );
+
+  const runsInput = await app.findElementByTestID('perf-runs-input');
+  const runsStr = String(totalRuns);
+  await app.waitUntil(
+    async () => {
+      await runsInput.setValue(runsStr);
+      return (await runsInput.getText()) === runsStr;
+    },
+    {interval: 500, timeout: 5000, timeoutMsg: 'Failed to set run count'},
+  );
+
+  const runBtn = await app.findElementByTestID('perf-run-btn');
+  await runBtn.waitForDisplayed({timeout: 5000});
+  await runBtn.click();
+
+  const statusEl = await app.findElementByTestID('perf-status');
+  await app.waitUntil(
+    async () => {
+      const text = await statusEl.getText();
+      return text === 'done';
+    },
+    {
+      interval: 1000,
+      timeout: 180000,
+      timeoutMsg: `Benchmark timed out for ${componentName}`,
+    },
+  );
+
+  const resultsEl = await app.findElementByTestID('perf-results');
+  const rawJson = await resultsEl.getText();
+
+  let parsed: {componentName: string; runs: number; durations: number[]};
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    const snippet = rawJson ? rawJson.slice(0, 200) : '(empty)';
+    throw new Error(
+      `Failed to parse perf results for "${componentName}". ` +
+        `Raw text length=${rawJson.length}, snippet: ${snippet}`,
+    );
+  }
+
+  const durations = parsed.durations.slice(warmupRuns);
+
+  if (durations.length < runs) {
+    throw new Error(
+      `Expected ${runs} durations after discarding ${warmupRuns} warmup, got ${durations.length}`,
+    );
+  }
+
+  const meanDuration = mean(durations);
+  const medianDuration = median(durations);
+  const stdDev = standardDeviation(durations);
+
+  return {
+    name: `${componentName} native mount`,
+    meanDuration,
+    medianDuration,
+    stdDev,
+    renderCount: 1,
+    runs: durations.length,
+    durations,
+    timestamp: new Date().toISOString(),
+    nativeTimings: {fullPipeline: medianDuration},
+  };
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/ActivityIndicator.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/ActivityIndicator.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('ActivityIndicator native mount', async () => {
+    const perf = await measureNativePerf('ActivityIndicator', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Button.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Button.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Button native mount', async () => {
+    const perf = await measureNativePerf('Button', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Image.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Image.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Image native mount', async () => {
+    const perf = await measureNativePerf('Image', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Modal.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Modal.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Modal native mount', async () => {
+    const perf = await measureNativePerf('Modal', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/ScrollView.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/ScrollView.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('ScrollView native mount', async () => {
+    const perf = await measureNativePerf('ScrollView', {
+      runs: 10,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot({...NATIVE, maxCV: 0.6});
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Switch.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Switch.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Switch native mount', async () => {
+    const perf = await measureNativePerf('Switch', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/Text.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/Text.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('Text native mount', async () => {
+    const perf = await measureNativePerf('Text', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/TextInput.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/TextInput.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('TextInput native mount', async () => {
+    const perf = await measureNativePerf('TextInput', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/View.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/View.native-perf-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Native Render Pipeline', () => {
+  test('View native mount', async () => {
+    const perf = await measureNativePerf('View', {runs: 15, warmupRuns: 2});
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ActivityIndicator.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ActivityIndicator.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline ActivityIndicator native mount 1": {
+    "metrics": {
+      "name": "ActivityIndicator native mount",
+      "meanDuration": 2.4800000031789144,
+      "medianDuration": 2.484100043773651,
+      "stdDev": 0.5289090397238356,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.568000018596649,
+        2.912999987602234,
+        2.0101999640464783,
+        1.866599977016449,
+        1.9577000141143799,
+        1.8373000025749207,
+        2.2786999940872192,
+        2.484100043773651,
+        2.536500036716461,
+        2.217199981212616,
+        3.1218000054359436,
+        2.221000015735626,
+        2.5859000086784363,
+        2.8073999881744385,
+        3.794600009918213
+      ],
+      "timestamp": "2026-03-25T09:12:07.260Z",
+      "nativeTimings": {
+        "fullPipeline": 2.484100043773651
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:07.262Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Button.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Button.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Button native mount 1": {
+    "metrics": {
+      "name": "Button native mount",
+      "meanDuration": 2.9556866606076557,
+      "medianDuration": 2.601099967956543,
+      "stdDev": 0.9540605755854736,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.457200050354004,
+        2.5554999709129333,
+        3.3740000128746033,
+        2.601099967956543,
+        2.444000005722046,
+        3.146499991416931,
+        2.1805999875068665,
+        6.153299987316132,
+        2.8115999698638916,
+        2.360199987888336,
+        2.432099997997284,
+        3.0877000093460083,
+        3.0518999695777893,
+        3.1615999937057495,
+        2.51800000667572
+      ],
+      "timestamp": "2026-03-25T09:12:32.621Z",
+      "nativeTimings": {
+        "fullPipeline": 2.601099967956543
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:32.623Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Image.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Image.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Image native mount 1": {
+    "metrics": {
+      "name": "Image native mount",
+      "meanDuration": 2.384059993426005,
+      "medianDuration": 2.26010000705719,
+      "stdDev": 0.585439113749715,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.26010000705719,
+        2.1991999745368958,
+        2.4451000094413757,
+        2.269699990749359,
+        2.214099943637848,
+        2.330900013446808,
+        2.5689000487327576,
+        1.9075999855995178,
+        2.264400005340576,
+        2.2530999779701233,
+        4.417899966239929,
+        2.332099974155426,
+        2.2284000515937805,
+        2.0417999625205994,
+        2.0275999903678894
+      ],
+      "timestamp": "2026-03-25T09:12:49.239Z",
+      "nativeTimings": {
+        "fullPipeline": 2.26010000705719
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:49.240Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Modal.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Modal.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Modal native mount 1": {
+    "metrics": {
+      "name": "Modal native mount",
+      "meanDuration": 1.3649799942970275,
+      "medianDuration": 1.217699944972992,
+      "stdDev": 0.23040005387861157,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.7878000140190125,
+        1.6008999943733215,
+        1.3690999746322632,
+        1.6188000440597534,
+        1.5525999665260315,
+        1.2020000219345093,
+        1.1894000172615051,
+        1.2010000348091125,
+        1.136900007724762,
+        1.1675999760627747,
+        1.2005999684333801,
+        1.217699944972992,
+        1.3144999742507935,
+        1.1704000234603882,
+        1.7453999519348145
+      ],
+      "timestamp": "2026-03-25T09:12:40.886Z",
+      "nativeTimings": {
+        "fullPipeline": 1.217699944972992
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:40.888Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ScrollView.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/ScrollView.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,38 @@
+{
+  "Native Render Pipeline ScrollView native mount 1": {
+    "metrics": {
+      "name": "ScrollView native mount",
+      "meanDuration": 4.355050003528595,
+      "medianDuration": 4.049349993467331,
+      "stdDev": 0.675293113217565,
+      "renderCount": 1,
+      "runs": 10,
+      "durations": [
+        4.063799977302551,
+        4.669399976730347,
+        4.014200031757355,
+        4.600199997425079,
+        3.747600018978119,
+        4.034900009632111,
+        4.375600039958954,
+        6.084399998188019,
+        3.9986000061035156,
+        3.9617999792099
+      ],
+      "timestamp": "2026-03-25T09:11:58.989Z",
+      "nativeTimings": {
+        "fullPipeline": 4.049349993467331
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.6,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:58.991Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Switch.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Switch.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Switch native mount 1": {
+    "metrics": {
+      "name": "Switch native mount",
+      "meanDuration": 1.7548199892044067,
+      "medianDuration": 1.7342000007629395,
+      "stdDev": 0.14067122956094338,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.7342000007629395,
+        1.7372000217437744,
+        1.8542999625205994,
+        1.7226999998092651,
+        1.6146999597549438,
+        1.69159996509552,
+        1.8396000266075134,
+        1.8578999638557434,
+        1.54339998960495,
+        1.6279000043869019,
+        1.9399999976158142,
+        1.8633999824523926,
+        1.6168999671936035,
+        1.6345999836921692,
+        2.0439000129699707
+      ],
+      "timestamp": "2026-03-25T09:12:24.458Z",
+      "nativeTimings": {
+        "fullPipeline": 1.7342000007629395
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:24.460Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Text.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/Text.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline Text native mount 1": {
+    "metrics": {
+      "name": "Text native mount",
+      "meanDuration": 1.7626999974250794,
+      "medianDuration": 1.7395999431610107,
+      "stdDev": 0.17253066691776484,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.9889000058174133,
+        1.7633000016212463,
+        1.8330000042915344,
+        2.02839994430542,
+        1.661899983882904,
+        1.6473000049591064,
+        1.496500015258789,
+        1.5873000025749207,
+        1.6305000185966492,
+        1.8646000027656555,
+        1.7395999431610107,
+        1.684000015258789,
+        1.6638000011444092,
+        2.1093000173568726,
+        1.7421000003814697
+      ],
+      "timestamp": "2026-03-25T09:12:57.555Z",
+      "nativeTimings": {
+        "fullPipeline": 1.7395999431610107
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:57.556Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/TextInput.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/TextInput.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline TextInput native mount 1": {
+    "metrics": {
+      "name": "TextInput native mount",
+      "meanDuration": 4.421840000152588,
+      "medianDuration": 4.0867999792099,
+      "stdDev": 0.9135329076138601,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        3.6496999859809875,
+        4.015100002288818,
+        4.0867999792099,
+        4.2186999917030334,
+        4.2085999846458435,
+        3.800499975681305,
+        4.18560004234314,
+        5.862399995326996,
+        6.951799988746643,
+        3.925000011920929,
+        4.065899968147278,
+        3.9510000348091125,
+        5.296599984169006,
+        3.7587000131607056,
+        4.351200044155121
+      ],
+      "timestamp": "2026-03-25T09:12:15.920Z",
+      "nativeTimings": {
+        "fullPipeline": 4.0867999792099
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:12:15.922Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/View.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/core/__perf_snapshots__/View.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Native Render Pipeline View native mount 1": {
+    "metrics": {
+      "name": "View native mount",
+      "meanDuration": 1.4776333411534628,
+      "medianDuration": 1.428600013256073,
+      "stdDev": 0.22794729910741268,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        1.428600013256073,
+        1.3898000121116638,
+        1.5759000182151794,
+        1.572700023651123,
+        1.257099986076355,
+        1.438700020313263,
+        2.015500009059906,
+        1.3089999556541443,
+        1.47680002450943,
+        1.517300009727478,
+        1.3051999807357788,
+        1.9368000030517578,
+        1.365600049495697,
+        1.332099974155426,
+        1.2434000372886658
+      ],
+      "timestamp": "2026-03-25T09:13:05.775Z",
+      "nativeTimings": {
+        "fullPipeline": 1.428600013256073
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:13:05.794Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/Pressable.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/Pressable.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Interactive Components — Native Render Pipeline', () => {
+  test('Pressable native mount', async () => {
+    const perf = await measureNativePerf('Pressable', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableHighlight.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableHighlight.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Interactive Components — Native Render Pipeline', () => {
+  test('TouchableHighlight native mount', async () => {
+    const perf = await measureNativePerf('TouchableHighlight', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableOpacity.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/TouchableOpacity.native-perf-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('Interactive Components — Native Render Pipeline', () => {
+  test('TouchableOpacity native mount', async () => {
+    const perf = await measureNativePerf('TouchableOpacity', {
+      runs: 15,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot(NATIVE);
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/Pressable.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/Pressable.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Interactive Components — Native Render Pipeline Pressable native mount 1": {
+    "metrics": {
+      "name": "Pressable native mount",
+      "meanDuration": 2.492093336582184,
+      "medianDuration": 2.510699987411499,
+      "stdDev": 0.6735438561451192,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        3.245199978351593,
+        1.9694000482559204,
+        2.761300027370453,
+        1.8480000495910645,
+        1.9053000211715698,
+        2.147000014781952,
+        1.6363999843597412,
+        4.235000014305115,
+        2.4139999747276306,
+        1.856499969959259,
+        3.0816999673843384,
+        2.5519999861717224,
+        2.587000012397766,
+        2.6319000124931335,
+        2.510699987411499
+      ],
+      "timestamp": "2026-03-25T09:11:51.045Z",
+      "nativeTimings": {
+        "fullPipeline": 2.510699987411499
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:51.046Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableHighlight.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableHighlight.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Interactive Components — Native Render Pipeline TouchableHighlight native mount 1": {
+    "metrics": {
+      "name": "TouchableHighlight native mount",
+      "meanDuration": 2.22730667591095,
+      "medianDuration": 2.0885000228881836,
+      "stdDev": 0.569642348560873,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        2.189400017261505,
+        2.055299997329712,
+        2.143899977207184,
+        3.991699993610382,
+        2.5550000071525574,
+        2.0536999702453613,
+        2.0885000228881836,
+        2.524199962615967,
+        1.9000999927520752,
+        2.5004000067710876,
+        1.7630000114440918,
+        1.7075000405311584,
+        2.4169000387191772,
+        1.8182000517845154,
+        1.7018000483512878
+      ],
+      "timestamp": "2026-03-25T09:11:34.994Z",
+      "nativeTimings": {
+        "fullPipeline": 2.0885000228881836
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:34.996Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableOpacity.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/interactive/__perf_snapshots__/TouchableOpacity.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,43 @@
+{
+  "Interactive Components — Native Render Pipeline TouchableOpacity native mount 1": {
+    "metrics": {
+      "name": "TouchableOpacity native mount",
+      "meanDuration": 3.190453334649404,
+      "medianDuration": 3.1384999752044678,
+      "stdDev": 0.7568414883957973,
+      "renderCount": 1,
+      "runs": 15,
+      "durations": [
+        3.0042999982833862,
+        2.795300006866455,
+        3.2402999997138977,
+        2.530400037765503,
+        3.032800018787384,
+        3.4493000507354736,
+        2.2537999749183655,
+        2.4357999563217163,
+        3.2348999977111816,
+        3.694700002670288,
+        3.1384999752044678,
+        3.163599967956543,
+        2.9884999990463257,
+        5.5409000515937805,
+        3.3536999821662903
+      ],
+      "timestamp": "2026-03-25T09:11:43.172Z",
+      "nativeTimings": {
+        "fullPipeline": 3.1384999752044678
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 15,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.5,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:43.174Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/FlatList.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/FlatList.native-perf-test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('List Components — Native Render Pipeline', () => {
+  test('FlatList native mount', async () => {
+    const perf = await measureNativePerf('FlatList', {
+      runs: 10,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot({
+      ...NATIVE,
+      maxDurationIncrease: 20,
+      maxCV: 0.6,
+    });
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/SectionList.native-perf-test.ts
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/SectionList.native-perf-test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {ThresholdPresets} from '@react-native-windows/perf-testing';
+import {
+  navigateToBenchmarkPage,
+  measureNativePerf,
+} from '../../NativePerfHelpers';
+
+beforeAll(async () => {
+  await app.setWindowPosition(0, 0);
+  await app.setWindowSize(1000, 1250);
+  await navigateToBenchmarkPage();
+});
+
+const NATIVE = ThresholdPresets.native;
+
+describe('List Components — Native Render Pipeline', () => {
+  test('SectionList native mount', async () => {
+    const perf = await measureNativePerf('SectionList', {
+      runs: 10,
+      warmupRuns: 2,
+    });
+    expect(perf).toMatchPerfSnapshot({
+      ...NATIVE,
+      maxDurationIncrease: 20,
+      maxCV: 0.6,
+    });
+  });
+});

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/FlatList.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/FlatList.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,38 @@
+{
+  "List Components — Native Render Pipeline FlatList native mount 1": {
+    "metrics": {
+      "name": "FlatList native mount",
+      "meanDuration": 9.108829998970032,
+      "medianDuration": 9.228249996900558,
+      "stdDev": 0.8543665552028276,
+      "renderCount": 1,
+      "runs": 10,
+      "durations": [
+        9.996599972248077,
+        7.9009000062942505,
+        8.30400002002716,
+        8.526000022888184,
+        9.10809999704361,
+        9.793299973011017,
+        9.348399996757507,
+        8.229200005531311,
+        9.370600044727325,
+        10.511199951171875
+      ],
+      "timestamp": "2026-03-25T09:11:26.174Z",
+      "nativeTimings": {
+        "fullPipeline": 9.228249996900558
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 20,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.6,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:26.176Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/SectionList.native-perf-test.ts.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__native_perf__/list/__perf_snapshots__/SectionList.native-perf-test.ts.perf-baseline.json
@@ -1,0 +1,38 @@
+{
+  "List Components — Native Render Pipeline SectionList native mount 1": {
+    "metrics": {
+      "name": "SectionList native mount",
+      "meanDuration": 6.658689999580384,
+      "medianDuration": 6.504900008440018,
+      "stdDev": 0.5578793185297047,
+      "renderCount": 1,
+      "runs": 10,
+      "durations": [
+        6.384400010108948,
+        7.875100016593933,
+        6.401300013065338,
+        6.394400000572205,
+        7.334999978542328,
+        6.771200001239777,
+        6.608500003814697,
+        6.627799987792969,
+        6.103399991989136,
+        6.085799992084503
+      ],
+      "timestamp": "2026-03-25T09:11:17.694Z",
+      "nativeTimings": {
+        "fullPipeline": 6.504900008440018
+      }
+    },
+    "threshold": {
+      "maxDurationIncrease": 20,
+      "maxDuration": null,
+      "minAbsoluteDelta": 5,
+      "maxRenderCount": 1,
+      "minRuns": 10,
+      "maxCV": 0.6,
+      "mode": "gate"
+    },
+    "capturedAt": "2026-03-25T09:11:17.697Z"
+  }
+}

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
@@ -279,7 +279,7 @@ describe('TouchableOpacity Performance', () => {
       expect(perf).toMatchPerfSnapshot({
         maxDurationIncrease: 30,
         minAbsoluteDelta: 15,
-        mode: 'gate',
+        mode: 'track',
       });
     });
   });

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
@@ -268,8 +268,8 @@ describe('TouchableOpacity Performance', () => {
       const scenario = touchableOpacityPerfTest.getCustomScenarios()[7];
       const perf = await scenario.run();
       expect(perf).toMatchPerfSnapshot({
-        maxDurationIncrease: 15,
-        minAbsoluteDelta: 5,
+        maxDurationIncrease: 30,
+        minAbsoluteDelta: 10,
       });
     });
 
@@ -277,8 +277,8 @@ describe('TouchableOpacity Performance', () => {
       const scenario = touchableOpacityPerfTest.getCustomScenarios()[8];
       const perf = await scenario.run();
       expect(perf).toMatchPerfSnapshot({
-        maxDurationIncrease: 10,
-        minAbsoluteDelta: 10,
+        maxDurationIncrease: 30,
+        minAbsoluteDelta: 15,
         mode: 'gate',
       });
     });

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
@@ -211,21 +211,21 @@
   "TouchableOpacity Performance TouchableOpacity-Specific Scenarios multiple-touchables-100 1": {
     "metrics": {
       "name": "TouchableOpacity multiple-100",
-      "meanDuration": 30.666666666666668,
-      "medianDuration": 30,
-      "stdDev": 3.6774732526300613,
+      "meanDuration": 50.27,
+      "medianDuration": 50,
+      "stdDev": 5.5,
       "renderCount": 1,
       "runs": 15,
-      "timestamp": "2026-02-25T08:49:05.289Z"
+      "timestamp": "2026-04-06T00:00:00.000Z"
     },
     "threshold": {
-      "maxDurationIncrease": 10,
+      "maxDurationIncrease": 30,
       "maxDuration": null,
-      "minAbsoluteDelta": 10,
+      "minAbsoluteDelta": 15,
       "maxRenderCount": 5,
       "minRuns": 10,
-      "mode": "gate"
+      "mode": "track"
     },
-    "capturedAt": "2026-02-25T08:49:05.290Z"
+    "capturedAt": "2026-04-06T00:00:00.000Z"
   }
 }

--- a/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
@@ -4142,6 +4142,87 @@ exports[`Home UIA Tree Dump Native Animated Example 1`] = `
 }
 `;
 
+exports[`Home UIA Tree Dump Native Perf Benchmark 1`] = `
+{
+  "Automation Tree": {
+    "AutomationId": "Native Perf Benchmark",
+    "ControlType": 50026,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "group",
+    "Name": "Native Perf Benchmark Measures native rendering pipeline via performance.mark/measure.",
+    "__Children": [
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "LocalizedControlType": "text",
+        "Name": "Native Perf Benchmark",
+        "TextRangePattern.GetText": "Native Perf Benchmark",
+      },
+      {
+        "AutomationId": "",
+        "ControlType": 50020,
+        "LocalizedControlType": "text",
+        "Name": "Measures native rendering pipeline via performance.mark/measure.",
+        "TextRangePattern.GetText": "Measures native rendering pipeline via performance.mark/measure.",
+      },
+    ],
+  },
+  "Component Tree": {
+    "Type": "Microsoft.ReactNative.Composition.ViewComponentView",
+    "_Props": {
+      "AccessibilityLabel": "Native Perf Benchmark Measures native rendering pipeline via performance.mark/measure.",
+      "TestId": "Native Perf Benchmark",
+    },
+    "__Children": [
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+      {
+        "Type": "Microsoft.ReactNative.Composition.ParagraphComponentView",
+        "_Props": {},
+      },
+    ],
+  },
+  "Visual Tree": {
+    "Brush": {
+      "Brush Type": "ColorBrush",
+      "Color": "rgba(255, 255, 255, 255)",
+    },
+    "Comment": "Native Perf Benchmark",
+    "Offset": "0, 0, 0",
+    "Size": "966, 77",
+    "Visual Type": "SpriteVisual",
+    "__Children": [
+      {
+        "Offset": "16, 16, 0",
+        "Size": "180, 25",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "180, 25",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+      {
+        "Offset": "16, 45, 0",
+        "Size": "934, 17",
+        "Visual Type": "SpriteVisual",
+        "__Children": [
+          {
+            "Offset": "0, 0, 0",
+            "Size": "934, 17",
+            "Visual Type": "SpriteVisual",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`Home UIA Tree Dump New App Screen 1`] = `
 {
   "Automation Tree": {

--- a/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
@@ -4272,7 +4272,7 @@ exports[`Home UIA Tree Dump New App Screen 1`] = `
     },
     "Comment": "New App Screen",
     "Offset": "0, 0, 0",
-    "Size": "966, 77",
+    "Size": "966, 78",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5099,12 +5099,12 @@ exports[`Home UIA Tree Dump ScrollView 1`] = `
       },
       {
         "Offset": "16, 45, 0",
-        "Size": "934, 17",
+        "Size": "934, 16",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "934, 17",
+            "Size": "934, 16",
             "Visual Type": "SpriteVisual",
           },
         ],
@@ -5180,12 +5180,12 @@ exports[`Home UIA Tree Dump ScrollViewAnimated 1`] = `
       },
       {
         "Offset": "16, 45, 0",
-        "Size": "934, 16",
+        "Size": "934, 17",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "934, 16",
+            "Size": "934, 17",
             "Visual Type": "SpriteVisual",
           },
         ],
@@ -5759,7 +5759,7 @@ exports[`Home UIA Tree Dump Text 1`] = `
     },
     "Comment": "Text",
     "Offset": "0, 0, 0",
-    "Size": "966, 78",
+    "Size": "966, 77",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -5840,7 +5840,7 @@ exports[`Home UIA Tree Dump TextInput 1`] = `
     },
     "Comment": "TextInput",
     "Offset": "0, 0, 0",
-    "Size": "966, 77",
+    "Size": "966, 78",
     "Visual Type": "SpriteVisual",
     "__Children": [
       {
@@ -6331,12 +6331,12 @@ exports[`Home UIA Tree Dump TransparentHitTestExample 1`] = `
     "__Children": [
       {
         "Offset": "16, 16, 0",
-        "Size": "214, 25",
+        "Size": "214, 24",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "214, 25",
+            "Size": "214, 24",
             "Visual Type": "SpriteVisual",
           },
         ],
@@ -6574,12 +6574,12 @@ exports[`Home UIA Tree Dump View 1`] = `
     "__Children": [
       {
         "Offset": "16, 16, 0",
-        "Size": "38, 24",
+        "Size": "38, 25",
         "Visual Type": "SpriteVisual",
         "__Children": [
           {
             "Offset": "0, 0, 0",
-            "Size": "38, 24",
+            "Size": "38, 25",
             "Visual Type": "SpriteVisual",
           },
         ],

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -34331,6 +34331,150 @@ exports[`snapshotAllPages Native Animated Example 14`] = `
 </View>
 `;
 
+exports[`snapshotAllPages Native Perf Benchmark 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+      "padding": 8,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "gap": 8,
+        "marginBottom": 8,
+      }
+    }
+  >
+    <TextInput
+      onChangeText={[Function]}
+      placeholder="Component name"
+      style={
+        {
+          "borderColor": "#ccc",
+          "borderWidth": 1,
+          "fontSize": 14,
+          "minWidth": 100,
+          "padding": 6,
+        }
+      }
+      testID="perf-component-input"
+      value="View"
+    />
+    <TextInput
+      keyboardType="numeric"
+      onChangeText={[Function]}
+      placeholder="Runs"
+      style={
+        {
+          "borderColor": "#ccc",
+          "borderWidth": 1,
+          "fontSize": 14,
+          "minWidth": 100,
+          "padding": 6,
+        }
+      }
+      testID="perf-runs-input"
+      value="15"
+    />
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "multiselectable": undefined,
+          "readOnly": undefined,
+          "required": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      disabled={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "backgroundColor": "#0078D4",
+          "borderRadius": 4,
+          "justifyContent": "center",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        }
+      }
+      testID="perf-run-btn"
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontWeight": "bold",
+          }
+        }
+      >
+        Run Benchmark
+      </Text>
+    </View>
+  </View>
+  <Text
+    style={
+      {
+        "color": "#666",
+        "fontSize": 12,
+        "marginBottom": 4,
+      }
+    }
+    testID="perf-status"
+  >
+    idle
+  </Text>
+  <View
+    style={
+      {
+        "borderColor": "#eee",
+        "borderWidth": 1,
+        "marginBottom": 8,
+        "minHeight": 100,
+      }
+    }
+  />
+  <Text
+    style={
+      {
+        "color": "#333",
+        "fontFamily": "monospace",
+        "fontSize": 10,
+      }
+    }
+    testID="perf-results"
+  />
+</View>
+`;
+
 exports[`snapshotAllPages PanResponder Sample 1`] = `
 <View
   style={

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -10,7 +10,7 @@
  *   node vnext/Scripts/perf/compare-results.js [options]
  *
  * Options:
- *   --results <path>    Path to CI results JSON (default: .perf-results/results.json)
+ *   --results <path>    Path to CI results JSON (repeatable, default: .perf-results/results.json)
  *   --baselines <dir>   Path to base branch perf snapshots directory
  *   --output <path>     Path to write markdown report (default: .perf-results/report.md)
  *   --fail-on-regression  Exit 1 if regressions found (default: true in CI)
@@ -25,17 +25,29 @@ const path = require('path');
 
 function parseArgs() {
   const args = process.argv.slice(2);
+
+  // Auto-discover results files: JS perf + native perf
+  const defaultResults = [
+    '.perf-results/results.json',
+    '.native-perf-results/results.json',
+  ].filter(p => fs.existsSync(p));
+
   const opts = {
-    results: '.perf-results/results.json',
+    results: defaultResults,
     baselines: null, // auto-detect from test file paths
     output: '.perf-results/report.md',
     failOnRegression: !!process.env.CI,
   };
 
+  let explicitResults = false;
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case '--results':
-        opts.results = args[++i];
+        if (!explicitResults) {
+          opts.results = [];
+          explicitResults = true;
+        }
+        opts.results.push(args[++i]);
         break;
       case '--baselines':
         opts.baselines = args[++i];
@@ -257,17 +269,41 @@ function generateMarkdown(suiteComparisons, ciResults) {
 function main() {
   const opts = parseArgs();
 
-  // 1. Load CI results JSON
-  if (!fs.existsSync(opts.results)) {
-    console.error(`❌ Results file not found: ${opts.results}`);
+  // 1. Load CI results JSON (supports multiple --results paths)
+  const ciResults = {
+    suites: [],
+    branch: '',
+    commitSha: '',
+    timestamp: '',
+    summary: {
+      totalSuites: 0,
+      totalTests: 0,
+      passed: 0,
+      failed: 0,
+      durationMs: 0,
+    },
+  };
+  const resultsPaths = opts.results.filter(p => fs.existsSync(p));
+  if (resultsPaths.length === 0) {
+    console.error(`❌ No results files found: ${opts.results.join(', ')}`);
     console.error('Run perf tests with CI=true first: CI=true yarn perf:ci');
     process.exit(1);
   }
-
-  const ciResults = JSON.parse(fs.readFileSync(opts.results, 'utf-8'));
-  console.log(
-    `📊 Loaded ${ciResults.suites.length} suite(s) from ${opts.results}`,
-  );
+  for (const resultsPath of resultsPaths) {
+    const partial = JSON.parse(fs.readFileSync(resultsPath, 'utf-8'));
+    ciResults.suites.push(...(partial.suites || []));
+    ciResults.branch = ciResults.branch || partial.branch;
+    ciResults.commitSha = ciResults.commitSha || partial.commitSha;
+    ciResults.timestamp = ciResults.timestamp || partial.timestamp;
+    ciResults.summary.totalSuites += partial.summary?.totalSuites || 0;
+    ciResults.summary.totalTests += partial.summary?.totalTests || 0;
+    ciResults.summary.passed += partial.summary?.passed || 0;
+    ciResults.summary.failed += partial.summary?.failed || 0;
+    ciResults.summary.durationMs += partial.summary?.durationMs || 0;
+    console.log(
+      `📊 Loaded ${partial.suites.length} suite(s) from ${resultsPath}`,
+    );
+  }
 
   // 2. Compare each suite against its committed baseline
   const suiteComparisons = [];

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -110,6 +110,7 @@ function compareEntry(head, base, threshold) {
         : 0;
 
   const errors = [];
+  const isTrackMode = threshold.mode === 'track';
 
   const absoluteDelta = head.medianDuration - base.medianDuration;
   const minAbsoluteDelta =
@@ -138,8 +139,9 @@ function compareEntry(head, base, threshold) {
     head,
     base,
     percentChange,
-    passed: errors.length === 0,
+    passed: isTrackMode || errors.length === 0,
     errors,
+    isTrackMode,
   };
 }
 
@@ -217,6 +219,24 @@ function generateMarkdown(suiteComparisons, ciResults) {
       }
       md += '\n';
     }
+  }
+
+  // Track-mode warnings (not blocking)
+  const trackedWarnings = suiteComparisons.flatMap(s =>
+    s.results.filter(r => r.isTrackMode && r.errors.length > 0),
+  );
+  if (trackedWarnings.length > 0) {
+    md += '### ⚠️ Tracked (not blocking)\n\n';
+    md += '| Scenario | Baseline | Current | Change |\n';
+    md += '|----------|----------|---------|--------|\n';
+    for (const r of trackedWarnings) {
+      const baseline = r.base ? `${r.base.meanDuration.toFixed(2)}ms` : 'N/A';
+      const current = r.head ? `${r.head.meanDuration.toFixed(2)}ms` : 'N/A';
+      const change =
+        r.percentChange != null ? `+${r.percentChange.toFixed(1)}%` : 'N/A';
+      md += `| ${r.name} | ${baseline} | ${current} | ${change} |\n`;
+    }
+    md += '\n';
   }
 
   // Passed suites


### PR DESCRIPTION
Cherry-picks perf testing infrastructure to 0.83-stable:

86e6a03 — [Fabric]: Performance Tests for React Native Windows (#15666)
9074f9d — Native perf benchmarking infra for Fabric components (#15772)
855a194 — fix: resolve artifact path mismatch in perf-comment workflow (#15883)
9430a12 — fix: include hidden files in perf artifact upload to restore PR comments (#15893)
ecef157 — fix: respect track mode in compare-results to avoid false regression (#15933)