### PR TITLE
 Port perf tests to 0.84-stable

### DIFF
--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: perf-results
+          include-hidden-files: true
           path: |
             packages/e2e-test-app-fabric/.perf-results/
             packages/e2e-test-app-fabric/.native-perf-results/

--- a/change/@react-native-windows-automation-78164800-9ca8-4247-80db-488d96ee93bf.json
+++ b/change/@react-native-windows-automation-78164800-9ca8-4247-80db-488d96ee93bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-66589478-9bd2-42e2-ab34-98bbf1e1af38.json
+++ b/change/@react-native-windows-automation-channel-66589478-9bd2-42e2-ab34-98bbf1e1af38.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-commands-f8e5375a-d777-4ae0-a076-d79c397c6d13.json
+++ b/change/@react-native-windows-automation-commands-f8e5375a-d777-4ae0-a076-d79c397c6d13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-60591a59-c0f3-421d-93ab-c50b80733ce4.json
+++ b/change/@react-native-windows-codegen-60591a59-c0f3-421d-93ab-c50b80733ce4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: capture live run metrics in PerfJsonReporter instead of re-reading baselines",
+  "packageName": "@react-native-windows/codegen",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-220b4fd8-6fce-4f20-bbc0-ba50f2f89d15.json
+++ b/change/@react-native-windows-perf-testing-220b4fd8-6fce-4f20-bbc0-ba50f2f89d15.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: capture live run metrics in PerfJsonReporter instead of re-reading baselines",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-f0fab0f1-4984-4664-b8af-b24ff2f15cd7.json
+++ b/change/@react-native-windows-perf-testing-f0fab0f1-4984-4664-b8af-b24ff2f15cd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Performance tests for react native windows(Fabric)",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-1f753cb4-5264-49b2-a35d-47fd9d986207.json
+++ b/change/react-native-windows-1f753cb4-5264-49b2-a35d-47fd9d986207.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Performance tests for react native windows(Fabric)",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-3a2f7870-03db-4287-b76f-b81c75d05ee8.json
+++ b/change/react-native-windows-3a2f7870-03db-4287-b76f-b81c75d05ee8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: respect track mode in compare-results to avoid false regression failures",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-995b7359-8f60-46fd-9939-5497cea09515.json
+++ b/change/react-native-windows-995b7359-8f60-46fd-9939-5497cea09515.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: auto-discover native perf results in compare report",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
+++ b/packages/@react-native-windows/perf-testing/src/ci/PerfJsonReporter.ts
@@ -78,11 +78,11 @@ export class PerfJsonReporter {
     const suites: SuiteResult[] = [];
 
     for (const suite of results.testResults) {
-      // Load the snapshot file for this test suite (written by toMatchPerfSnapshot)
+      // Use live run metrics captured during the test run
       const {file: snapshotFilePath} = SnapshotManager.getSnapshotPath(
         suite.testFilePath,
       );
-      const snapshots = SnapshotManager.load(snapshotFilePath);
+      const snapshots = SnapshotManager.getRunMetrics(snapshotFilePath) ?? {};
 
       const passed = suite.testResults.filter(
         t => t.status === 'passed',

--- a/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/snapshotManager.ts
@@ -7,6 +7,7 @@
 
 import fs from '@react-native-windows/fs';
 import * as path from 'path';
+import * as os from 'os';
 import type {PerfMetrics} from '../interfaces/PerfMetrics';
 import type {PerfThreshold} from '../interfaces/PerfThreshold';
 
@@ -26,8 +27,63 @@ export type SnapshotFile = Record<string, SnapshotEntry>;
 
 /**
  * Manages reading and writing of perf snapshot files.
+ * Also writes live run metrics to a temp directory so the CI reporter
+ * (which runs in the Jest main process) can access fresh results
+ * from the worker process.
  */
 export class SnapshotManager {
+  /** Directory for live run metrics (cross-process via temp files). */
+  private static readonly _runMetricsDir =
+    process.env.PERF_RUN_METRICS_DIR ||
+    path.join(os.tmpdir(), 'rnw-perf-run-metrics');
+
+  /** Record a live metric entry for the current run (written to temp file). */
+  static recordRunMetric(
+    snapshotFilePath: string,
+    key: string,
+    entry: SnapshotEntry,
+  ): void {
+    const metricsFile = path.join(
+      SnapshotManager._runMetricsDir,
+      Buffer.from(snapshotFilePath).toString('base64url') + '.json',
+    );
+    let existing: SnapshotFile = {};
+    if (fs.existsSync(metricsFile)) {
+      existing = JSON.parse(
+        fs.readFileSync(metricsFile, 'utf-8'),
+      ) as SnapshotFile;
+    } else if (!fs.existsSync(SnapshotManager._runMetricsDir)) {
+      fs.mkdirSync(SnapshotManager._runMetricsDir, {recursive: true});
+    }
+    existing[key] = entry;
+    fs.writeFileSync(
+      metricsFile,
+      JSON.stringify(existing, null, 2) + '\n',
+      'utf-8',
+    );
+  }
+
+  /** Get live run metrics for a snapshot file, or null if none were recorded. */
+  static getRunMetrics(snapshotFilePath: string): SnapshotFile | null {
+    const metricsFile = path.join(
+      SnapshotManager._runMetricsDir,
+      Buffer.from(snapshotFilePath).toString('base64url') + '.json',
+    );
+    if (fs.existsSync(metricsFile)) {
+      return JSON.parse(fs.readFileSync(metricsFile, 'utf-8')) as SnapshotFile;
+    }
+    return null;
+  }
+
+  /** Clean up temp run metrics directory. */
+  static clearRunMetrics(): void {
+    if (fs.existsSync(SnapshotManager._runMetricsDir)) {
+      for (const f of fs.readdirSync(SnapshotManager._runMetricsDir)) {
+        fs.unlinkSync(path.join(SnapshotManager._runMetricsDir, f));
+      }
+    }
+  }
+
   static getSnapshotPath(testFilePath: string): {
     dir: string;
     file: string;

--- a/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
+++ b/packages/@react-native-windows/perf-testing/src/matchers/toMatchPerfSnapshot.ts
@@ -168,6 +168,13 @@ expect.extend({
 
     const threshold: PerfThreshold = {...DEFAULT_THRESHOLD, ...customThreshold};
 
+    // Always record the live metrics for the CI reporter
+    SnapshotManager.recordRunMetric(snapshotFile, snapshotKey, {
+      metrics: received,
+      threshold,
+      capturedAt: new Date().toISOString(),
+    });
+
     // UPDATE MODE or FIRST RUN: write new baseline
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (isUpdateMode || !baseline) {

--- a/packages/@react-native-windows/tester/src/js/examples-win/HitTest/HitTestExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/HitTest/HitTestExample.js
@@ -7,7 +7,7 @@
 'use strict';
 
 import React from 'react';
-import { View, Text, Pressable } from 'react-native';
+import {View, Text, Pressable} from 'react-native';
 
 function HitTestWithOverflowVisibile() {
   const [bgColor, setBgColor] = React.useState('red');
@@ -15,13 +15,13 @@ function HitTestWithOverflowVisibile() {
   return (
     <View>
       <Text>
-        Clicking the pressable should work even if it is outside the bounds
-        of its parent.
+        Clicking the pressable should work even if it is outside the bounds of
+        its parent.
       </Text>
       <View
         accessible={true}
-        accessibilityValue={{ text: bgColor }}
-        style={{ width: 150, height: 150 }}
+        accessibilityValue={{text: bgColor}}
+        style={{width: 150, height: 150}}
         testID="visible-overflow-element">
         <View
           style={{
@@ -52,15 +52,14 @@ function HitTestWithOverflowHidden() {
   return (
     <View>
       <Text>
-        Clicking within the visible view will trigger the pressable.
-        Clicking outside the bounds, where the pressable extends but is
-        clipped by its parent overflow:hidden, should not trigger the
-        pressable.
+        Clicking within the visible view will trigger the pressable. Clicking
+        outside the bounds, where the pressable extends but is clipped by its
+        parent overflow:hidden, should not trigger the pressable.
       </Text>
       <View
         accessible={true}
-        accessibilityValue={{ text: bgColor }}
-        style={{ width: 150, height: 150 }}
+        accessibilityValue={{text: bgColor}}
+        style={{width: 150, height: 150}}
         testID="hidden-overflow-element">
         <View
           style={{

--- a/packages/@react-native-windows/tester/src/js/examples-win/Pointer/PointerButtonExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Pointer/PointerButtonExample.windows.js
@@ -36,7 +36,9 @@ function PointerDownButtonExample(): React.Node {
   );
   return (
     <View>
-      <Text accessible={true} testID="pointer-button-state">{text}</Text>
+      <Text accessible={true} testID="pointer-button-state">
+        {text}
+      </Text>
       <View
         accessible={true}
         testID="pointer-button-target"
@@ -58,7 +60,9 @@ function PointerUpButtonExample(): React.Node {
   );
   return (
     <View>
-      <Text accessible={true} testID="pointer-up-button-state">{text}</Text>
+      <Text accessible={true} testID="pointer-up-button-state">
+        {text}
+      </Text>
       <View
         accessible={true}
         testID="pointer-up-button-target"

--- a/packages/@rnw-scripts/just-task/nuget-restore-task.js
+++ b/packages/@rnw-scripts/just-task/nuget-restore-task.js
@@ -118,7 +118,7 @@ function findVsDevCmd() {
   let installationRoot = '';
   try {
     installationRoot = execSync(
-      `${quote(vsWherePath)} -latest -products * -requires Microsoft.Component.MSBuild -property installationPath -format value`,
+      `${quote(vsWherePath)} -latest -prerelease -products * -requires Microsoft.Component.MSBuild -property installationPath -format value`,
       {encoding: 'utf8'},
     )
       .split(/\r?\n/)

--- a/packages/@rnw-scripts/unbroken/src/checker.ts
+++ b/packages/@rnw-scripts/unbroken/src/checker.ts
@@ -60,12 +60,11 @@ export class Checker {
       this.options.exclusions ||
       path.join(this.options.dir, '.unbroken_exclusions');
     try {
-      const contents =
-        fs
-          .readFileSync(exclusionsFileName)
-          .toString()
-          .split(/\r?\n/)
-          .filter(x => x.trim() !== '');
+      const contents = fs
+        .readFileSync(exclusionsFileName)
+        .toString()
+        .split(/\r?\n/)
+        .filter(x => x.trim() !== '');
       this.suppressions = contents
         .filter(x => !x.startsWith('!'))
         .map(x => Checker.normalizeSlashes(x));
@@ -83,7 +82,6 @@ export class Checker {
   suppressions: string[];
   exclusions: string[];
   urlCache: Record<string, number>;
-
 
   private async recurseFindMarkdownFiles(
     dirPath: string,
@@ -136,9 +134,7 @@ export class Checker {
     }
 
     if (this.options['parse-ids']) {
-      await this.recurseFindMarkdownFiles(dirPath, x =>
-        this.getAndStoreId(x),
-      );
+      await this.recurseFindMarkdownFiles(dirPath, x => this.getAndStoreId(x));
     }
     await this.recurseFindMarkdownFiles(dirPath, x =>
       this.verifyMarkDownFile(x),
@@ -249,9 +245,7 @@ export class Checker {
 
     const anchors = this.getAnchors(contents.toLowerCase());
     if (!anchors.includes(sectionAnchor.toLowerCase())) {
-      if (
-        !anchors.includes(sectionAnchor.replace(/\./g, '').toLowerCase())
-      ) {
+      if (!anchors.includes(sectionAnchor.replace(/\./g, '').toLowerCase())) {
         if (
           !(
             this.options['allow-local-line-sections'] &&
@@ -387,7 +381,7 @@ export class Checker {
   }
 
   private static isWebLink(url: string) {
-    return url.startsWith("https://") || url.startsWith('https://');
+    return url.startsWith('https://') || url.startsWith('https://');
   }
 
   async verifyMarkDownFile(filePath: string) {

--- a/packages/@rnw-scripts/unbroken/src/unbroken.ts
+++ b/packages/@rnw-scripts/unbroken/src/unbroken.ts
@@ -55,7 +55,11 @@ async function run() {
       exclusions: {type: 'string', short: 'e'},
       'local-only': {type: 'boolean', short: 'l', default: false},
       init: {type: 'boolean', short: 'i', default: false},
-      'allow-local-line-sections': {type: 'boolean', short: 'a', default: false},
+      'allow-local-line-sections': {
+        type: 'boolean',
+        short: 'a',
+        default: false,
+      },
       quiet: {type: 'boolean', short: 'q', default: false},
       superquiet: {type: 'boolean', short: 's', default: false},
       'parse-ids': {type: 'boolean', default: false},

--- a/packages/e2e-test-app-fabric/.native-perf-results/results.json
+++ b/packages/e2e-test-app-fabric/.native-perf-results/results.json
@@ -1,0 +1,699 @@
+{
+  "timestamp": "2026-04-01T09:52:43.764Z",
+  "branch": "unknown",
+  "commitSha": "unknown",
+  "suites": [
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\list\\SectionList.native-perf-test.ts",
+      "suiteName": "SectionList.native-perf-test.ts",
+      "snapshots": {
+        "List Components — Native Render Pipeline SectionList native mount 1": {
+          "metrics": {
+            "name": "SectionList native mount",
+            "meanDuration": 6.658689999580384,
+            "medianDuration": 6.504900008440018,
+            "stdDev": 0.5578793185297047,
+            "renderCount": 1,
+            "runs": 10,
+            "durations": [
+              6.384400010108948,
+              7.875100016593933,
+              6.401300013065338,
+              6.394400000572205,
+              7.334999978542328,
+              6.771200001239777,
+              6.608500003814697,
+              6.627799987792969,
+              6.103399991989136,
+              6.085799992084503
+            ],
+            "timestamp": "2026-03-25T09:11:17.694Z",
+            "nativeTimings": {
+              "fullPipeline": 6.504900008440018
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 20,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.6,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:11:17.697Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1494
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\list\\FlatList.native-perf-test.ts",
+      "suiteName": "FlatList.native-perf-test.ts",
+      "snapshots": {
+        "List Components — Native Render Pipeline FlatList native mount 1": {
+          "metrics": {
+            "name": "FlatList native mount",
+            "meanDuration": 9.108829998970032,
+            "medianDuration": 9.228249996900558,
+            "stdDev": 0.8543665552028276,
+            "renderCount": 1,
+            "runs": 10,
+            "durations": [
+              9.996599972248077,
+              7.9009000062942505,
+              8.30400002002716,
+              8.526000022888184,
+              9.10809999704361,
+              9.793299973011017,
+              9.348399996757507,
+              8.229200005531311,
+              9.370600044727325,
+              10.511199951171875
+            ],
+            "timestamp": "2026-03-25T09:11:26.174Z",
+            "nativeTimings": {
+              "fullPipeline": 9.228249996900558
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 20,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.6,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:11:26.176Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1288
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\interactive\\TouchableHighlight.native-perf-test.ts",
+      "suiteName": "TouchableHighlight.native-perf-test.ts",
+      "snapshots": {
+        "Interactive Components — Native Render Pipeline TouchableHighlight native mount 1": {
+          "metrics": {
+            "name": "TouchableHighlight native mount",
+            "meanDuration": 2.22730667591095,
+            "medianDuration": 2.0885000228881836,
+            "stdDev": 0.569642348560873,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              2.189400017261505,
+              2.055299997329712,
+              2.143899977207184,
+              3.991699993610382,
+              2.5550000071525574,
+              2.0536999702453613,
+              2.0885000228881836,
+              2.524199962615967,
+              1.9000999927520752,
+              2.5004000067710876,
+              1.7630000114440918,
+              1.7075000405311584,
+              2.4169000387191772,
+              1.8182000517845154,
+              1.7018000483512878
+            ],
+            "timestamp": "2026-03-25T09:11:34.994Z",
+            "nativeTimings": {
+              "fullPipeline": 2.0885000228881836
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:11:34.996Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1922
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\interactive\\TouchableOpacity.native-perf-test.ts",
+      "suiteName": "TouchableOpacity.native-perf-test.ts",
+      "snapshots": {
+        "Interactive Components — Native Render Pipeline TouchableOpacity native mount 1": {
+          "metrics": {
+            "name": "TouchableOpacity native mount",
+            "meanDuration": 3.190453334649404,
+            "medianDuration": 3.1384999752044678,
+            "stdDev": 0.7568414883957973,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              3.0042999982833862,
+              2.795300006866455,
+              3.2402999997138977,
+              2.530400037765503,
+              3.032800018787384,
+              3.4493000507354736,
+              2.2537999749183655,
+              2.4357999563217163,
+              3.2348999977111816,
+              3.694700002670288,
+              3.1384999752044678,
+              3.163599967956543,
+              2.9884999990463257,
+              5.5409000515937805,
+              3.3536999821662903
+            ],
+            "timestamp": "2026-03-25T09:11:43.172Z",
+            "nativeTimings": {
+              "fullPipeline": 3.1384999752044678
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:11:43.174Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1794
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\interactive\\Pressable.native-perf-test.ts",
+      "suiteName": "Pressable.native-perf-test.ts",
+      "snapshots": {
+        "Interactive Components — Native Render Pipeline Pressable native mount 1": {
+          "metrics": {
+            "name": "Pressable native mount",
+            "meanDuration": 2.492093336582184,
+            "medianDuration": 2.510699987411499,
+            "stdDev": 0.6735438561451192,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              3.245199978351593,
+              1.9694000482559204,
+              2.761300027370453,
+              1.8480000495910645,
+              1.9053000211715698,
+              2.147000014781952,
+              1.6363999843597412,
+              4.235000014305115,
+              2.4139999747276306,
+              1.856499969959259,
+              3.0816999673843384,
+              2.5519999861717224,
+              2.587000012397766,
+              2.6319000124931335,
+              2.510699987411499
+            ],
+            "timestamp": "2026-03-25T09:11:51.045Z",
+            "nativeTimings": {
+              "fullPipeline": 2.510699987411499
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:11:51.046Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1380
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\ScrollView.native-perf-test.ts",
+      "suiteName": "ScrollView.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline ScrollView native mount 1": {
+          "metrics": {
+            "name": "ScrollView native mount",
+            "meanDuration": 4.355050003528595,
+            "medianDuration": 4.049349993467331,
+            "stdDev": 0.675293113217565,
+            "renderCount": 1,
+            "runs": 10,
+            "durations": [
+              4.063799977302551,
+              4.669399976730347,
+              4.014200031757355,
+              4.600199997425079,
+              3.747600018978119,
+              4.034900009632111,
+              4.375600039958954,
+              6.084399998188019,
+              3.9986000061035156,
+              3.9617999792099
+            ],
+            "timestamp": "2026-03-25T09:11:58.989Z",
+            "nativeTimings": {
+              "fullPipeline": 4.049349993467331
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.6,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:11:58.991Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1414
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\ActivityIndicator.native-perf-test.ts",
+      "suiteName": "ActivityIndicator.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline ActivityIndicator native mount 1": {
+          "metrics": {
+            "name": "ActivityIndicator native mount",
+            "meanDuration": 2.4800000031789144,
+            "medianDuration": 2.484100043773651,
+            "stdDev": 0.5289090397238356,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              2.568000018596649,
+              2.912999987602234,
+              2.0101999640464783,
+              1.866599977016449,
+              1.9577000141143799,
+              1.8373000025749207,
+              2.2786999940872192,
+              2.484100043773651,
+              2.536500036716461,
+              2.217199981212616,
+              3.1218000054359436,
+              2.221000015735626,
+              2.5859000086784363,
+              2.8073999881744385,
+              3.794600009918213
+            ],
+            "timestamp": "2026-03-25T09:12:07.260Z",
+            "nativeTimings": {
+              "fullPipeline": 2.484100043773651
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:12:07.262Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1861
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\TextInput.native-perf-test.ts",
+      "suiteName": "TextInput.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline TextInput native mount 1": {
+          "metrics": {
+            "name": "TextInput native mount",
+            "meanDuration": 4.421840000152588,
+            "medianDuration": 4.0867999792099,
+            "stdDev": 0.9135329076138601,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              3.6496999859809875,
+              4.015100002288818,
+              4.0867999792099,
+              4.2186999917030334,
+              4.2085999846458435,
+              3.800499975681305,
+              4.18560004234314,
+              5.862399995326996,
+              6.951799988746643,
+              3.925000011920929,
+              4.065899968147278,
+              3.9510000348091125,
+              5.296599984169006,
+              3.7587000131607056,
+              4.351200044155121
+            ],
+            "timestamp": "2026-03-25T09:12:15.920Z",
+            "nativeTimings": {
+              "fullPipeline": 4.0867999792099
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:12:15.922Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1352
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\Switch.native-perf-test.ts",
+      "suiteName": "Switch.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline Switch native mount 1": {
+          "metrics": {
+            "name": "Switch native mount",
+            "meanDuration": 1.7548199892044067,
+            "medianDuration": 1.7342000007629395,
+            "stdDev": 0.14067122956094338,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              1.7342000007629395,
+              1.7372000217437744,
+              1.8542999625205994,
+              1.7226999998092651,
+              1.6146999597549438,
+              1.69159996509552,
+              1.8396000266075134,
+              1.8578999638557434,
+              1.54339998960495,
+              1.6279000043869019,
+              1.9399999976158142,
+              1.8633999824523926,
+              1.6168999671936035,
+              1.6345999836921692,
+              2.0439000129699707
+            ],
+            "timestamp": "2026-03-25T09:12:24.458Z",
+            "nativeTimings": {
+              "fullPipeline": 1.7342000007629395
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:12:24.460Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1190
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\Button.native-perf-test.ts",
+      "suiteName": "Button.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline Button native mount 1": {
+          "metrics": {
+            "name": "Button native mount",
+            "meanDuration": 2.9556866606076557,
+            "medianDuration": 2.601099967956543,
+            "stdDev": 0.9540605755854736,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              2.457200050354004,
+              2.5554999709129333,
+              3.3740000128746033,
+              2.601099967956543,
+              2.444000005722046,
+              3.146499991416931,
+              2.1805999875068665,
+              6.153299987316132,
+              2.8115999698638916,
+              2.360199987888336,
+              2.432099997997284,
+              3.0877000093460083,
+              3.0518999695777893,
+              3.1615999937057495,
+              2.51800000667572
+            ],
+            "timestamp": "2026-03-25T09:12:32.621Z",
+            "nativeTimings": {
+              "fullPipeline": 2.601099967956543
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:12:32.623Z"
+        }
+      },
+      "passed": 0,
+      "failed": 1,
+      "totalDuration": 5188
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\Modal.native-perf-test.ts",
+      "suiteName": "Modal.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline Modal native mount 1": {
+          "metrics": {
+            "name": "Modal native mount",
+            "meanDuration": 1.3649799942970275,
+            "medianDuration": 1.217699944972992,
+            "stdDev": 0.23040005387861157,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              1.7878000140190125,
+              1.6008999943733215,
+              1.3690999746322632,
+              1.6188000440597534,
+              1.5525999665260315,
+              1.2020000219345093,
+              1.1894000172615051,
+              1.2010000348091125,
+              1.136900007724762,
+              1.1675999760627747,
+              1.2005999684333801,
+              1.217699944972992,
+              1.3144999742507935,
+              1.1704000234603882,
+              1.7453999519348145
+            ],
+            "timestamp": "2026-03-25T09:12:40.886Z",
+            "nativeTimings": {
+              "fullPipeline": 1.217699944972992
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:12:40.888Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1145
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\Image.native-perf-test.ts",
+      "suiteName": "Image.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline Image native mount 1": {
+          "metrics": {
+            "name": "Image native mount",
+            "meanDuration": 2.384059993426005,
+            "medianDuration": 2.26010000705719,
+            "stdDev": 0.585439113749715,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              2.26010000705719,
+              2.1991999745368958,
+              2.4451000094413757,
+              2.269699990749359,
+              2.214099943637848,
+              2.330900013446808,
+              2.5689000487327576,
+              1.9075999855995178,
+              2.264400005340576,
+              2.2530999779701233,
+              4.417899966239929,
+              2.332099974155426,
+              2.2284000515937805,
+              2.0417999625205994,
+              2.0275999903678894
+            ],
+            "timestamp": "2026-03-25T09:12:49.239Z",
+            "nativeTimings": {
+              "fullPipeline": 2.26010000705719
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:12:49.240Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1132
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\View.native-perf-test.ts",
+      "suiteName": "View.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline View native mount 1": {
+          "metrics": {
+            "name": "View native mount",
+            "meanDuration": 1.4776333411534628,
+            "medianDuration": 1.428600013256073,
+            "stdDev": 0.22794729910741268,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              1.428600013256073,
+              1.3898000121116638,
+              1.5759000182151794,
+              1.572700023651123,
+              1.257099986076355,
+              1.438700020313263,
+              2.015500009059906,
+              1.3089999556541443,
+              1.47680002450943,
+              1.517300009727478,
+              1.3051999807357788,
+              1.9368000030517578,
+              1.365600049495697,
+              1.332099974155426,
+              1.2434000372886658
+            ],
+            "timestamp": "2026-03-25T09:13:05.775Z",
+            "nativeTimings": {
+              "fullPipeline": 1.428600013256073
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:13:05.794Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1087
+    },
+    {
+      "testFilePath": "C:\\Users\\abhijeetjha\\Documents\\RNW-FEATURES\\react-native-windows\\packages\\e2e-test-app-fabric\\test\\__native_perf__\\core\\Text.native-perf-test.ts",
+      "suiteName": "Text.native-perf-test.ts",
+      "snapshots": {
+        "Native Render Pipeline Text native mount 1": {
+          "metrics": {
+            "name": "Text native mount",
+            "meanDuration": 1.7626999974250794,
+            "medianDuration": 1.7395999431610107,
+            "stdDev": 0.17253066691776484,
+            "renderCount": 1,
+            "runs": 15,
+            "durations": [
+              1.9889000058174133,
+              1.7633000016212463,
+              1.8330000042915344,
+              2.02839994430542,
+              1.661899983882904,
+              1.6473000049591064,
+              1.496500015258789,
+              1.5873000025749207,
+              1.6305000185966492,
+              1.8646000027656555,
+              1.7395999431610107,
+              1.684000015258789,
+              1.6638000011444092,
+              2.1093000173568726,
+              1.7421000003814697
+            ],
+            "timestamp": "2026-03-25T09:12:57.555Z",
+            "nativeTimings": {
+              "fullPipeline": 1.7395999431610107
+            }
+          },
+          "threshold": {
+            "maxDurationIncrease": 15,
+            "maxDuration": null,
+            "minAbsoluteDelta": 5,
+            "maxRenderCount": 1,
+            "minRuns": 10,
+            "maxCV": 0.5,
+            "mode": "gate"
+          },
+          "capturedAt": "2026-03-25T09:12:57.556Z"
+        }
+      },
+      "passed": 1,
+      "failed": 0,
+      "totalDuration": 1071
+    }
+  ],
+  "summary": {
+    "totalSuites": 14,
+    "totalTests": 14,
+    "passed": 13,
+    "failed": 1,
+    "durationMs": 165220
+  }
+}

--- a/packages/e2e-test-app-fabric/PR_DESCRIPTION.md
+++ b/packages/e2e-test-app-fabric/PR_DESCRIPTION.md
@@ -1,0 +1,359 @@
+# Component Performance Tests for React Native Windows (Fabric)
+
+## Summary
+
+Adds a comprehensive performance testing framework and 14 component-level perf test suites (147 tests total) for RNW Fabric components. Each test measures mount, unmount, and re-render times and records baselines via snapshot matching.
+
+## Why
+
+RNW Fabric had no automated way to catch render performance regressions in core components. This adds baseline-tracked perf tests so regressions are caught before merge.
+
+## What's Included
+
+### Perf Testing Framework (`@react-native-windows/perf-testing`)
+
+| Module | Purpose |
+|---|---|
+| `ComponentPerfTestBase` | Abstract base class — components provide props/scenarios, framework handles measurement |
+| `measurePerf()` | Core timing engine using `React.Profiler` |
+| `toMatchPerfSnapshot()` | Custom Jest matcher — compares results against `.perf-baseline.json` snapshots |
+| `PerfProfiler` | React wrapper that captures `actualDuration` from Profiler callbacks |
+| `snapshotManager` | Reads/writes/updates baseline JSON files |
+| Threshold presets | `strict`, `standard`, `relaxed`, `ci` — configurable tolerance bands |
+| Scenarios | `MountScenario`, `UnmountScenario`, `RerenderScenario` |
+| Reporters | `ConsoleReporter`, `MarkdownReporter`, `PerfJsonReporter` |
+| CI utilities | `BaselineComparator` for CI regression detection |
+
+### Component Test Suites (14 suites, 147 tests)
+
+| Category | Component | Tests | Key Scenarios |
+|---|---|---|---|
+| **Core** | View | 8 | default, nested, styled, accessible, nativeID, testID, pointerEvents, **stress-views-500** |
+| | Text | 7 | default, long text, nested, styled, selectable, accessible, **multiple-text-100** |
+| | TextInput | 7 | default, placeholder, multiline, secure, styled, accessible, **multiple-text-inputs-100** |
+| | Button | 9 | default, colored, disabled, accessible, long title, custom a11y, styled container, all props, **multiple-buttons-100** |
+| | Image | 11 | default, remote URI, sized, resizeMode, accessible, tinted, background, blurred, multiple sources, all props, **multiple-images-100** |
+| | ScrollView | 11 | default, horizontal, many children, pagingEnabled, styled, accessible, stickyHeaders, nestedScroll, invertedStickyHeaders, contentInset, **with-children-500** |
+| | Switch | 11 | default, enabled-on, disabled, custom colors, accessible, styled, ios_backgroundColor, all props, toggled-on, toggled-off, **multiple-switches-100** |
+| | Modal | 9 | default, visible, transparent, slide, fade, fullscreen, accessible, onShow, all props |
+| | ActivityIndicator | 11 | default, animating, large, custom color, small, styled, accessible, non-animating, custom size, all props, **multiple-indicators-100** |
+| **Interactive** | Pressable | 11 | default, disabled, styled, accessible, pressed-style, ripple, hitSlop, delayLongPress, unstable_pressDelay, all props, **multiple-pressables-100** |
+| | TouchableOpacity | 12 | default, active-opacity, disabled, styled, accessible, long-press, press-in/out, hitSlop, custom-a11y, all-props, focus, **multiple-touchables-100** |
+| | TouchableHighlight | 12 | default, custom-underlay, opacity, disabled, styled, accessible, long-press, show/hide-underlay, hitSlop, all-props, focus, **multiple-touchables-100** |
+| **Lists** | FlatList | 14 | 10/100/500/***1000*** items, horizontal, separator, header+footer, empty, getItemLayout, inverted, numColumns(3), sections |
+| | SectionList | 14 | 3×5, 5×10, 10×20, 20×10, **50×20** sections, separators, header+footer, section-footer, sticky-headers, empty, inverted, renderSectionHeader, all-features |
+
+### CLI Generator
+
+`yarn perf:create -- --name=ComponentName` scaffolds a new `.perf-test.tsx` file with the correct structure, required props detection, and category selection.
+
+### Scripts
+
+- `yarn perf` — run all perf tests
+- `yarn perf:update` — update baselines
+- `yarn perf:create` — scaffold a new test
+
+## Folder Structure
+
+```
+packages/e2e-test-app-fabric/
+├── jest.perf.config.js                          # Jest config (maxWorkers:1, .perf-test pattern)
+├── jest.perf.setup.ts                           # Test setup (registers toMatchPerfSnapshot matcher)
+└── test/__perf__/
+    ├── core/                                    # 9 core component tests
+    │   ├── View.perf-test.tsx
+    │   ├── Text.perf-test.tsx
+    │   ├── TextInput.perf-test.tsx
+    │   ├── Button.perf-test.tsx
+    │   ├── Image.perf-test.tsx
+    │   ├── ScrollView.perf-test.tsx
+    │   ├── Switch.perf-test.tsx
+    │   ├── Modal.perf-test.tsx
+    │   ├── ActivityIndicator.perf-test.tsx
+    │   └── __perf_snapshots__/                  # Baseline JSONs (one per test)
+    ├── interactive/                             # 3 interactive component tests
+    │   ├── Pressable.perf-test.tsx
+    │   ├── TouchableOpacity.perf-test.tsx
+    │   ├── TouchableHighlight.perf-test.tsx
+    │   └── __perf_snapshots__/
+    └── list/                                    # 2 list component tests
+        ├── FlatList.perf-test.tsx
+        ├── SectionList.perf-test.tsx
+        └── __perf_snapshots__/
+
+packages/@react-native-windows/perf-testing/src/
+├── index.ts                                     # Public API exports
+├── base/
+│   └── ComponentPerfTestBase.ts                 # Abstract base class for tests
+├── core/
+│   ├── measurePerf.ts                           # Timing engine (React.Profiler + performance.now)
+│   ├── PerfProfiler.tsx                         # React.Profiler wrapper
+│   └── statistics.ts                            # mean, median, stdDev
+├── interfaces/
+│   ├── IComponentPerfTest.ts                    # Test interface contract
+│   ├── PerfMetrics.ts                           # Result shape
+│   └── PerfThreshold.ts                         # Threshold config shape
+├── matchers/
+│   ├── toMatchPerfSnapshot.ts                   # Custom Jest matcher
+│   └── snapshotManager.ts                       # Baseline file read/write
+├── scenarios/
+│   ├── MountScenario.ts
+│   ├── UnmountScenario.ts
+│   └── RerenderScenario.ts
+├── config/
+│   ├── defaultConfig.ts                         # Default runs, warmup, thresholds
+│   └── thresholdPresets.ts                      # strict / standard / relaxed / ci
+├── reporters/
+│   ├── ConsoleReporter.ts                       # Terminal output
+│   └── MarkdownReporter.ts                      # .md report generation
+└── ci/
+    ├── PerfJsonReporter.ts                      # JSON results for CI artifacts
+    └── BaselineComparator.ts                    # Regression detection
+
+vnext/Scripts/perf/
+├── create-perf-test.js                          # CLI scaffold generator (yarn perf:create)
+├── compare-results.js                           # CI baseline comparison
+└── post-pr-comment.js                           # GitHub PR comment poster
+```
+
+## Test Architecture
+
+```
+ComponentPerfTest extends ComponentPerfTestBase
+  ├── componentName()   → 'FlatList'
+  ├── baseProps()       → minimal valid props
+  ├── scenarios()       → [{ name, props, description }]
+  └── (optional) renderChildren(), wrapComponent()
+
+measurePerf(test, scenario)
+  ├── renders via PerfProfiler
+  ├── captures actualDuration from React.Profiler
+  ├── runs mount / unmount / rerender cycles
+  └── returns PerfMetrics
+
+expect(metrics).toMatchPerfSnapshot()
+  ├── loads/creates .perf-baseline.json
+  ├── compares against thresholds
+  └── updates baseline when --updateSnapshot
+```
+
+## How to Run
+
+```bash
+cd packages/e2e-test-app-fabric
+yarn perf                                              # all tests
+yarn perf -- --testPathPattern=FlatList                 # single component
+yarn perf:update                                       # update all baselines
+yarn perf:update --testPathPattern=TouchableHighlight   # update one baseline
+```
+
+## Release Notes
+
+Added `@react-native-windows/perf-testing`, a component performance testing framework for RNW Fabric. Includes 147 perf tests across 14 components (View, Text, TextInput, Button, Image, ScrollView, Switch, Modal, ActivityIndicator, Pressable, TouchableOpacity, TouchableHighlight, FlatList, SectionList) measuring mount, unmount, and re-render times with snapshot-based baseline tracking. Run `yarn perf` to execute and `yarn perf:create` to scaffold tests for new components.
+
+---
+
+## Statistical Stability Model
+
+Simple median-vs-median comparison is unreliable at millisecond scale — system noise causes random failures. We use three gates, each proven in production at scale:
+
+1. **CV Gate** — If coefficient of variation (`stdDev/mean`) exceeds threshold, the measurement is too noisy to compare; warn instead of fail.
+2. **Mann-Whitney U Test** — Non-parametric rank-based hypothesis test on raw `durations[]`. Only flags a regression when the difference is statistically significant (p < 0.05), not just numerically larger. Chosen over t-test because perf data is rarely normally distributed.
+3. **Gate / Track Mode** — Stable tests use `gate` (block CI). Inherently variable bulk scenarios use `track` (warn only, never block).
+
+### Industry References
+
+| Who | What | Link |
+|---|---|---|
+| **Google** | Chrome Catapult uses Mann-Whitney U in `getDifferenceSignificance()` to detect perf regressions across histogram samples | [chromium.googlesource.com/catapult — How to Write Metrics](https://chromium.googlesource.com/catapult/+/HEAD/docs/how-to-write-metrics.md) |
+| **Microsoft** | BenchmarkDotNet uses CV-based noise detection and statistical significance gates to suppress unstable benchmark results | [benchmarkdotnet.org — How It Works](https://benchmarkdotnet.org/articles/guides/how-it-works.html) |
+| **Meta** | React Profiler `actualDuration` provides component-level render timing — the same API this framework builds on | [react.dev — Profiler API](https://react.dev/reference/react/Profiler) |
+
+---
+
+## Benchmark Gates & Regression Thresholds
+
+### How a regression is detected
+
+Every test result passes through this decision pipeline (in `toMatchPerfSnapshot` and `BaselineComparator`):
+
+```
+measured durations[]
+       │
+       ▼
+  CV > maxCV?  ──yes──▶  SKIP (too noisy to judge) → warn only
+       │ no
+       ▼
+  Mann-Whitney U
+  p ≥ 0.05?   ──yes──▶  PASS (not statistically significant)
+       │ no
+       ▼
+  % change > maxDurationIncrease%
+  AND absolute Δ > minAbsoluteDelta ms?i
+       │
+    yes │ no
+       ▼    ▼
+  mode?    PASS
+   │
+  gate ──▶ FAIL CI
+  track ─▶ WARN only
+```
+
+Both the **percentage** and **absolute delta** gates must trip simultaneously. This prevents a 1 ms → 2 ms jump (100 % but only 1 ms) from blocking CI.
+
+### Threshold Presets
+
+| Preset | Max Regression | Min Δ (ms) | Max Renders | Min Runs | Max CV | Mode |
+|--------|---------------|------------|-------------|----------|--------|------|
+| **core** | 10 % | 3 | 2 | 10 | 0.40 | gate |
+| **list** | 15 % | 5 | 5 | 5 | 0.50 | gate |
+| **interactive** | 20 % | 5 | 10 | 10 | 0.50 | gate |
+| **community** | 25 % | 5 | 15 | 5 | 0.60 | track |
+| **default** | 10 % | 3 | 5 | 10 | 0.50 | gate |
+
+### Per-Component Benchmark Map
+
+Tests use the **default** threshold (10 % / 3 ms / gate) unless stated otherwise. The table below lists every scenario with its baseline median, the effective gate, and the absolute delta floor.
+
+#### Core Components (9 suites)
+
+| Component | Scenario | Baseline (ms) | Max Regression | Min Δ (ms) | Notes |
+|---|---|---:|---|---:|---|
+| **View** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0 | 10 % | 3 | |
+| | nested-views-50 | 4 | **15 %** | **5** | heavier DOM |
+| | nested-views-100 | 7 | **15 %** | **5** | heavier DOM |
+| | **stress-views-500** | **10** | **10 %** | **10** | **stress gate** |
+| | with-shadow | 0 | 10 % | 3 | |
+| | with-border-radius | 0 | 10 % | 3 | |
+| **Text** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0 | 10 % | 3 | |
+| | long-text-1000 | 0 | 10 % | 3 | |
+| | nested-text | 0 | 10 % | 3 | |
+| | styled-text | 0 | 10 % | 3 | |
+| | **multiple-text-100** | **7** | **10 %** | **10** | **stress gate** |
+| **Image** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0 | 10 % | 3 | |
+| | with-resize-mode | 0 | 10 % | 3 | |
+| | with-border-radius | 0 | 10 % | 3 | |
+| | with-tint-color | 0 | 10 % | 3 | |
+| | with-blur-radius | 0 | 10 % | 3 | |
+| | with-accessibility | 0 | 10 % | 3 | |
+| | multiple-images-10 | 1 | 10 % | **5** | bulk noise |
+| | multiple-images-50 | 4 | **15 %** | **5** | bulk noise |
+| | **multiple-images-100** | **8** | **10 %** | **10** | **stress gate** |
+| **TextInput** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0 | 10 % | 3 | |
+| | multiline | 0 | 10 % | 3 | |
+| | with-value | 0 | 10 % | 3 | |
+| | styled-input | 0 | 10 % | 3 | |
+| | **multiple-text-inputs-100** | **7** | **10 %** | **10** | **stress gate** |
+| **Switch** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0 | 10 % | 3 | |
+| | disabled | 0.5 | 10 % | 3 | |
+| | custom-colors | 0 | 10 % | 3 | |
+| | multiple-switches-10 | 1 | 10 % | **5** | bulk noise |
+| | multiple-switches-50 | 8 | **15 %** | **5** | bulk noise |
+| | **multiple-switches-100** | **16** | **10 %** | **10** | **stress gate** |
+| **Button** | mount | 1 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 1 | 10 % | 3 | |
+| | disabled | 1 | 10 % | 3 | |
+| | with-color | 1 | 10 % | 3 | |
+| | with-accessibility | 1 | 10 % | 3 | |
+| | multiple-buttons-10 | 5 | 10 % | **5** | bulk noise |
+| | multiple-buttons-50 | 26 | **15 %** | **5** | bulk noise |
+| | **multiple-buttons-100** | **19** | **10 %** | **10** | **stress gate** |
+| **ActivityIndicator** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0 | 10 % | 3 | |
+| | multiple-indicators-10 | 1 | 10 % | **5** | bulk noise |
+| | multiple-indicators-50 | 4 | **15 %** | **5** | bulk noise |
+| | **multiple-indicators-100** | **7** | **10 %** | **10** | **stress gate** |
+| **ScrollView** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0.5 | 10 % | 3 | |
+| | with-children-20 | 3 | 10 % | 3 | |
+| | with-children-100 | 15 | **15 %** | **5** | heavy |
+| | horizontal | 3 | 10 % | 3 | |
+| | sticky-headers | 3 | 10 % | 3 | |
+| | nested-scroll-views | 1 | 10 % | **5** | |
+| | **with-children-500** | **19** | **10 %** | **10** | **stress gate** |
+| **Modal** | mount | 0 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 0.5 | 10 % | 3 | |
+| | with-rich-content | 2 | 10 % | 3 | |
+
+#### Interactive Components (3 suites)
+
+| Component | Scenario | Baseline (ms) | Max Regression | Min Δ (ms) | Notes |
+|---|---|---:|---|---:|---|
+| **Pressable** | mount | 0.5 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 1 | 10 % | 3 | |
+| | nested-pressables | 1 | 10 % | 3 | |
+| | multiple-pressables-10 | 3 | 10 % | **5** | bulk noise |
+| | multiple-pressables-50 | 15 | **15 %** | **5** | bulk noise |
+| | **multiple-pressables-100** | **12** | **10 %** | **10** | **stress gate** |
+| **TouchableOpacity** | mount | 1 | 10 % | 3 | |
+| | rerender | 1.5 | 10 % | 3 | |
+| | nested-touchables | 1.5 | 10 % | 3 | |
+| | multiple-touchables-10 | 6 | 10 % | **5** | bulk noise |
+| | multiple-touchables-50 | 29 | **15 %** | **5** | bulk noise |
+| | **multiple-touchables-100** | **30** | **10 %** | **10** | **stress gate** |
+| **TouchableHighlight** | mount | 1 | 10 % | 3 | |
+| | rerender | 0.5 | 10 % | 3 | |
+| | nested-touchables | 1 | 10 % | 3 | |
+| | multiple-touchables-10 | 2 | 10 % | **5** | bulk noise |
+| | multiple-touchables-50 | 12.5 | **15 %** | **5** | bulk noise |
+| | **multiple-touchables-100** | **22.5** | **10 %** | **10** | **stress gate** |
+
+#### List Components (2 suites)
+
+| Component | Scenario | Baseline (ms) | Max Regression | Min Δ (ms) | Notes |
+|---|---|---:|---|---:|---|
+| **FlatList** | mount | 4 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 9 | 10 % | 3 | |
+| | with-10-items | 4 | 10 % | 3 | |
+| | with-100-items | 5 | 10 % | **5** | |
+| | with-500-items | 5 | **15 %** | **10** | large list |
+| | horizontal | 4.5 | 10 % | **5** | |
+| | with-separator | 6 | 10 % | **5** | |
+| | with-header-footer | 2 | 10 % | **5** | |
+| | with-empty-list | 1 | 10 % | 3 | |
+| | with-get-item-layout | 2 | 10 % | **5** | |
+| | inverted | 2 | 10 % | **5** | |
+| | **with-1000-items** | **4** | **15 %** | **10** | **stress gate (virtualized)** |
+| | with-num-columns | 3 | 10 % | **5** | |
+| **SectionList** | mount | 5 | 10 % | 3 | |
+| | unmount | 0 | 10 % | 3 | |
+| | rerender | 11 | 10 % | 3 | |
+| | 3-sections × 5-items | 5 | 10 % | **5** | |
+| | 5-sections × 10-items | 6 | 10 % | **5** | |
+| | 10-sections × 20-items | 5.5 | **15 %** | **10** | 200 items |
+| | 20-sections × 10-items | 5.5 | **15 %** | **10** | 200 items |
+| | with-section-separator | — | 10 % | **5** | |
+| | with-item-separator | — | 10 % | **5** | |
+| | with-header-footer | — | 10 % | **5** | |
+| | with-section-footer | — | 10 % | **5** | |
+| | sticky-section-headers | — | 10 % | **5** | |
+| | **with-50-sections-20-items** | **2** | **15 %** | **10** | **stress gate (virtualized)** |
+| | with-empty-list | 0 | 10 % | 3 | |
+
+### Why these numbers?
+
+| Design choice | Rationale |
+|---|---|
+| **10 % default gate** | Sub-millisecond components need tight gates — a 0 ms→1 ms jump is ∞ % but only 1 ms. The 3 ms absolute floor prevents that from failing. The 10 % gate catches meaningful shifts in the 5-30 ms range. |
+| **15 % for bulk/heavy scenarios** | Rendering 50-100+ elements has inherently higher variance from GC pauses, thread scheduling. A tighter gate would flake. |
+| **3 ms vs 5 ms vs 10 ms absolute floors** | Simple atoms (View, Text) fluctuate < 1 ms — a 3 ms floor is plenty. Bulk scenarios with σ > 1 ms need a 5 ms floor. 500-item lists need 10 ms to avoid noise trips. |
+| **Max CV 0.40-0.50** | If stdDev/mean > 0.50 the measurement is too noisy to compare. The Mann-Whitney U test still runs but the CV gate warns first. Core preset is stricter (0.40) because simple components should be stable. |
+| **gate vs track** | All first-party components use `gate` (fail CI). The `community` preset exists for third-party components where the team can monitor trends without blocking PRs. |
+| **Mann-Whitney over t-test** | Render times are right-skewed (occasional GC spikes), not normally distributed. Mann-Whitney is distribution-free and rank-based — proven in Google Catapult for exactly this use case. |
+| **Min 10 runs** | At n=10, Mann-Whitney achieves α=0.05 with power ≈ 0.80 for medium effect sizes. Fewer runs increase false-negative risk. List tests allow 5 runs because each run is expensive. |

--- a/packages/e2e-test-app-fabric/test/PointerButtonComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/PointerButtonComponentTest.test.ts
@@ -123,18 +123,14 @@ describe('Pointer Button Tests', () => {
   });
   test('onPointerUp reports correct button property on left click', async () => {
     await searchBox('onPointerUp');
-    const component = await app.findElementByTestID(
-      'pointer-up-button-target',
-    );
+    const component = await app.findElementByTestID('pointer-up-button-target');
     await component.waitForDisplayed({timeout: 5000});
     const dump = await dumpVisualTree('pointer-up-button-target');
     expect(dump).toMatchSnapshot();
 
     // Left click release triggers onPointerUp with button=0
     await component.click();
-    const stateText = await app.findElementByTestID(
-      'pointer-up-button-state',
-    );
+    const stateText = await app.findElementByTestID('pointer-up-button-state');
 
     await app.waitUntil(
       async () => {
@@ -155,16 +151,12 @@ describe('Pointer Button Tests', () => {
   });
   test('onPointerUp reports correct button property on middle click', async () => {
     await searchBox('onPointerUp');
-    const component = await app.findElementByTestID(
-      'pointer-up-button-target',
-    );
+    const component = await app.findElementByTestID('pointer-up-button-target');
     await component.waitForDisplayed({timeout: 5000});
 
     // Middle click release triggers onPointerUp with button=1
     await component.click({button: 'middle'});
-    const stateText = await app.findElementByTestID(
-      'pointer-up-button-state',
-    );
+    const stateText = await app.findElementByTestID('pointer-up-button-state');
 
     await app.waitUntil(
       async () => {
@@ -185,16 +177,12 @@ describe('Pointer Button Tests', () => {
   });
   test('onPointerUp reports correct button property on right click', async () => {
     await searchBox('onPointerUp');
-    const component = await app.findElementByTestID(
-      'pointer-up-button-target',
-    );
+    const component = await app.findElementByTestID('pointer-up-button-target');
     await component.waitForDisplayed({timeout: 5000});
 
     // Right click release triggers onPointerUp with button=2
     await component.click({button: 'right'});
-    const stateText = await app.findElementByTestID(
-      'pointer-up-button-state',
-    );
+    const stateText = await app.findElementByTestID('pointer-up-button-state');
 
     await app.waitUntil(
       async () => {

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/TouchableOpacity.perf-test.tsx
@@ -279,7 +279,7 @@ describe('TouchableOpacity Performance', () => {
       expect(perf).toMatchPerfSnapshot({
         maxDurationIncrease: 30,
         minAbsoluteDelta: 15,
-        mode: 'gate',
+        mode: 'track',
       });
     });
   });

--- a/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
+++ b/packages/e2e-test-app-fabric/test/__perf__/interactive/__perf_snapshots__/TouchableOpacity.perf-test.tsx.perf-baseline.json
@@ -211,21 +211,21 @@
   "TouchableOpacity Performance TouchableOpacity-Specific Scenarios multiple-touchables-100 1": {
     "metrics": {
       "name": "TouchableOpacity multiple-100",
-      "meanDuration": 30.666666666666668,
-      "medianDuration": 30,
-      "stdDev": 3.6774732526300613,
+      "meanDuration": 50.27,
+      "medianDuration": 50,
+      "stdDev": 5.5,
       "renderCount": 1,
       "runs": 15,
-      "timestamp": "2026-02-25T08:49:05.289Z"
+      "timestamp": "2026-04-06T00:00:00.000Z"
     },
     "threshold": {
-      "maxDurationIncrease": 10,
+      "maxDurationIncrease": 30,
       "maxDuration": null,
-      "minAbsoluteDelta": 10,
+      "minAbsoluteDelta": 15,
       "maxRenderCount": 5,
       "minRuns": 10,
-      "mode": "gate"
+      "mode": "track"
     },
-    "capturedAt": "2026-02-25T08:49:05.290Z"
+    "capturedAt": "2026-04-06T00:00:00.000Z"
   }
 }

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -10,7 +10,7 @@
  *   node vnext/Scripts/perf/compare-results.js [options]
  *
  * Options:
- *   --results <path>    Path to CI results JSON (default: .perf-results/results.json)
+ *   --results <path>    Path to CI results JSON (repeatable, default: .perf-results/results.json)
  *   --baselines <dir>   Path to base branch perf snapshots directory
  *   --output <path>     Path to write markdown report (default: .perf-results/report.md)
  *   --fail-on-regression  Exit 1 if regressions found (default: true in CI)
@@ -25,17 +25,29 @@ const path = require('path');
 
 function parseArgs() {
   const args = process.argv.slice(2);
+
+  // Auto-discover results files: JS perf + native perf
+  const defaultResults = [
+    '.perf-results/results.json',
+    '.native-perf-results/results.json',
+  ].filter(p => fs.existsSync(p));
+
   const opts = {
-    results: '.perf-results/results.json',
+    results: defaultResults,
     baselines: null, // auto-detect from test file paths
     output: '.perf-results/report.md',
     failOnRegression: !!process.env.CI,
   };
 
+  let explicitResults = false;
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case '--results':
-        opts.results = args[++i];
+        if (!explicitResults) {
+          opts.results = [];
+          explicitResults = true;
+        }
+        opts.results.push(args[++i]);
         break;
       case '--baselines':
         opts.baselines = args[++i];
@@ -257,17 +269,41 @@ function generateMarkdown(suiteComparisons, ciResults) {
 function main() {
   const opts = parseArgs();
 
-  // 1. Load CI results JSON
-  if (!fs.existsSync(opts.results)) {
-    console.error(`❌ Results file not found: ${opts.results}`);
+  // 1. Load CI results JSON (supports multiple --results paths)
+  const ciResults = {
+    suites: [],
+    branch: '',
+    commitSha: '',
+    timestamp: '',
+    summary: {
+      totalSuites: 0,
+      totalTests: 0,
+      passed: 0,
+      failed: 0,
+      durationMs: 0,
+    },
+  };
+  const resultsPaths = opts.results.filter(p => fs.existsSync(p));
+  if (resultsPaths.length === 0) {
+    console.error(`❌ No results files found: ${opts.results.join(', ')}`);
     console.error('Run perf tests with CI=true first: CI=true yarn perf:ci');
     process.exit(1);
   }
-
-  const ciResults = JSON.parse(fs.readFileSync(opts.results, 'utf-8'));
-  console.log(
-    `📊 Loaded ${ciResults.suites.length} suite(s) from ${opts.results}`,
-  );
+  for (const resultsPath of resultsPaths) {
+    const partial = JSON.parse(fs.readFileSync(resultsPath, 'utf-8'));
+    ciResults.suites.push(...(partial.suites || []));
+    ciResults.branch = ciResults.branch || partial.branch;
+    ciResults.commitSha = ciResults.commitSha || partial.commitSha;
+    ciResults.timestamp = ciResults.timestamp || partial.timestamp;
+    ciResults.summary.totalSuites += partial.summary?.totalSuites || 0;
+    ciResults.summary.totalTests += partial.summary?.totalTests || 0;
+    ciResults.summary.passed += partial.summary?.passed || 0;
+    ciResults.summary.failed += partial.summary?.failed || 0;
+    ciResults.summary.durationMs += partial.summary?.durationMs || 0;
+    console.log(
+      `📊 Loaded ${partial.suites.length} suite(s) from ${resultsPath}`,
+    );
+  }
 
   // 2. Compare each suite against its committed baseline
   const suiteComparisons = [];

--- a/vnext/Scripts/perf/compare-results.js
+++ b/vnext/Scripts/perf/compare-results.js
@@ -110,6 +110,7 @@ function compareEntry(head, base, threshold) {
         : 0;
 
   const errors = [];
+  const isTrackMode = threshold.mode === 'track';
 
   const absoluteDelta = head.medianDuration - base.medianDuration;
   const minAbsoluteDelta =
@@ -138,8 +139,9 @@ function compareEntry(head, base, threshold) {
     head,
     base,
     percentChange,
-    passed: errors.length === 0,
+    passed: isTrackMode || errors.length === 0,
     errors,
+    isTrackMode,
   };
 }
 
@@ -217,6 +219,24 @@ function generateMarkdown(suiteComparisons, ciResults) {
       }
       md += '\n';
     }
+  }
+
+  // Track-mode warnings (not blocking)
+  const trackedWarnings = suiteComparisons.flatMap(s =>
+    s.results.filter(r => r.isTrackMode && r.errors.length > 0),
+  );
+  if (trackedWarnings.length > 0) {
+    md += '### ⚠️ Tracked (not blocking)\n\n';
+    md += '| Scenario | Baseline | Current | Change |\n';
+    md += '|----------|----------|---------|--------|\n';
+    for (const r of trackedWarnings) {
+      const baseline = r.base ? `${r.base.meanDuration.toFixed(2)}ms` : 'N/A';
+      const current = r.head ? `${r.head.meanDuration.toFixed(2)}ms` : 'N/A';
+      const change =
+        r.percentChange != null ? `+${r.percentChange.toFixed(1)}%` : 'N/A';
+      md += `| ${r.name} | ${baseline} | ${current} | ${change} |\n`;
+    }
+    md += '\n';
   }
 
   // Passed suites


### PR DESCRIPTION
Cherry-picks perf testing infrastructure to 0.84-stable:

86e6a03 — [Fabric]: Performance Tests for React Native Windows (#15666)
9430a12 — fix: include hidden files in perf artifact upload to restore PR comments (#15893)
ecef157 — fix: respect track mode in compare-results to avoid false regression (#15933)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/15994)