### PR TITLE
[0.83] Fix multiline TextInput crash from TxDrawD2D reentrancy (#15990)

### DIFF
--- a/change/react-native-windows-fd21e9f2-3f90-4b4a-94f5-fbf8802080dc.json
+++ b/change/react-native-windows-fd21e9f2-3f90-4b4a-94f5-fbf8802080dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix multiline TextInput crash from TxDrawD2D reentrancy",
+  "packageName": "react-native-windows",
+  "email": "74712637+iamAbhi-916@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1780,7 +1780,10 @@ void WindowsTextInputComponentView::DrawText() noexcept {
       }
 
       // TODO keep track of proper invalid rect
+      // Prevent reentrancy: TxDrawD2D may call TxViewChange -> DrawText
+      m_cDrawBlock++;
       auto hrDraw = m_textServices->TxDrawD2D(d2dDeviceContext, &rc, nullptr, TXTVIEW_ACTIVE);
+      m_cDrawBlock--;
       winrt::check_hresult(hrDraw);
 
       // draw placeholder text if needed


### PR DESCRIPTION
cherry pick : https://github.com/microsoft/react-native-windows/commit/778a82d434d097117ca3e3e6f77c47ece95f132f
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16004)