### PR TITLE
[fix] touch issues

### DIFF
--- a/change/react-native-windows-83b6df1e-ce5d-4de3-9cf1-2a5b8f9b74f5.json
+++ b/change/react-native-windows-83b6df1e-ce5d-4de3-9cf1-2a5b8f9b74f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed: Touch screen events not properly captured for pressable and text inputs",
+  "packageName": "react-native-windows",
+  "email": "gordomacmaster@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -358,6 +358,7 @@ CompositionEventHandler::~CompositionEventHandler() {
       pointerSource.PointerMoved(m_pointerMovedToken);
       pointerSource.PointerCaptureLost(m_pointerCaptureLostToken);
       pointerSource.PointerWheelChanged(m_pointerWheelChangedToken);
+      pointerSource.PointerExited(m_pointerExitedToken);
       auto keyboardSource = winrt::Microsoft::UI::Input::InputKeyboardSource::GetForIsland(island);
       keyboardSource.KeyDown(m_keyDownToken);
       keyboardSource.KeyUp(m_keyUpToken);
@@ -1185,9 +1186,12 @@ void CompositionEventHandler::onPointerPressed(
   });
 
   if (staleTouch != m_activeTouches.end()) {
-    // A pointer with this ID already exists - Should we fire a button cancel or something?
-    // assert(false);
-    return;
+    // A previous pointer with this ID was never properly released (e.g., app lost focus,
+    // pointer left window). Cancel the stale touch and clean it up so the new press can proceed.
+    if (staleTouch->second.eventEmitter) {
+      DispatchSynthesizedTouchCancelForActiveTouch(staleTouch->second, pointerPoint, keyModifiers);
+    }
+    m_activeTouches.erase(staleTouch);
   }
 
   const auto eventType = TouchEventType::Start;
@@ -1246,6 +1250,12 @@ void CompositionEventHandler::onPointerPressed(
       targetComponentView = targetComponentView.Parent();
     }
 
+    // Don't register the touch if no eventEmitter was found — inserting a null-emitter entry
+    // into m_activeTouches would block future presses with the same pointer ID.
+    if (!activeTouch.eventEmitter) {
+      return;
+    }
+
     UpdateActiveTouch(activeTouch, ptScaled, ptLocal);
 
     // activeTouch.touch.isPrimary = true;
@@ -1283,8 +1293,13 @@ void CompositionEventHandler::onPointerReleased(
     facebook::react::Point ptLocal, ptScaled;
     getTargetPointerArgs(fabricuiManager, pointerPoint, tag, ptScaled, ptLocal);
 
-    if (tag == -1)
+    if (tag == -1) {
+      if (activeTouch->second.eventEmitter) {
+        DispatchSynthesizedTouchCancelForActiveTouch(activeTouch->second, pointerPoint, keyModifiers);
+      }
+      m_activeTouches.erase(pointerId);
       return;
+    }
 
     auto targetComponentView = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(tag).view;
     auto args = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerRoutedEventArgs>(
@@ -1454,6 +1469,47 @@ facebook::react::PointerEvent CompositionEventHandler::CreatePointerEventFromAct
   // event.isPrimary = activeTouch.isPrimary;
 
   return event;
+}
+
+void CompositionEventHandler::DispatchSynthesizedTouchCancelForActiveTouch(
+    const ActiveTouch &cancelledTouch,
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
+    winrt::Windows::System::VirtualKeyModifiers keyModifiers) {
+  if (!cancelledTouch.eventEmitter) {
+    return;
+  }
+
+  facebook::react::PointerEvent pointerEvent =
+      CreatePointerEventFromActiveTouch(cancelledTouch, TouchEventType::Cancel);
+  winrt::Microsoft::ReactNative::ComponentView targetView{nullptr};
+  facebook::react::SharedTouchEventEmitter emitter = cancelledTouch.eventEmitter;
+  auto pointerHandler = [emitter, pointerEvent](std::vector<winrt::Microsoft::ReactNative::ComponentView> &) {
+    emitter->onPointerCancel(pointerEvent);
+  };
+  HandleIncomingPointerEvent(pointerEvent, targetView, pointerPoint, keyModifiers, pointerHandler);
+
+  facebook::react::TouchEvent touchEvent;
+  touchEvent.changedTouches.insert(cancelledTouch.touch);
+
+  for (const auto &pair : m_activeTouches) {
+    if (!pair.second.eventEmitter || pair.second.eventEmitter != cancelledTouch.eventEmitter) {
+      continue;
+    }
+
+    if (touchEvent.changedTouches.find(pair.second.touch) != touchEvent.changedTouches.end()) {
+      continue;
+    }
+
+    touchEvent.touches.insert(pair.second.touch);
+  }
+
+  for (const auto &pair : m_activeTouches) {
+    if (pair.second.eventEmitter == cancelledTouch.eventEmitter) {
+      touchEvent.targetTouches.insert(pair.second.touch);
+    }
+  }
+
+  cancelledTouch.eventEmitter->onTouchCancel(touchEvent);
 }
 
 // If we have events that include multiple pointer updates, we should change arg from pointerId to vector<pointerId>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1181,9 +1181,7 @@ void CompositionEventHandler::onPointerPressed(
 
   PointerId pointerId = pointerPoint.PointerId();
 
-  auto staleTouch = std::find_if(m_activeTouches.begin(), m_activeTouches.end(), [pointerId](const auto &pair) {
-    return pair.second.touch.identifier == pointerId;
-  });
+  auto staleTouch = m_activeTouches.find(pointerId);
 
   if (staleTouch != m_activeTouches.end()) {
     // A previous pointer with this ID was never properly released (e.g., app lost focus,
@@ -1279,9 +1277,7 @@ void CompositionEventHandler::onPointerReleased(
     winrt::Windows::System::VirtualKeyModifiers keyModifiers) noexcept {
   int pointerId = pointerPoint.PointerId();
 
-  auto activeTouch = std::find_if(m_activeTouches.begin(), m_activeTouches.end(), [pointerId](const auto &pair) {
-    return pair.second.touch.identifier == pointerId;
-  });
+  auto activeTouch = m_activeTouches.find(pointerId);
 
   if (activeTouch == m_activeTouches.end()) {
     return;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -149,6 +149,11 @@ class CompositionEventHandler : public std::enable_shared_from_this<CompositionE
   static void
   UpdateActiveTouch(ActiveTouch &activeTouch, facebook::react::Point ptScaled, facebook::react::Point ptLocal) noexcept;
 
+  void DispatchSynthesizedTouchCancelForActiveTouch(
+      const ActiveTouch &cancelledTouch,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
+      winrt::Windows::System::VirtualKeyModifiers keyModifiers);
+
   void UpdateCursor() noexcept;
   void SetCursor(facebook::react::Cursor cursor, HCURSOR hcur) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -697,10 +697,14 @@ void WindowsTextInputComponentView::OnPointerPressed(
         wParam |= (XBUTTON2 << 16);
         break;
     }
-    wParam = PointerRoutedEventArgsToMouseWParam(args);
+    wParam |= PointerRoutedEventArgsToMouseWParam(args);
   } else {
-    msg = WM_POINTERDOWN;
-    wParam = PointerPointToPointerWParam(pp);
+    if (IsDoubleClick()) {
+      msg = WM_LBUTTONDBLCLK;
+    } else {
+      msg = WM_LBUTTONDOWN;
+    }
+    wParam = PointerRoutedEventArgsToMouseWParam(args);
   }
 
   if (m_textServices && msg) {
@@ -762,10 +766,10 @@ void WindowsTextInputComponentView::OnPointerReleased(
         wParam |= (XBUTTON2 << 16);
         break;
     }
-    wParam = PointerRoutedEventArgsToMouseWParam(args);
+    wParam |= PointerRoutedEventArgsToMouseWParam(args);
   } else {
-    msg = WM_POINTERUP;
-    wParam = PointerPointToPointerWParam(pp);
+    msg = WM_LBUTTONUP;
+    wParam = PointerRoutedEventArgsToMouseWParam(args);
   }
 
   if (m_textServices && msg) {
@@ -819,8 +823,8 @@ void WindowsTextInputComponentView::OnPointerMoved(
     msg = WM_MOUSEMOVE;
     wParam = PointerRoutedEventArgsToMouseWParam(args);
   } else {
-    msg = WM_POINTERUPDATE;
-    wParam = PointerPointToPointerWParam(pp);
+    msg = WM_MOUSEMOVE;
+    wParam = PointerRoutedEventArgsToMouseWParam(args);
   }
 
   if (m_textServices) {
@@ -828,10 +832,10 @@ void WindowsTextInputComponentView::OnPointerMoved(
     DrawBlock db(*this);
     auto hr = m_textServices->TxSendMessage(msg, static_cast<WPARAM>(wParam), static_cast<LPARAM>(lParam), &lresult);
     args.Handled(hr != S_FALSE);
-  }
 
-  m_textServices->OnTxSetCursor(
-      DVASPECT_CONTENT, -1, nullptr, nullptr, nullptr, nullptr, nullptr, ptContainer.x, ptContainer.y);
+    m_textServices->OnTxSetCursor(
+        DVASPECT_CONTENT, -1, nullptr, nullptr, nullptr, nullptr, nullptr, ptContainer.x, ptContainer.y);
+  }
 }
 
 void WindowsTextInputComponentView::OnPointerWheelChanged(
@@ -933,7 +937,7 @@ bool WindowsTextInputComponentView::ShouldSubmit(
         bool ctrlDown = (args.KeyboardSource().GetKeyState(winrt::Windows::System::VirtualKey::Control) &
                          winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
             winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
-        bool altDown = (args.KeyboardSource().GetKeyState(winrt::Windows::System::VirtualKey::Control) &
+        bool altDown = (args.KeyboardSource().GetKeyState(winrt::Windows::System::VirtualKey::Menu) &
                         winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ==
             winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
         bool metaDown = (args.KeyboardSource().GetKeyState(winrt::Windows::System::VirtualKey::LeftWindows) &
@@ -944,7 +948,7 @@ bool WindowsTextInputComponentView::ShouldSubmit(
                 winrt::Microsoft::UI::Input::VirtualKeyStates::Down;
         return (submitKeyEvent.shiftKey && shiftDown) || (submitKeyEvent.ctrlKey && ctrlDown) ||
             (submitKeyEvent.altKey && altDown) || (submitKeyEvent.metaKey && metaDown) ||
-            (!submitKeyEvent.shiftKey && !submitKeyEvent.altKey && !submitKeyEvent.metaKey && !submitKeyEvent.altKey &&
+            (!submitKeyEvent.shiftKey && !submitKeyEvent.ctrlKey && !submitKeyEvent.altKey && !submitKeyEvent.metaKey &&
              !shiftDown && !ctrlDown && !altDown && !metaDown);
       } else {
         shouldSubmit = false;


### PR DESCRIPTION
## Description
This PR fixes touch input handling for Pressable and TextInput components on Windows by: (1) detecting and cancelling stale active touches in onPointerPressed when a pointer ID is reused without a prior release, (2) synthesizing a touch-cancel when a pointer is released outside any view (tag == -1), and (3) emitting the onPressIn event from WindowsTextInputComponentView. The new DispatchSynthesizedTouchCancelForActiveTouch helper correctly scopes cancels to a single emitter (avoiding the previous spurious broadcast to all emitters), but its touches list is built per-emitter rather than from all active touches, which is inconsistent with DispatchTouchEvent and the W3C spec.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Touch screens cannot focus on text input and have flaky pressable areas. 

### What
Improved ouch event handling

## Changelog
Should this change be included in the release notes: yes

Fixed touch screen events not properly captured for pressable and text inputs

```mermaid
flowchart TD
    A[Pointer Event] --> B{PointerDeviceType?}
    B -->|Mouse| C[Switch on PointerUpdateKind]
    B -->|Touch / Pen| D[IsDoubleClick?]
    C --> E[WM_LBUTTONDOWN / DBLCLK / UP / RBUTTONUP etc.]
    D -->|Yes| F[WM_LBUTTONDBLCLK]
    D -->|No| G[WM_LBUTTONDOWN or WM_LBUTTONUP]
    E --> H[TxSendMessage to RichEdit]
    F --> H
    G --> H
    H --> I[args.Handled]
    A --> J[Emit GestureResponderEvent]
    J -->|Pressed| K[onPressIn]
    J -->|Released| L[onPressOut]
```

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[onPointerPressed] --> B{Stale touch\nfor same pointer ID?}
    B -- Yes --> C[DispatchSynthesizedTouchCancelForActiveTouch\nstale touch]
    C --> D[Erase stale touch\nfrom m_activeTouches]
    D --> E[Register new touch &\nDispatchTouchEvent Start]
    B -- No --> E

    F[onPointerReleased] --> G{tag == -1?\nPointer outside view}
    G -- Yes --> H[DispatchSynthesizedTouchCancelForActiveTouch\nactive touch]
    H --> I[Erase touch & return]
    G -- No --> J[DispatchTouchEvent End\nErase touch]

    subgraph DispatchSynthesizedTouchCancelForActiveTouch
        K[Fire onPointerCancel\nvia HandleIncomingPointerEvent] --> L[Build TouchEvent:\nchangedTouches = cancelled touch\ntouches = same-emitter touches only ⚠️\ntargetTouches = same-emitter touches]
        L --> M[Fire onTouchCancel\non cancelled emitter only]
    end
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16009)