### PR TITLE
[0.84] fix: Improvements on MSRC CLI

### DIFF
--- a/change/@react-native-windows-cli-9830d0c0-7418-4c74-bfc3-f1db60545711.json
+++ b/change/@react-native-windows-cli-9830d0c0-7418-4c74-bfc3-f1db60545711.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix command injection in cleanProject() (CWE-78) and argument injection in uninstallAppPackage() (CWE-88)",
+  "packageName": "@react-native-windows/cli",
+  "email": "nitchaudhary@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
@@ -45,11 +45,11 @@ export default class MSBuildTools {
   }
 
   cleanProject(slnFile: string) {
-    const cmd = `"${path.join(
-      this.msbuildPath(),
-      'msbuild.exe',
-    )}" "${slnFile}" /t:Clean`;
-    const results = child_process.execSync(cmd).toString().split(EOL);
+    const msbuild = path.join(this.msbuildPath(), 'msbuild.exe');
+    const results = child_process
+      .execFileSync(msbuild, [slnFile, '/t:Clean'])
+      .toString()
+      .split(EOL);
     results.forEach(result => console.log(chalk.white(result)));
   }
 

--- a/packages/@react-native-windows/cli/src/utils/winappdeploytool.ts
+++ b/packages/@react-native-windows/cli/src/utils/winappdeploytool.ts
@@ -157,7 +157,7 @@ export default class WinAppDeployTool {
       newSpinner(text),
       text,
       this.path,
-      `uninstall -package ${appName} -ip {$targetDevice.ip}`.split(' '),
+      ['uninstall', '-package', appName, '-ip', targetDevice.ip],
       verbose,
       'UninstallAppOnDeviceFailure',
     );


### PR DESCRIPTION
* fix: resolve MSRC command/argument injection vulnerabilities in CLI

- MSRC 112511: Replace execSync with execFileSync in msbuildtools.ts cleanProject() to prevent shell command injection via slnFile parameter (CWE-78)
- MSRC 112495/112540: Replace .split(' ') anti-pattern with discrete argument array in winappdeploytool.ts uninstallAppPackage() to prevent argument injection via appName parameter (CWE-88)
- Also fixes {$targetDevice.ip} syntax bug (was never interpolating the IP address)


Cherry pick: #15974
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16010)