### PR TITLE
Ignore fixed versions for dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,17 @@ updates:
       update-types:
         - 'minor'
         - 'patch'
+  ignore:
+    # Pin @types/react* to the React 18.2 minor used by this branch.
+    # Bumping to 18.3 breaks TS compilation against the React 18.2 runtime.
+    - dependency-name: "@types/react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "@types/react-dom"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
   schedule:
     interval: weekly
     time: "05:00"
@@ -57,6 +68,16 @@ updates:
       update-types:
         - 'minor'
         - 'patch'
+  ignore:
+    # Pin @types/react* to the React 19.1 minor used by this branch.
+    - dependency-name: "@types/react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "@types/react-dom"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
   schedule:
     interval: weekly
     time: "05:00"
@@ -79,6 +100,16 @@ updates:
       update-types:
         - 'minor'
         - 'patch'
+  ignore:
+    # Pin @types/react* to the React 19.1 minor used by this branch.
+    - dependency-name: "@types/react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "@types/react-dom"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
   schedule:
     interval: weekly
     time: "05:00"
@@ -101,6 +132,16 @@ updates:
       update-types:
         - 'minor'
         - 'patch'
+  ignore:
+    # Pin @types/react* to the React 19.2 minor used by this branch.
+    - dependency-name: "@types/react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "@types/react-dom"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
   schedule:
     interval: weekly
     time: "05:00"
@@ -123,6 +164,16 @@ updates:
       update-types:
         - 'minor'
         - 'patch'
+  ignore:
+    # Pin @types/react* to the React 19.2 minor used by this branch.
+    - dependency-name: "@types/react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "@types/react-dom"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
   schedule:
     interval: weekly
     time: "05:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,20 @@ updates:
         - 'minor'
         - 'patch'
   ignore:
-    # Pin @types/react* to the React 18.2 minor used by this branch.
+    # Pin react + react-native + react-test-renderer + @types/react* to the React 18.2 minor used by this branch.
     # Bumping to 18.3 breaks TS compilation against the React 18.2 runtime.
+    - dependency-name: "react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-native"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-test-renderer"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
     - dependency-name: "@types/react"
       update-types:
         - "version-update:semver-minor"
@@ -69,7 +81,19 @@ updates:
         - 'minor'
         - 'patch'
   ignore:
-    # Pin @types/react* to the React 19.1 minor used by this branch.
+    # Pin react + react-native + react-test-renderer + @types/react* to the React 19.1 minor used by this branch.
+    - dependency-name: "react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-native"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-test-renderer"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
     - dependency-name: "@types/react"
       update-types:
         - "version-update:semver-minor"
@@ -101,7 +125,19 @@ updates:
         - 'minor'
         - 'patch'
   ignore:
-    # Pin @types/react* to the React 19.1 minor used by this branch.
+    # Pin react + react-native + react-test-renderer + @types/react* to the React 19.1 minor used by this branch.
+    - dependency-name: "react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-native"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-test-renderer"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
     - dependency-name: "@types/react"
       update-types:
         - "version-update:semver-minor"
@@ -133,7 +169,19 @@ updates:
         - 'minor'
         - 'patch'
   ignore:
-    # Pin @types/react* to the React 19.2 minor used by this branch.
+    # Pin react + react-native + react-test-renderer + @types/react* to the React 19.2 minor used by this branch.
+    - dependency-name: "react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-native"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-test-renderer"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
     - dependency-name: "@types/react"
       update-types:
         - "version-update:semver-minor"
@@ -165,7 +213,19 @@ updates:
         - 'minor'
         - 'patch'
   ignore:
-    # Pin @types/react* to the React 19.2 minor used by this branch.
+    # Pin react + react-native + react-test-renderer + @types/react* to the React 19.2 minor used by this branch.
+    - dependency-name: "react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-native"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-test-renderer"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
     - dependency-name: "@types/react"
       update-types:
         - "version-update:semver-minor"


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
Dependabot's grouped `all-dependencies` updates on stable branches can sweep in a minor bump of `@types/react` that is incompatible with the branch's frozen `react` runtime. On `0.74-stable` this surfaced as [#15911](https://github.com/microsoft/react-native-windows/pull/15911) — bumping `@types/react` from 18.2.67 → 18.3.28 broke TS compilation with a `forwardRef` inference error in `KeyboardExt.tsx`:

```
src-win/Libraries/Components/Keyboard/KeyboardExt.tsx(34,5): error TS2345:
  Argument of type '(props: PropsWithoutForwardedRef, ref: React.Ref<any>) => React.JSX.Element'
  is not assignable to parameter of type 'ForwardRefRenderFunction<any, PropsWithoutRef<PropsWithoutForwardedRef>>'.
```

Because `@types/react` is declared with a caret range (e.g. `^18.2.6`, `^19.1.4`) in the package.jsons, Dependabot's `lockfile-only` strategy still proposes minor bumps within that range — even though the paired `react` runtime is effectively pinned on each stable branch. The whole React family (`react`, `react-native`, `react-test-renderer`, `@types/react`) moves together, so any of them drifting to a different minor can break the build.

With the `all-dependencies: '*'` catch-all group (introduced in [#15856](https://github.com/microsoft/react-native-windows/pull/15856)) one bad package bump now blocks the entire grouped PR, where previously each update was a standalone PR that could be closed individually. The grouping is still a good idea for signal-to-noise; it just needs explicit `ignore` rules for packages that are version-locked to the branch's frozen React runtime.

Resolves #15911 (the bad bump will no longer be proposed on the next Dependabot run).

### What
Added an `ignore:` block to each of the five stable-branch update entries in `.github/dependabot.yml`:

| Branch | `react` | Locked minor for React family |
|---|---|---|
| `0.74-stable` | 18.2.0 | 18.2.x |
| `0.81-stable` | 19.1.4 | 19.1.x |
| `0.82-stable` | 19.1.1 | 19.1.x |
| `0.83-stable` | 19.2.0 | 19.2.x |
| `0.84-stable` | 19.2.3 | 19.2.x |

Each ignore block filters `version-update:semver-minor` and `version-update:semver-major` updates for:
- `react`
- `react-native`
- `react-test-renderer`
- `@types/react`
- `@types/react-dom` (defensive — not currently in any stable-branch `package.json`, but pinned if added later)

Patch updates still flow through, so security patches within the locked minor continue to land.

The `main`-branch entry is **unchanged** — it should keep tracking upstream React releases.

## Screenshots
N/A

## Testing
Dependabot configuration is declarative YAML; changes take effect on the next scheduled Dependabot run. No local tests applicable.

Follow-up after merge:
- Close [#15911](https://github.com/microsoft/react-native-windows/pull/15911) and delete its `dependabot/npm_and_yarn/0.74-stable/types/react-18.3.28` branch. Dependabot will not recreate it on the next weekly run because 18.3.x is now filtered out of the group.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16036)