### PR TITLE
[0.82 stable]fix: resolve MSRC command/argument injection vulnerabilities in CLI

### DIFF
--- a/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
@@ -45,11 +45,11 @@ export default class MSBuildTools {
   }
 
   cleanProject(slnFile: string) {
-    const cmd = `"${path.join(
-      this.msbuildPath(),
-      'msbuild.exe',
-    )}" "${slnFile}" /t:Clean`;
-    const results = child_process.execSync(cmd).toString().split(EOL);
+    const msbuild = path.join(this.msbuildPath(), 'msbuild.exe');
+    const results = child_process
+      .execFileSync(msbuild, [slnFile, '/t:Clean'])
+      .toString()
+      .split(EOL);
     results.forEach(result => console.log(chalk.white(result)));
   }
 

--- a/packages/@react-native-windows/cli/src/utils/winappdeploytool.ts
+++ b/packages/@react-native-windows/cli/src/utils/winappdeploytool.ts
@@ -157,7 +157,7 @@ export default class WinAppDeployTool {
       newSpinner(text),
       text,
       this.path,
-      `uninstall -package ${appName} -ip {$targetDevice.ip}`.split(' '),
+      ['uninstall', '-package', appName, '-ip', targetDevice.ip],
       verbose,
       'UninstallAppOnDeviceFailure',
     );


### PR DESCRIPTION
- MSRC 112511: Replace execSync with execFileSync in msbuildtools.ts cleanProject() to prevent shell command injection via slnFile parameter (CWE-78)
- MSRC 112495/112540: Replace .split(' ') anti-pattern with discrete argument array in winappdeploytool.ts uninstallAppPackage() to prevent argument injection via appName parameter (CWE-88)
- Also fixes {$targetDevice.ip} syntax bug (was never interpolating the IP address)

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_

Add a brief summary of the change to use in the release notes for the next release.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16056)