### PR TITLE
[0.84] fix: map Windows touch pointer IDs to small JS-safe identifiers in CompositionEventHandle

### DIFF
--- a/change/react-native-windows-2c040593-f202-44fc-a55c-5d523c493705.json
+++ b/change/react-native-windows-2c040593-f202-44fc-a55c-5d523c493705.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: map Windows touch pointer IDs to small JS-safe identifiers in CompositionEventHandler",
+  "packageName": "react-native-windows",
+  "email": "gordomacmaster@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1218,10 +1218,14 @@ void CompositionEventHandler::onPointerExited(
 // touch handler uses identifiers as array indices and warns/misbehaves for values > 20.
 // This function maps each live Windows pointer to a small identifier in [0, 19] by
 // scanning m_activeTouches for in-use slots and cycling from the last assigned index.
+// Identifier MOUSE_POINTER_ID (1) is permanently reserved for mouse and never returned here.
 int CompositionEventHandler::AllocateTouchIdentifier() noexcept {
   constexpr int kMaxTouchIdentifier = 20;
   for (int i = 0; i < kMaxTouchIdentifier; i++) {
     int candidate = (m_touchId + i) % kMaxTouchIdentifier;
+    if (candidate == static_cast<int>(MOUSE_POINTER_ID)) {
+      continue; // reserved for mouse
+    }
     bool inUse = std::any_of(m_activeTouches.begin(), m_activeTouches.end(), [candidate](const auto &pair) {
       return pair.second.touch.identifier == candidate;
     });
@@ -1230,9 +1234,14 @@ int CompositionEventHandler::AllocateTouchIdentifier() noexcept {
       return candidate;
     }
   }
-  // All 20 slots occupied (> 20 simultaneous touch points) — wrap anyway.
-  int fallback = m_touchId % kMaxTouchIdentifier;
+  // All non-mouse slots occupied (> 19 simultaneous touch/pen points) — wrap anyway,
+  // skipping the mouse-reserved slot.
+  int fallback = m_touchId;
   m_touchId = (m_touchId + 1) % kMaxTouchIdentifier;
+  if (fallback == static_cast<int>(MOUSE_POINTER_ID)) {
+    fallback = m_touchId;
+    m_touchId = (m_touchId + 1) % kMaxTouchIdentifier;
+  }
   return fallback;
 }
 
@@ -1347,7 +1356,12 @@ void CompositionEventHandler::onPointerPressed(
     // Map the Windows pointer ID to a small identifier (0–19) safe for use as a JS array index.
     // Windows touch IDs can be arbitrarily large (e.g. 2233), which causes React Native to warn
     // and corrupts touch state, leaving Pressables stuck after a scroll.
-    activeTouch.touch.identifier = AllocateTouchIdentifier();
+    // Mouse pointer ID is always 1 (MOUSE_POINTER_ID), which is already within the safe range —
+    // use it directly to preserve stable, predictable identifier assignment for mouse input.
+    activeTouch.touch.identifier =
+        (pointerPoint.PointerDeviceType() == Composition::Input::PointerDeviceType::Mouse)
+        ? static_cast<int>(MOUSE_POINTER_ID)
+        : AllocateTouchIdentifier();
 
     // If the pointer has not been marked as hovering over views before the touch started, we register
     // that the activeTouch should not maintain its hovered state once the pointer has been lifted.

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1358,8 +1358,7 @@ void CompositionEventHandler::onPointerPressed(
     // and corrupts touch state, leaving Pressables stuck after a scroll.
     // Mouse pointer ID is always 1 (MOUSE_POINTER_ID), which is already within the safe range —
     // use it directly to preserve stable, predictable identifier assignment for mouse input.
-    activeTouch.touch.identifier =
-        (pointerPoint.PointerDeviceType() == Composition::Input::PointerDeviceType::Mouse)
+    activeTouch.touch.identifier = (pointerPoint.PointerDeviceType() == Composition::Input::PointerDeviceType::Mouse)
         ? static_cast<int>(MOUSE_POINTER_ID)
         : AllocateTouchIdentifier();
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1214,6 +1214,28 @@ void CompositionEventHandler::onPointerExited(
   }
 }
 
+// Windows touch pointer IDs can be arbitrarily large (e.g. 2233). React Native's JS
+// touch handler uses identifiers as array indices and warns/misbehaves for values > 20.
+// This function maps each live Windows pointer to a small identifier in [0, 19] by
+// scanning m_activeTouches for in-use slots and cycling from the last assigned index.
+int CompositionEventHandler::AllocateTouchIdentifier() noexcept {
+  constexpr int kMaxTouchIdentifier = 20;
+  for (int i = 0; i < kMaxTouchIdentifier; i++) {
+    int candidate = (m_touchId + i) % kMaxTouchIdentifier;
+    bool inUse = std::any_of(m_activeTouches.begin(), m_activeTouches.end(), [candidate](const auto &pair) {
+      return pair.second.touch.identifier == candidate;
+    });
+    if (!inUse) {
+      m_touchId = (candidate + 1) % kMaxTouchIdentifier;
+      return candidate;
+    }
+  }
+  // All 20 slots occupied (> 20 simultaneous touch points) — wrap anyway.
+  int fallback = m_touchId % kMaxTouchIdentifier;
+  m_touchId = (m_touchId + 1) % kMaxTouchIdentifier;
+  return fallback;
+}
+
 void CompositionEventHandler::onPointerPressed(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
     winrt::Windows::System::VirtualKeyModifiers keyModifiers) noexcept {
@@ -1322,11 +1344,14 @@ void CompositionEventHandler::onPointerPressed(
     UpdateActiveTouch(activeTouch, ptScaled, ptLocal);
 
     activeTouch.isPrimary = pointerId == 1;
-    activeTouch.touch.identifier = pointerId;
+    // Map the Windows pointer ID to a small identifier (0–19) safe for use as a JS array index.
+    // Windows touch IDs can be arbitrarily large (e.g. 2233), which causes React Native to warn
+    // and corrupts touch state, leaving Pressables stuck after a scroll.
+    activeTouch.touch.identifier = AllocateTouchIdentifier();
 
     // If the pointer has not been marked as hovering over views before the touch started, we register
     // that the activeTouch should not maintain its hovered state once the pointer has been lifted.
-    auto currentlyHoveredTags = m_currentlyHoveredViewsPerPointer.find(activeTouch.touch.identifier);
+    auto currentlyHoveredTags = m_currentlyHoveredViewsPerPointer.find(pointerId);
     if (currentlyHoveredTags == m_currentlyHoveredViewsPerPointer.end() || currentlyHoveredTags->second.empty()) {
       activeTouch.shouldLeaveWhenReleased = true;
     }
@@ -1641,7 +1666,7 @@ void CompositionEventHandler::DispatchTouchEvent(
       continue;
     }
 
-    if (activeTouch.touch.identifier == pointerId) {
+    if (pair.first == pointerId) {
       event.changedTouches.insert(activeTouch.touch);
     }
     uniqueEventEmitters.insert(activeTouch.eventEmitter);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -162,8 +162,13 @@ class CompositionEventHandler : public std::enable_shared_from_this<CompositionE
   void UpdateCursor() noexcept;
   void SetCursor(facebook::react::Cursor cursor, HCURSOR hcur) noexcept;
 
+  // Allocates a small touch identifier (0–19) that is safe to use as a JS array index.
+  // Windows pointer IDs can be arbitrarily large, which causes React Native to warn and
+  // back-fill huge arrays, corrupting touch state after scrolling.
+  int AllocateTouchIdentifier() noexcept;
+
   std::map<PointerId, ActiveTouch> m_activeTouches; // iOS is map of touch event args to ActiveTouch..?
-  PointerId m_touchId = 0;
+  int m_touchId = 0; // cycling base used by AllocateTouchIdentifier
 
   std::map<PointerId, std::vector<ReactTaggedView>> m_currentlyHoveredViewsPerPointer;
   winrt::weak_ref<winrt::Microsoft::ReactNative::ReactNativeIsland> m_wkRootView;


### PR DESCRIPTION
Port https://github.com/microsoft/react-native-windows/pull/16081 to .84
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16082)