### PR TITLE
Text rendering perf improvement

### DIFF
--- a/change/react-native-windows-636c3119-029d-4fee-9c71-1116858423a5.json
+++ b/change/react-native-windows-636c3119-029d-4fee-9c71-1116858423a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Minor text rendering perf improvement",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -338,7 +338,9 @@ void ParagraphComponentView::updateVisualBrush() noexcept {
             break;
         }
       }
-      winrt::check_hresult(m_textLayout->SetTextAlignment(alignment));
+
+      if (alignment != m_textLayout->GetTextAlignment())
+        winrt::check_hresult(m_textLayout->SetTextAlignment(alignment));
     }
 
     requireNewBrush = true;

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
@@ -196,12 +196,7 @@ void WindowsTextLayoutManager::GetTextLayout(
       ));
 
   // Apply max width constraint and ellipsis trimming to ensure consistency with rendering
-  DWRITE_TEXT_METRICS metrics;
-  winrt::check_hresult(spTextLayout->GetMetrics(&metrics));
-
-  if (metrics.width > size.width) {
-    spTextLayout->SetMaxWidth(size.width);
-  }
+  spTextLayout->SetMaxWidth(size.width);
 
   // Apply DWRITE_TRIMMING for ellipsizeMode
   DWRITE_TRIMMING trimming = {};
@@ -396,7 +391,7 @@ void WindowsTextLayoutManager::GetTextLayoutByAdjustingFontSizeToFit(
   }
 }
 
-// measure entire text (inluding attachments)
+// measure entire text (including attachments)
 TextMeasurement TextLayoutManager::measure(
     const AttributedStringBox &attributedStringBox,
     const ParagraphAttributes &paragraphAttributes,


### PR DESCRIPTION
## Description

Calling TextLayout->GetMetrics runs text layout.  There was a call to GetMetrics being used in GetTextLayout to determine if we should set maxWidth.  There was no need for that logic, and we can just always set the maxWidth, and avoid the extra text layout pass.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16083)