### PR TITLE
fix: cancel active touches in onPointerCaptureLost to prevent zombie touch state

### DIFF
--- a/change/react-native-windows-f47bdf2a-0807-483f-b63e-3c2c086bee92.json
+++ b/change/react-native-windows-f47bdf2a-0807-483f-b63e-3c2c086bee92.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: cancel active touches in onPointerCaptureLost to prevent zombie touch state",
+  "packageName": "react-native-windows",
+  "email": "gordomacmaster@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1092,12 +1092,26 @@ void CompositionEventHandler::onPointerCaptureLost(
   if (SurfaceId() == -1)
     return;
 
-  if (m_pointerCapturingComponentTag) {
+  if (m_pointerCapturingComponentTag != -1) {
     // copy array to avoid iterator being invalidated during deletion
     std::unordered_set<PointerId> capturedPointers = m_capturedPointers;
 
     for (auto pointerId : capturedPointers) {
       releasePointerCapture(pointerId, m_pointerCapturingComponentTag);
+
+      // Cancel any active touch for this pointer so React Native is notified that
+      // the touch ended. Without this, m_activeTouches retains a zombie entry and
+      // RN JS is never told the touch is gone — leaving Pressables stuck in a
+      // pressed state after a system-interrupted gesture (e.g. system back swipe,
+      // Alt+Tab, another window coming foreground).
+      auto activeTouch = m_activeTouches.find(pointerId);
+      if (activeTouch != m_activeTouches.end()) {
+        ActiveTouch cancelledTouchCopy = std::move(activeTouch->second);
+        m_activeTouches.erase(activeTouch);
+        if (cancelledTouchCopy.eventEmitter) {
+          DispatchSynthesizedTouchCancelForActiveTouch(cancelledTouchCopy, pointerPoint, keyModifiers);
+        }
+      }
     }
 
     m_pointerCapturingComponentTag = -1;


### PR DESCRIPTION
## Description
This PR fixes a zombie touch state in onPointerCaptureLost: when the OS reclaims pointer capture mid-gesture, entries were never removed from m_activeTouches and no touchcancel was dispatched to React Native JS. The fix applies the copy-then-erase-then-dispatch pattern (already used in onPointerPressed) and also corrects a latent bug where a component tag of 0 would have been silently skipped by the old if (m_pointerCapturingComponentTag) guard.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Touch/pointer sturdiness

### What
For each captured pointer in the lost-capture set, copy and erase the
m_activeTouches entry before calling DispatchSynthesizedTouchCancelForActiveTouch,
mirroring the pattern already used in onPointerPressed and onPointerReleased.
The erase-before-dispatch ordering is required because
DispatchSynthesizedTouchCancelForActiveTouch iterates m_activeTouches internally.


## Changelog
Should this change be included in the release notes: yes

Fix zombie touch states when OS reclaims the pointer mid-gesture

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16086)