### PR TITLE
Add ability to make TurboModules eager init

### DIFF
--- a/change/react-native-windows-3f20e903-f2ed-45d8-b852-7408a50c36f2.json
+++ b/change/react-native-windows-3f20e903-f2ed-45d8-b852-7408a50c36f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add ability to register modules as eager init",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
@@ -18,7 +18,10 @@ ModuleRegistration::ModuleRegistration(wchar_t const *moduleName) noexcept : m_m
 void AddAttributedModules(IReactPackageBuilder const &packageBuilder, bool useTurboModules) noexcept {
   for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
     if (useTurboModules || reg->ShouldRegisterAsTurboModule())
-      packageBuilder.AddTurboModule(reg->ModuleName(), reg->MakeModuleProvider());
+      if (reg->IsEagerInit())
+        packageBuilder.AddEagerInitTurboModule(reg->ModuleName(), reg->MakeModuleProvider());
+      else
+        packageBuilder.AddTurboModule(reg->ModuleName(), reg->MakeModuleProvider());
     else
       packageBuilder.AddModule(reg->ModuleName(), reg->MakeModuleProvider());
   }
@@ -31,7 +34,10 @@ bool TryAddAttributedModule(
   for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
     if (moduleName == reg->ModuleName()) {
       if (useTurboModule || reg->ShouldRegisterAsTurboModule()) {
-        packageBuilder.AddTurboModule(moduleName, reg->MakeModuleProvider());
+        if (reg->IsEagerInit())
+          packageBuilder.AddEagerInitTurboModule(moduleName, reg->MakeModuleProvider());
+        else
+          packageBuilder.AddTurboModule(moduleName, reg->MakeModuleProvider());
       } else {
         packageBuilder.AddModule(moduleName, reg->MakeModuleProvider());
       }

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -30,10 +30,11 @@ template <typename T>
 struct IsReactTurboModule : std::bool_constant<ReactIsReactTurboModuleImpl(static_cast<T *>(nullptr))> {};
 
 #define INTERNAL_REACT_MODULE_REGISTRATION_AND_PROVIDER(                                                            \
-    moduleStruct, moduleName, eventEmitterName, isReactTurboModule)                                                 \
+    moduleStruct, moduleName, eventEmitterName, isReactTurboModule, isEagerInit)                                    \
   struct moduleStruct;                                                                                              \
                                                                                                                     \
   constexpr bool ReactIsReactTurboModuleImpl(moduleStruct *) noexcept { return isReactTurboModule; }                \
+  constexpr bool ReactIsEagerInitTurboModuleImpl(moduleStruct *) noexcept { return isEagerInit; }                   \
                                                                                                                     \
   template <class TDummy>                                                                                           \
   struct moduleStruct##_ModuleRegistration final : winrt::Microsoft::ReactNative::ModuleRegistration {              \
@@ -44,6 +45,7 @@ struct IsReactTurboModule : std::bool_constant<ReactIsReactTurboModuleImpl(stati
     }                                                                                                               \
                                                                                                                     \
     bool ShouldRegisterAsTurboModule() const noexcept override { return isReactTurboModule; }                       \
+    bool IsEagerInit() const noexcept override { return isEagerInit; }                                              \
                                                                                                                     \
     static const moduleStruct##_ModuleRegistration Registration;                                                    \
   };                                                                                                                \
@@ -59,7 +61,7 @@ struct IsReactTurboModule : std::bool_constant<ReactIsReactTurboModuleImpl(stati
   }
 
 #define INTERNAL_REACT_MODULE_3_ARGS(moduleStruct, moduleName, eventEmitterName) \
-  INTERNAL_REACT_MODULE_REGISTRATION_AND_PROVIDER(moduleStruct, moduleName, eventEmitterName, false)
+  INTERNAL_REACT_MODULE_REGISTRATION_AND_PROVIDER(moduleStruct, moduleName, eventEmitterName, false, false)
 
 #define INTERNAL_REACT_MODULE_2_ARGS(moduleStruct, moduleName) \
   INTERNAL_REACT_MODULE_3_ARGS(moduleStruct, moduleName, L"")
@@ -104,17 +106,27 @@ struct IsReactTurboModule : std::bool_constant<ReactIsReactTurboModuleImpl(stati
 
 // Register struct as a ReactNative module.
 #define INTERNAL_REACT_TURBO_MODULE_2_ARGS(moduleStruct, moduleName) \
-  INTERNAL_REACT_MODULE_REGISTRATION_AND_PROVIDER(moduleStruct, moduleName, L"", true)
+  INTERNAL_REACT_MODULE_REGISTRATION_AND_PROVIDER(moduleStruct, moduleName, L"", true, false)
+
+#define INTERNAL_REACT_EAGER_TURBO_MODULE_2_ARGS(moduleStruct, moduleName) \
+  INTERNAL_REACT_MODULE_REGISTRATION_AND_PROVIDER(moduleStruct, moduleName, L"", true, true)
 
 #define INTERNAL_REACT_TURBO_MODULE_1_ARG(moduleStruct) \
   INTERNAL_REACT_TURBO_MODULE_2_ARGS(moduleStruct, L## #moduleStruct)
 
+#define INTERNAL_REACT_EAGER_TURBO_MODULE_1_ARG(moduleStruct) \
+  INTERNAL_REACT_EAGER_TURBO_MODULE_2_ARGS(moduleStruct, L## #moduleStruct)
+
 #define INTERNAL_REACT_TURBO_MODULE(...) \
   INTERNAL_REACT_RECOMPOSER_3((__VA_ARGS__, INTERNAL_REACT_TURBO_MODULE_2_ARGS, INTERNAL_REACT_TURBO_MODULE_1_ARG, ))
 
+#define INTERNAL_REACT_EAGER_TURBO_MODULE(...) \
+  INTERNAL_REACT_RECOMPOSER_3(                 \
+      (__VA_ARGS__, INTERNAL_REACT_EAGER_TURBO_MODULE_2_ARGS, INTERNAL_REACT_EAGER_TURBO_MODULE_1_ARG, ))
+
 // Another version of REACT_MODULE but does not do auto registration
 #define INTERNAL_REACT_TURBO_MODULE_NOREG_2_ARGS(moduleStruct, moduleName) \
-  INTERNAL_REACT_MODULE_NO_REGISTRATION_AND_PROVIDER(moduleStruct, moduleName, L"", true)
+  INTERNAL_REACT_MODULE_NO_REGISTRATION_AND_PROVIDER(moduleStruct, moduleName, L"", true, false)
 
 #define INTERNAL_REACT_TURBO_MODULE_NOREG_1_ARG(moduleStruct) \
   INTERNAL_REACT_TURBO_MODULE_NOREG_2_ARGS(moduleStruct, L## #moduleStruct)
@@ -153,6 +165,7 @@ struct ModuleRegistration {
 
   virtual ReactModuleProvider MakeModuleProvider() const noexcept = 0;
   virtual bool ShouldRegisterAsTurboModule() const noexcept = 0;
+  virtual bool IsEagerInit() const noexcept = 0;
 
   static ModuleRegistration const *Head() noexcept {
     return s_head;

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -47,6 +47,11 @@
 #define REACT_TURBO_MODULE(/* moduleStruct, [opt] moduleName */...) \
   INTERNAL_REACT_TURBO_MODULE(__VA_ARGS__)(__VA_ARGS__)
 
+// Same as REACT_TURBO_MODULE, but will register using AddEagerInitTurboModule, and this module
+// will be created and init'd on instance creation.
+#define REACT_EAGER_TURBO_MODULE(/* moduleStruct, [opt] moduleName */...) \
+  INTERNAL_REACT_EAGER_TURBO_MODULE(__VA_ARGS__)(__VA_ARGS__)
+
 // REACT_MODULE_NOREG is REACT_MODULE without auto registration
 // they have the same arguments
 #define REACT_MODULE_NOREG(/* moduleStruct, [opt] moduleName, [opt] eventEmitterName */...) \

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -21,5 +21,11 @@ namespace Microsoft.ReactNative
     DOC_STRING("Adds a custom native module. See @ReactModuleProvider. This will register the"
     "module as a TurboModule.")
     void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
+
+    DOC_STRING("Adds a custom native module. See @ReactModuleProvider. This will register the"
+    "module as a TurboModule.  This module will be created and have init called as soon as the"
+    "instance is created, event before the module is accessed from JavaScript.")
+    void AddEagerInitTurboModule(String moduleName, ReactModuleProvider moduleProvider);
+
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -241,6 +241,7 @@ void ReactInstanceWin::LoadModules(
   registerTurboModule(
       L"FabricUIManagerBinding",
       winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::FabricUIManager>());
+  turboModulesProvider->AddEagerInit("FabricUIManagerBinding");
 
   registerTurboModule(
       L"AccessibilityInfo",

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -34,6 +34,13 @@ void ReactPackageBuilder::AddTurboModule(
   m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider, true);
 }
 
+void ReactPackageBuilder::AddEagerInitTurboModule(
+    hstring const &moduleName,
+    ReactModuleProvider const &moduleProvider) noexcept {
+  m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider, true);
+  m_turboModulesProvider->AddEagerInit(winrt::to_string(moduleName));
+}
+
 void ReactPackageBuilder::AddViewComponent(
     winrt::hstring componentName,
     ReactViewComponentProvider const &viewComponentProvider) noexcept {

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -20,6 +20,7 @@ struct ReactPackageBuilder : winrt::implements<ReactPackageBuilder, IReactPackag
  public: // IReactPackageBuilder
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
   void AddTurboModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
+  void AddEagerInitTurboModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
 
   // IReactPackageBuilderFabric
   void AddViewComponent(winrt::hstring componentName, ReactViewComponentProvider const &viewComponentProvider) noexcept;

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -494,16 +494,11 @@ std::shared_ptr<facebook::react::TurboModule> TurboModulesProvider::getModule(
 }
 
 std::vector<std::string> TurboModulesProvider::getEagerInitModuleNames() noexcept {
-  std::vector<std::string> eagerModules;
-  auto it = m_moduleProviders.find("UIManager");
-  if (it != m_moduleProviders.end()) {
-    eagerModules.push_back("UIManager");
-  }
-  it = m_moduleProviders.find("FabricUIManagerBinding");
-  if (it != m_moduleProviders.end()) {
-    eagerModules.push_back("FabricUIManagerBinding");
-  }
-  return eagerModules;
+  return m_eagerInitModuleNames;
+}
+
+void TurboModulesProvider::AddEagerInit(std::string moduleName) noexcept {
+  m_eagerInitModuleNames.push_back(moduleName);
 }
 
 void TurboModulesProvider::SetReactContext(const IReactContext &reactContext) noexcept {

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -26,6 +26,7 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
       winrt::hstring const &moduleName,
       ReactModuleProvider const &moduleProvider,
       bool overwriteExisting) noexcept;
+  void AddEagerInit(std::string moduleName) noexcept;
   std::shared_ptr<facebook::react::LongLivedObjectCollection> const &LongLivedObjectCollection() noexcept;
 
  private:
@@ -33,6 +34,7 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
   std::shared_ptr<facebook::react::LongLivedObjectCollection> m_longLivedObjectCollection{
       std::make_shared<facebook::react::LongLivedObjectCollection>()};
   std::unordered_map<std::string, ReactModuleProvider> m_moduleProviders;
+  std::vector<std::string> m_eagerInitModuleNames;
   IReactContext m_reactContext;
 };
 


### PR DESCRIPTION
## Description
Core has a function on TurboModuleProvider to return a list of modules that should be eagerly initialized rather than waiting for access from JS.

This change add a new REACT_EAGER_TURBO_MODULE which can be used to make an attributed module eager init.
Or if manually adding a module to the package builder, you can call AddEagerInitTurboModule instead of AddTurboModule

### Type of Change
- New feature (non-breaking change which adds functionality)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16093)