### PR TITLE
Use hermes-windows 0.0.0-2605.6002-2279da22

### DIFF
--- a/change/@react-native-windows-automation-channel-7c207539-3227-4d0e-9f3c-1cf97ffed508.json
+++ b/change/@react-native-windows-automation-channel-7c207539-3227-4d0e-9f3c-1cf97ffed508.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use hermes-windows 0.0.0-2605.6002-2279da22",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-1c918c46-1b17-42cc-8252-2908c431fbdb.json
+++ b/change/react-native-windows-1c918c46-1b17-42cc-8252-2908c431fbdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use hermes-windows 0.0.0-2605.6002-2279da22",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/packages.lock.json
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric.Package/packages.lock.json
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric.Package/packages.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -182,7 +182,7 @@
         "type": "Project",
         "dependencies": {
           "AutomationChannel": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/packages.lock.json
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -175,7 +175,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/playground/windows/playground-composition.Package/packages.experimentalwinui3.lock.json
+++ b/packages/playground/windows/playground-composition.Package/packages.experimentalwinui3.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -156,7 +156,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",
@@ -166,7 +166,7 @@
       "playground-composition": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",

--- a/packages/playground/windows/playground-composition.Package/packages.lock.json
+++ b/packages/playground/windows/playground-composition.Package/packages.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -156,7 +156,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -166,7 +166,7 @@
       "playground-composition": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",

--- a/packages/playground/windows/playground-composition/packages.experimentalwinui3.lock.json
+++ b/packages/playground/windows/playground-composition/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -166,7 +166,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/playground/windows/playground-composition/packages.lock.json
+++ b/packages/playground/windows/playground-composition/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -166,7 +166,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/sample-app-fabric/windows/SampleAppFabric.Package/packages.lock.json
+++ b/packages/sample-app-fabric/windows/SampleAppFabric.Package/packages.lock.json
@@ -14,8 +14,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -156,7 +156,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -172,7 +172,7 @@
       "sampleappfabric": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.ReactNative": "[1.0.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",

--- a/packages/sample-app-fabric/windows/SampleAppFabric/packages.lock.json
+++ b/packages/sample-app-fabric/windows/SampleAppFabric/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -166,7 +166,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/sample-custom-component/windows/SampleCustomComponent/packages.experimentalwinui3.lock.json
+++ b/packages/sample-custom-component/windows/SampleCustomComponent/packages.experimentalwinui3.lock.json
@@ -44,8 +44,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/packages/sample-custom-component/windows/SampleCustomComponent/packages.lock.json
+++ b/packages/sample-custom-component/windows/SampleCustomComponent/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.DLL/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop.DLL/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -160,7 +160,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.DLL/packages.lock.json
+++ b/vnext/Desktop.DLL/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -160,7 +160,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.IntegrationTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop.IntegrationTests/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",
@@ -176,7 +176,7 @@
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
           "ReactNative.V8Jsi.Windows": "[0.71.8, )",

--- a/vnext/Desktop.IntegrationTests/packages.lock.json
+++ b/vnext/Desktop.IntegrationTests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",
@@ -165,7 +165,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",
@@ -176,7 +176,7 @@
       "react.windows.desktop.dll": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "React.Windows.Desktop": "[1.0.0, )",
           "ReactNative.V8Jsi.Windows": "[0.71.8, )",

--- a/vnext/Desktop.UnitTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop.UnitTests/packages.experimentalwinui3.lock.json
@@ -21,8 +21,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -163,7 +163,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop.UnitTests/packages.lock.json
+++ b/vnext/Desktop.UnitTests/packages.lock.json
@@ -21,8 +21,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -163,7 +163,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Desktop/packages.experimentalwinui3.lock.json
+++ b/vnext/Desktop/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/Desktop/packages.lock.json
+++ b/vnext/Desktop/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.experimentalwinui3.lock.json
@@ -37,8 +37,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -158,7 +158,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
@@ -37,8 +37,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -158,7 +158,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative.IntegrationTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/packages.experimentalwinui3.lock.json
@@ -50,8 +50,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -171,7 +171,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/packages.lock.json
@@ -50,8 +50,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -171,7 +171,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/Microsoft.ReactNative/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/Microsoft.ReactNative/packages.lock.json
+++ b/vnext/Microsoft.ReactNative/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Direct",
-        "requested": "[0.0.0-2604.21001-94aa5e1d, )",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "requested": "[0.0.0-2605.6002-2279da22, )",
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -6,7 +6,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">true</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.0.0-2604.21001-94aa5e1d</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.0.0-2605.6002-2279da22 </HermesVersion>
     <HermesPackageName Condition="'$(HermesPackageName)' == ''">Microsoft.JavaScript.Hermes</HermesPackageName>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgMicrosoft_JavaScript_Hermes)')">$(PkgMicrosoft_JavaScript_Hermes)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\$(HermesPackageName)\$(HermesVersion)</HermesPackage>

--- a/vnext/ReactCommon.UnitTests/packages.experimentalwinui3.lock.json
+++ b/vnext/ReactCommon.UnitTests/packages.experimentalwinui3.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -164,7 +164,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[2.0.0-experimental3, )",
           "ReactCommon": "[1.0.0, )",

--- a/vnext/ReactCommon.UnitTests/packages.lock.json
+++ b/vnext/ReactCommon.UnitTests/packages.lock.json
@@ -27,8 +27,8 @@
       },
       "Microsoft.JavaScript.Hermes": {
         "type": "Transitive",
-        "resolved": "0.0.0-2604.21001-94aa5e1d",
-        "contentHash": "8eHA3O043jIeK7E1gJbzgsdujaDTIBwLSl6pZj7CdQl+ryFqaW88XVU9ogWJPxk5lR2T4cU/OlEJfZynqoyYew=="
+        "resolved": "0.0.0-2605.6002-2279da22",
+        "contentHash": "E59URq24UdJMpLMkMY92h3hs91EHelicbUsBRETn+FJ19uQbzU3gqkh2NPyBtMj4IVYK5K9FW+hIUTLg8SG25g=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -164,7 +164,7 @@
         "type": "Project",
         "dependencies": {
           "Common": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.0.0-2604.21001-94aa5e1d, )",
+          "Microsoft.JavaScript.Hermes": "[0.0.0-2605.6002-2279da22, )",
           "Microsoft.SourceLink.GitHub": "[1.1.1, )",
           "Microsoft.WindowsAppSDK": "[1.8.260209005, )",
           "ReactCommon": "[1.0.0, )",


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Our e2e tests are often failing. Some of the issues are due to the crashes in Hermes code due to GC unsafe code in Node-API.

### What
The hermes-windows issue was fixed in that PR: https://github.com/microsoft/hermes-windows/pull/321
The new hermes-windows version 0.0.0-2605.6002-2279da22 has all required changes.

## Testing
See the tests done in the hermes-windows PR.

## Changelog
Should this change be included in the release notes: yes

Update hermes-windows version to 0.0.0-2605.6002-2279da22 that should fix crashes caused by GC unsafe code in Node-API.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16094)