### PR TITLE
fix: use IsPrimary() for touch pointer isPrimary instead of hardcoded id

### DIFF
--- a/change/react-native-windows-4ad3ddaf-1358-4ff0-9971-38a7db68266c.json
+++ b/change/react-native-windows-4ad3ddaf-1358-4ff0-9971-38a7db68266c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: use IsPrimary() for touch pointer isPrimary instead of hardcoded pointer ID check",
+  "packageName": "react-native-windows",
+  "email": "gordomacmaster@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1366,7 +1366,7 @@ void CompositionEventHandler::onPointerPressed(
 
     UpdateActiveTouch(activeTouch, ptScaled, ptLocal);
 
-    activeTouch.isPrimary = pointerId == 1;
+    activeTouch.isPrimary = pointerPoint.Properties().IsPrimary();
     // Map the Windows pointer ID to a small identifier (0–19) safe for use as a JS array index.
     // Windows touch IDs can be arbitrarily large (e.g. 2233), which causes React Native to warn
     // and corrupts touch state, leaving Pressables stuck after a scroll.


### PR DESCRIPTION
## Description
activeTouch.isPrimary was set via `pointerId == 1`, which only works for
mouse (MOUSE_POINTER_ID == 1). Windows touch pointer IDs are OS-allocated
and essentially never 1, so isPrimary was always false for touch input.
This meant touch pointers never triggered onClick (gated behind
isPrimary && button == 0) and reported incorrect isPrimary in
PointerEvents sent to JS.



### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Replace with pointerPoint.Properties().IsPrimary(), which reads the OS
POINTER_FLAG_PRIMARY flag directly. This API is already used elsewhere
in the codebase (SwitchComponentView, WindowsTextInputComponentView,
Composition.Input).

Resolves: N/a

### What
Today, touch fingers never trigger onClick (because isPrimary is always false). After the fix, the primary finger would. Combined with secondary fix 1 above, those new clicks would be dispatched correctly per W3C — but they are still new dispatches that did not happen before. That is a behaviour change worth its own changeset, its own review, and its own test pass.

## Changelog
Should this change be included in the release notes: yes

fix: use IsPrimary() for touch pointer isPrimary instead of hardcoded pointer ID check
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16099)