### PR TITLE
[0.81] Disable slices that use experimental winui

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -133,12 +133,12 @@ parameters:
             configuration: Release
             platform: x64
             lowResource: true
-          - Name: PaperX64ReleaseCppWinUI3
-            template: old/uwp-cpp-app
-            configuration: Release
-            platform: x64
-            runWack: true
-            useExperimentalWinUI3: true
+          # - Name: PaperX64ReleaseCppWinUI3
+          #   template: old/uwp-cpp-app
+          #   configuration: Release
+          #   platform: x64
+          #   runWack: true
+          #   useExperimentalWinUI3: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: FabricX64Debug

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -67,16 +67,16 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-          - Name: X86DebugCompositionExperimentalWinUI3
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X64ReleaseCompositionExperimentalWinUI3
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
+          # - Name: X86DebugCompositionExperimentalWinUI3
+          #   BuildConfiguration: Debug
+          #   BuildPlatform: x86
+          #   SolutionFile: Playground-Composition.sln
+          #   UseExperimentalWinUI3: true
+          # - Name: X64ReleaseCompositionExperimentalWinUI3
+          #   BuildConfiguration: Release
+          #   BuildPlatform: x64
+          #   SolutionFile: Playground-Composition.sln
+          #   UseExperimentalWinUI3: true
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:


### PR DESCRIPTION
Publish broke as it tries to build using the experimental WinAppSDK version, but the version we have for experimental isn't actually an experimental version, so the code attemping to use experimental APIs fails to build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16101)