### PR TITLE
Image does not consistently rerender on image source change

### DIFF
--- a/change/react-native-windows-f88fd0c5-a799-4c62-9e2d-edce4c369727.json
+++ b/change/react-native-windows-f88fd0c5-a799-4c62-9e2d-edce4c369727.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Image does not consistently rerender on image source change",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
@@ -30,6 +30,10 @@ const searchBox = async (input: string) => {
       // than replace. Without the clear, a retry produces "onPressInonPressIn"
       // and the comparison never converges.
       await searchBox.clearValue();
+
+      // Do an extra wait here, since the autofocus textinput will move focus to itself and steal focus from the search box, causing the setValue to fail.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       await searchBox.setValue(input);
       return (await searchBox.getText()) === input;
     },

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -130,6 +130,7 @@ void ImageComponentView::didReceiveImage(const std::shared_ptr<ImageResponseImag
 #endif
 
   m_imageResponseImage = imageResponseImage;
+  m_requiresImageRedraw = true;
   ensureDrawingSurface();
 }
 
@@ -315,6 +316,9 @@ void ImageComponentView::ensureDrawingSurface() noexcept {
   } else if (m_imageResponseImage->m_brushFactory) {
     Visual().as<Experimental::ISpriteVisual>().Brush(
         m_imageResponseImage->m_brushFactory(m_reactContext.Handle(), m_compContext));
+  } else if (m_requiresImageRedraw) {
+    m_requiresImageRedraw = false;
+    DrawImage();
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -98,6 +98,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ViewComponen
   winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_drawingSurface;
   std::shared_ptr<ImageResponseImage> m_imageResponseImage;
   std::shared_ptr<WindowsImageResponseObserver> m_imageResponseObserver;
+  bool m_requiresImageRedraw{true};
   facebook::react::ImageShadowNode::ConcreteState::Shared m_state;
 };
 


### PR DESCRIPTION
## Description

The following Pressable would not change the image when hovered:
```jsx

const Test = () => {
    const [hover, setHover] = React.useState(false);

    return (
        <Pressable
            onPress={() => {}}
            onHoverIn={() => setHover(true)}
            onHoverOut={() => setHover(false)}>
                <Text>{hover ? 'Hovering' : 'Not Hovering'}</Text>
            <Image
                source={hover ? require('./assets/bottom-nav-apis-icon-light.png') : require('./assets/bottom-nav-apis-icon-dark.png')}
            />
        </Pressable>
    );
}
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16107)