### PR TITLE
[0.84] fix: null dereference in get_SelectionContainer when no selection container exists

### DIFF
--- a/change/react-native-windows-0ddd05a5-b75b-423a-a461-6dcafc41d3b4.json
+++ b/change/react-native-windows-0ddd05a5-b75b-423a-a461-6dcafc41d3b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: null dereference in get_SelectionContainer when no container found",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -1064,6 +1064,11 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::get_SelectionContainer(I
   *pRetVal = nullptr;
 
   auto selectionContainerView = GetSelectionContainer();
+  // Per UIA spec, returning S_OK with *pRetVal == nullptr is correct when the element
+  // is not contained within a selection container.
+  if (!selectionContainerView)
+    return S_OK;
+
   auto uiaProvider =
       winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(selectionContainerView)
           ->EnsureUiaProvider();


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
`get_SelectionContainer` (UIA `SelectionItemPattern.SelectionContainer`) crashes with a null dereference when the element has no ancestor with a selection container. `GetSelectionContainer()` walks the parent tree looking for a view with `multiselectable` and `required` props set; if none is found it returns `nullptr`, which was immediately dereferenced on the next line.

### What
- Added a null check on the return value of `GetSelectionContainer()` in `get_SelectionContainer`
- Returns `S_OK` with `*pRetVal == nullptr` when no container is found — correct per UIA spec (element is simply not inside a selection container)

```cpp
auto selectionContainerView = GetSelectionContainer();
// Per UIA spec, returning S_OK with *pRetVal == nullptr is correct when the element
// is not contained within a selection container.
if (!selectionContainerView)
  return S_OK;
```

## Screenshots
N/A

## Testing
Reproduced by calling `get_SelectionContainer` on a selection item whose ancestor tree contains no multiselectable container. Verified the null check prevents the crash and returns `S_OK` with a null provider pointer.

## Changelog
Should this change be included in the release notes: yes

Fix crash (null dereference) in UIA `SelectionItemPattern.get_SelectionContainer` when the element has no selection 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16111)