### PR TITLE
[0.84] fix: use IsPrimary() for touch pointer isPrimary instead of hardcoded id

### DIFF
--- a/change/react-native-windows-4ad3ddaf-1358-4ff0-9971-38a7db68266c.json
+++ b/change/react-native-windows-4ad3ddaf-1358-4ff0-9971-38a7db68266c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: use IsPrimary() for touch pointer isPrimary instead of hardcoded pointer ID check",
+  "packageName": "react-native-windows",
+  "email": "gordomacmaster@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1385,7 +1385,7 @@ void CompositionEventHandler::onPointerPressed(
 
     UpdateActiveTouch(activeTouch, ptScaled, ptLocal);
 
-    activeTouch.isPrimary = pointerId == 1;
+    activeTouch.isPrimary = pointerPoint.Properties().IsPrimary();
     // Map the Windows pointer ID to a small identifier (0–19) safe for use as a JS array index.
     // Windows touch IDs can be arbitrarily large (e.g. 2233), which causes React Native to warn
     // and corrupts touch state, leaving Pressables stuck after a scroll.


### PR DESCRIPTION
port over https://github.com/microsoft/react-native-windows/pull/16099
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16121)