### PR TITLE
[0.74] Fix possible crash when creating multiple ReactNativeHost's at once

### DIFF
--- a/change/react-native-windows-fecfda46-4780-4d20-8763-7a74f87e00c1.json
+++ b/change/react-native-windows-fecfda46-4780-4d20-8763-7a74f87e00c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix possible crash when creating multiple ReactNativeHost's at once",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -287,7 +287,7 @@ ReactHost::ReactHost(Mso::DispatchQueue const &queue) noexcept
       m_options{Queue(), m_mutex},
       m_notifyWhenClosed{ReactHostRegistry::Register(*this), Queue(), m_mutex} {
   static std::once_flag initFeatureFlagsOnce;
-  std::call_once(initFeatureFlagsOnce, []() noexcept { ReactNativeFeatureFlags::commonTestFlag(); });
+  std::call_once(initFeatureFlagsOnce, []() noexcept { facebook::react::ReactNativeFeatureFlags::commonTestFlag(); });
 }
 
 ReactHost::~ReactHost() noexcept {}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -4,6 +4,7 @@
 #include "ReactHost.h"
 #include <Future/FutureWait.h>
 #include <ReactPropertyBag.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <winrt/Windows.Foundation.h>
 
 namespace Mso::React {
@@ -284,7 +285,10 @@ bool ReactOptions::EnableDefaultCrashHandler() const noexcept {
 ReactHost::ReactHost(Mso::DispatchQueue const &queue) noexcept
     : Super{EnsureSerialQueue(queue)},
       m_options{Queue(), m_mutex},
-      m_notifyWhenClosed{ReactHostRegistry::Register(*this), Queue(), m_mutex} {}
+      m_notifyWhenClosed{ReactHostRegistry::Register(*this), Queue(), m_mutex} {
+  static std::once_flag initFeatureFlagsOnce;
+  std::call_once(initFeatureFlagsOnce, []() noexcept { ReactNativeFeatureFlags::commonTestFlag(); });
+}
 
 ReactHost::~ReactHost() noexcept {}
 


### PR DESCRIPTION
## Description

If [ReactNativeFeatureFlags::getAccessor](https://github.com/facebook/react-native/blob/b7801f29c50b5c71ab0e516e23d652b30f82c656/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp#L418) is accessed from two thread at the same time, it could potentially return a destructed ReactNativeFeatureFlagsAccessor.

In later versions of RNW we apply an override to ReactNativeFeatureFlags in ReactHost which ensures that we gate on the first access to the flags.  https://github.com/microsoft/react-native-windows/blob/0644ae838ce6eafacffffd548df70af7ba23fb5c/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp#L355
By adding a similar gate here, that just accesses a flag, we ensure that only one ReactNativeFeatureFlagsAccessor is created.

## Fixes
[Bug 11479530* Watson Anomaly Found: facebook::react::reactnativefeatureflagsaccessor::usemodernrunt…](https://office.visualstudio.com/OC/_workitems/edit/11479530)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16125)