### PR TITLE
[0.84] fix: correct CompositionHwndHost initialization order for DPI-aware second windows

### DIFF
--- a/change/react-native-windows-c628c673-e01f-4887-9fcf-b1e5c468d311.json
+++ b/change/react-native-windows-c628c673-e01f-4887-9fcf-b1e5c468d311.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Fix CompositionHwndHost initialization order and add WM_DPICHANGED handling: ResizePolicy is now set before Connect and ScaleFactor before the island is connected, matching the ReactNativeWindow reference pattern, so that secondary windows render with correct DPI-aware touch coordinates. A new WM_DPICHANGED handler updates the island's scale factor and invalidates cached pixel dimensions before SetWindowPos, ensuring layout re-arranges immediately on runtime DPI changes — including same-monitor scale changes where the pixel rect is unchanged.",
+  "comment": "Fix CompositionHwndHost initialization order: ResizePolicy is now set before Connect and ScaleFactor before the island is connected, matching the ReactNativeWindow reference pattern, so that secondary windows render with correct DPI-aware touch coordinates.",
   "packageName": "react-native-windows",
   "email": "gordomacmaster@gmail.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-c628c673-e01f-4887-9fcf-b1e5c468d311.json
+++ b/change/react-native-windows-c628c673-e01f-4887-9fcf-b1e5c468d311.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix CompositionHwndHost initialization order and add WM_DPICHANGED handling: ResizePolicy is now set before Connect and ScaleFactor before the island is connected, matching the ReactNativeWindow reference pattern, so that secondary windows render with correct DPI-aware touch coordinates. A new WM_DPICHANGED handler updates the island's scale factor and invalidates cached pixel dimensions before SetWindowPos, ensuring layout re-arranges immediately on runtime DPI changes — including same-monitor scale changes where the pixel rect is unchanged.",
+  "packageName": "react-native-windows",
+  "email": "gordomacmaster@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -34,16 +34,19 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
       ReactViewHost().ReactNativeHost().InstanceSettings().Properties());
   m_compRootView = winrt::Microsoft::ReactNative::ReactNativeIsland(compositor);
 
-  auto bridge = winrt::Microsoft::UI::Content::DesktopChildSiteBridge::Create(
+  m_bridge = winrt::Microsoft::UI::Content::DesktopChildSiteBridge::Create(
       compositor, winrt::Microsoft::UI::GetWindowIdFromWindow(m_hwnd));
 
+  // ResizePolicy must be set before Connect so the bridge configures the
+  // island's coordinate space with correct DPI awareness (matches
+  // ReactNativeWindow::ContentSiteBridge initialization order).
+  m_bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
+
   auto island = m_compRootView.Island();
-
-  bridge.Connect(island);
-  bridge.Show();
-
   m_compRootView.ScaleFactor(ScaleFactor());
-  bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
+
+  m_bridge.Connect(island);
+  m_bridge.Show();
 
   m_compRootView.ReactViewHost(std::move(m_reactViewHost));
   m_compRootView.ScaleFactor(ScaleFactor());
@@ -80,6 +83,26 @@ LRESULT CompositionHwndHost::TranslateMessage(int msg, uint64_t wParam, int64_t 
   switch (msg) {
     case WM_WINDOWPOSCHANGED: {
       UpdateSize();
+      return 0;
+    }
+    case WM_DPICHANGED: {
+      m_compRootView.ScaleFactor(ScaleFactor());
+      // Invalidate cached pixel dimensions so the WM_WINDOWPOSCHANGED that
+      // follows SetWindowPos always passes UpdateSize's dimension guard and
+      // re-runs Arrange with the new DIP scale.  Without this, a same-monitor
+      // scale change (identical pixel rect) would short-circuit UpdateSize and
+      // leave layout stale.
+      m_width = 0;
+      m_height = 0;
+      auto *suggestedRect = reinterpret_cast<const RECT *>(lParam);
+      SetWindowPos(
+          m_hwnd,
+          nullptr,
+          suggestedRect->left,
+          suggestedRect->top,
+          suggestedRect->right - suggestedRect->left,
+          suggestedRect->bottom - suggestedRect->top,
+          SWP_NOZORDER | SWP_NOACTIVATE);
       return 0;
     }
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -85,26 +85,6 @@ LRESULT CompositionHwndHost::TranslateMessage(int msg, uint64_t wParam, int64_t 
       UpdateSize();
       return 0;
     }
-    case WM_DPICHANGED: {
-      m_compRootView.ScaleFactor(ScaleFactor());
-      // Invalidate cached pixel dimensions so the WM_WINDOWPOSCHANGED that
-      // follows SetWindowPos always passes UpdateSize's dimension guard and
-      // re-runs Arrange with the new DIP scale.  Without this, a same-monitor
-      // scale change (identical pixel rect) would short-circuit UpdateSize and
-      // leave layout stale.
-      m_width = 0;
-      m_height = 0;
-      auto *suggestedRect = reinterpret_cast<const RECT *>(lParam);
-      SetWindowPos(
-          m_hwnd,
-          nullptr,
-          suggestedRect->left,
-          suggestedRect->top,
-          suggestedRect->right - suggestedRect->left,
-          suggestedRect->bottom - suggestedRect->top,
-          SWP_NOZORDER | SWP_NOACTIVATE);
-      return 0;
-    }
   }
 
   if (m_compRootView) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
@@ -5,6 +5,7 @@
 #include "CompositionHwndHost.g.h"
 
 #include <windows.ui.composition.interop.h>
+#include <winrt/Microsoft.UI.Content.h>
 #include <winrt/Windows.UI.Composition.Desktop.h>
 #include "ReactHost/React.h"
 
@@ -34,6 +35,7 @@ struct CompositionHwndHost : CompositionHwndHostT<CompositionHwndHost> {
 
   HWND m_hwnd;
   winrt::Microsoft::ReactNative::ReactNativeIsland m_compRootView{nullptr};
+  winrt::Microsoft::UI::Content::DesktopChildSiteBridge m_bridge{nullptr};
   LONG m_height{0};
   LONG m_width{0};
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
`CompositionHwndHost::Initialize()` connected the `ContentIsland` to the `DesktopChildSiteBridge` before setting the `ResizePolicy`, causing the island's coordinate space to be configured without proper DPI awareness. This led to `InputPointerSource` delivering touch coordinates that did not account for the display's scale factor on secondary windows at non-100% zoom.

### What
**Initialization reorder (`CompositionHwndHost.cpp` / `.h`):**

- Promoted `DesktopChildSiteBridge` from a local variable to a member (`m_bridge`) so it survives past `Initialize()`.
- Reordered `Initialize()` so that `ResizePolicy` is set *before* `Connect`, and `ScaleFactor` is set *before* the island is connected — matching the `ReactNativeWindow::ContentSiteBridge` reference pattern.

Runtime DPI changes (e.g., moving the window between monitors with different scales) are already handled by `ReactNativeIsland`'s `ContentIsland::StateChanged` subscription, which responds to `DidRasterizationScaleChange()` and calls `ScaleFactor()` → `Arrange()` directly.

## Screenshots
N/A — this is a behavioral/layout correctness fix; the visual result is that touch input on secondary windows at non-100% DPI now aligns correctly with their visual positions.

## Testing
Verified locally by:
1. Launching a React Native Windows app with a second `CompositionHwndHost` window on a 150% DPI display — touch targets now align correctly with their visual positions.
2. Moving the window between monitors with different DPI settings — layout remains correct (handled by `ReactNativeIsland`'s `RasterizationScaleChanged` subscription).

## Changelog
Should this change be included in the release notes: **yes**

Fix `CompositionHwndHost` initialization order so that `ResizePolicy` is set before `Connect` and `ScaleFactor` before the island is connected, ensuring secondary windows render with correct DPI-aware touch coordinates.