### PR TITLE
Fix assert in x86 when using custom align

### DIFF
--- a/change/react-native-windows-50367e69-5758-42cc-8ed0-32490253f5f6.json
+++ b/change/react-native-windows-50367e69-5758-42cc-8ed0-32490253f5f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix assert in x86 when using custom align",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/external/folly/folly/hash/SpookyHashV2.h
+++ b/vnext/external/folly/folly/hash/SpookyHashV2.h
@@ -299,7 +299,12 @@ private:
         FOLLY_BUILTIN_MEMCPY(&out, buf + off, sizeof(out));
         return out;
       } else {
-        assert(0 == reinterpret_cast<uintptr_t>(buf) % sizeof(*buf));
+        // [Windows
+        // This assert is not correct for the x86 code where the allocated buffer can be aligned by 32-bits instead of 64-bits.
+        // Intel CPUs allow unaligned memory access without issues.
+        // ARM64 CPUs prohibit unaligned memory access, but if it happens, then we would have an immediate crash at this point. Thus, the assert is redundant.
+        // Windows]
+        // assert(0 == reinterpret_cast<uintptr_t>(buf) % sizeof(*buf));
         return buf[off];
       }
     }


### PR DESCRIPTION
Port #16145 to main
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16152)