### PR TITLE
Add Windows Platform Release constant

### DIFF
--- a/vnext/Microsoft.ReactNative/Modules/PlatformConstantsWinModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PlatformConstantsWinModule.cpp
@@ -7,8 +7,32 @@
 #include <VersionHelpers.h>
 #include <cxxreact/ReactNativeVersion.h>
 #include <winrt/Windows.Foundation.Metadata.h>
+#include <winrt/Windows.System.Profile.h>
+#include <cstdint>
+#include <string>
 
 namespace Microsoft::ReactNative {
+
+namespace {
+
+std::string GetReleaseVersion() noexcept {
+  try {
+    std::uint64_t deviceFamilyVersion = std::stoull(
+        winrt::to_string(winrt::Windows::System::Profile::AnalyticsInfo::VersionInfo().DeviceFamilyVersion()));
+
+    uint16_t major = static_cast<uint16_t>((deviceFamilyVersion & 0xFFFF000000000000ULL) >> 48);
+    uint16_t minor = static_cast<uint16_t>((deviceFamilyVersion & 0x0000FFFF00000000ULL) >> 32);
+    uint16_t build = static_cast<uint16_t>((deviceFamilyVersion & 0x00000000FFFF0000ULL) >> 16);
+    uint16_t revision = static_cast<uint16_t>(deviceFamilyVersion & 0x000000000000FFFFULL);
+
+    return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(build) + "." +
+        std::to_string(revision);
+  } catch (...) {
+    return "";
+  }
+}
+
+} // namespace
 
 ReactNativeSpecs::PlatformConstantsWindowsSpec_PlatformConstantsWindows PlatformConstants::GetConstants() noexcept {
   ReactNativeSpecs::PlatformConstantsWindowsSpec_PlatformConstantsWindows constants;
@@ -29,6 +53,8 @@ ReactNativeSpecs::PlatformConstantsWindowsSpec_PlatformConstantsWindows Platform
   constants.reactNativeWindowsVersion.major = RNW_MAJOR;
   constants.reactNativeWindowsVersion.minor = RNW_MINOR;
   constants.reactNativeWindowsVersion.patch = RNW_PATCH;
+
+  constants.Release = GetReleaseVersion();
 
   // Provide the universal API contract as an OS version
   if (!IsWindows10OrGreater()) {

--- a/vnext/src-win/Libraries/Utilities/Platform.windows.js
+++ b/vnext/src-win/Libraries/Utilities/Platform.windows.js
@@ -34,6 +34,7 @@ const Platform: PlatformType = {
       minor: number,
       patch: number,
     },
+    Release: string,
     osVersion: number,
   } {
     // $FlowFixMe[object-this-reference]

--- a/vnext/src-win/Libraries/Utilities/PlatformTypes.js
+++ b/vnext/src-win/Libraries/Utilities/PlatformTypes.js
@@ -117,6 +117,7 @@ type WindowsPlatform = {
       minor: number,
       patch: number,
     },
+    Release: string,
     osVersion: number,
   },
   // $FlowFixMe[unsafe-getters-setters]

--- a/vnext/src-win/src/private/specs_DEPRECATED/modules/NativePlatformConstantsWindows.js
+++ b/vnext/src-win/src/private/specs_DEPRECATED/modules/NativePlatformConstantsWindows.js
@@ -28,6 +28,7 @@ export type PlatformConstantsWindows = {|
     minor: number,
     patch: number,
   |},
+  Release: string,
   osVersion: number,
 |};
 


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
`Platform.constants['Release']` is currently undefined on Windows, while React Native Android exposes a `Release` string for the OS release version. This adds the Windows equivalent so callers can read the OS release from `Platform.constants`.

Resolves #11012

### What
- Added `Release` to the Windows PlatformConstants Flow spec and JS platform types.
- Populated `Release` in the native Windows PlatformConstants module from `AnalyticsInfo.VersionInfo.DeviceFamilyVersion()`, formatted as `major.minor.build.revision`.
- Left the existing numeric `osVersion` API contract value unchanged.

## Screenshots
Not applicable.

## Testing
- `./node_modules/.bin/prettier --plugin=prettier-plugin-hermes-parser --check vnext/src-win/src/private/specs_DEPRECATED/modules/NativePlatformConstantsWindows.js vnext/src-win/Libraries/Utilities/Platform.windows.js vnext/src-win/Libraries/Utilities/PlatformTypes.js`
- `./../node_modules/.bin/react-native-windows-codegen --files 'src/**/*Native*.js' --namespace Microsoft::ReactNativeSpecs --libraryName rnwcore --componentsWindows --modulesWindows --internalComponents --modulesCxx --test` from `vnext`
- `./node_modules/.bin/eslint vnext/src-win/src/private/specs_DEPRECATED/modules/NativePlatformConstantsWindows.js vnext/src-win/Libraries/Utilities/Platform.windows.js vnext/src-win/Libraries/Utilities/PlatformTypes.js`
- `git diff --check`

I also tried `npx just-scripts codegen:check`, but this macOS checkout could not load `vnext/just-task.js` because `pwsh.exe`/dotnet tooling was unavailable. I tried `flow check` from `vnext`; it failed on existing repository-wide missing-module and unused-suppression errors unrelated to these files.

## Changelog
Should this change be included in the release notes: yes

Add `Platform.constants.Release` on Windows with the OS release version string.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16156)