### PR TITLE
Fix PowerShell installation

### DIFF
--- a/change/react-native-windows-f139800b-c305-4d90-a3f6-8d348530a0ce.json
+++ b/change/react-native-windows-f139800b-c305-4d90-a3f6-8d348530a0ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Defer findPowershell to layoutMSRNCxx",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/just-task.js
+++ b/vnext/just-task.js
@@ -45,10 +45,9 @@ function codegen(test) {
   );
 }
 
-const powershell = findPowerShell();
-
 function layoutMSRNCxx() {
   if (require('os').platform() === 'win32') {
+    const powershell = findPowerShell();
     execSync(
       `"${powershell}" -NoProfile .\\Scripts\\Tfs\\Layout-MSRN-Headers.ps1 -GenerateLocalCxx`,
       {


### PR DESCRIPTION
## Description

Fixes just-task PowerShell lookup.


### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
PowerShell lookup triggered by `yarn` will fail due to being invoked before the tool is installed. 

### What
The lookup function at `vnext/just-task.js` gets theferred to the calling method instead of being a global const call.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16164)