### PR TITLE
Update template to have more consistent config between ship/debug

### DIFF
--- a/change/react-native-windows-b3b7eb2e-82b3-424d-b7c1-82b30a97fbe3.json
+++ b/change/react-native-windows-b3b7eb2e-82b3-424d-b7c1-82b30a97fbe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update template to have more consistent config between ship/debug",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -66,13 +66,13 @@ winrt::Microsoft::ReactNative::ReactNativeHost CreateReactNativeHost(
 
   host.PackageProviders().Append(winrt::make<CompReactPackageProvider>());
   host.PackageProviders().Append(winrt::SampleCustomComponent::ReactPackageProvider());
-
-#if BUNDLE
   host.InstanceSettings().JavaScriptBundleFile(L"index.windows");
   host.InstanceSettings().BundleRootPath(std::wstring(L"file://").append(appDirectory).append(L"\\Bundle\\").c_str());
+  host.InstanceSettings().DebugBundlePath(L"index");
+
+#if BUNDLE
   host.InstanceSettings().UseFastRefresh(false);
 #else
-  host.InstanceSettings().JavaScriptBundleFile(L"index");
   host.InstanceSettings().UseFastRefresh(true);
 #endif
 

--- a/packages/sample-app-fabric/windows/SampleAppFabric/SampleAppFabric.cpp
+++ b/packages/sample-app-fabric/windows/SampleAppFabric/SampleAppFabric.cpp
@@ -40,17 +40,20 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   // Register any native modules defined within this app project
   settings.PackageProviders().Append(winrt::make<CompReactPackageProvider>());
 
-#if BUNDLE
   // Load the JS bundle from a file (not Metro):
   // Set the path (on disk) where the .bundle file is located
   settings.BundleRootPath(std::wstring(L"file://").append(appDirectory).append(L"\\Bundle\\").c_str());
+
   // Set the name of the bundle file (without the .bundle extension)
   settings.JavaScriptBundleFile(L"index.windows");
+
+  // JS Entry file to use when loading from Metro:
+  settings.DebugBundlePath(L"index");
+
+#if BUNDLE
   // Disable hot reload
   settings.UseFastRefresh(false);
 #else
-  // Load the JS bundle from Metro
-  settings.JavaScriptBundleFile(L"index");
   // Enable hot reload
   settings.UseFastRefresh(true);
 #endif

--- a/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
+++ b/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
@@ -40,18 +40,21 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   // Register any native modules defined within this app project
   settings.PackageProviders().Append(winrt::make<CompReactPackageProvider>());
 
-#if BUNDLE
-  // Load the JS bundle from a file (not Metro):
+    // When loading the JS bundle from a file (not Metro):
   // Set the path (on disk) where the .bundle file is located
   settings.BundleRootPath(std::wstring(L"file://").append(appDirectory).append(L"\\Bundle\\").c_str());
+
   // Set the name of the bundle file (without the .bundle extension)
   settings.JavaScriptBundleFile(L"index.windows");
-  // Disable hot reload
+
+  // JS Entry file to use when loading from Metro:
+  settings.DebugBundlePath(L"index");
+
+#if BUNDLE
+  // Disable hot reload - bundle will be loaded from prebuilt bundle file.
   settings.UseFastRefresh(false);
 #else
-  // Load the JS bundle from Metro
-  settings.JavaScriptBundleFile(L"index");
-  // Enable hot reload
+  // Enable hot reload - load the JS bundle from Metro
   settings.UseFastRefresh(true);
 #endif
 #if _DEBUG


### PR DESCRIPTION
## Description
The current template changes the value of `host.InstanceSettings().JavaScriptBundleFile` to switch between values for loading from metro vs loading from a bundle file.

But we have a seperate property, `host.InstanceSettings().DebugBundlePath` which if set is used when loading from metro.

This allows us to have a single config which will work when loading from metro or the bundle file.  And allow the developer to switch between metro and a bundle file from the dev menu without any additional config.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16165)