### PR TITLE
Harden perf-comment workflow inputs

### DIFF
--- a/.github/workflows/perf-comment.yml
+++ b/.github/workflows/perf-comment.yml
@@ -39,6 +39,11 @@ jobs:
             exit 0
           fi
           PR_NUMBER=$(cat "$PR_FILE" | tr -d '[:space:]')
+          # Validate: must be a positive integer to prevent injection via artifact poisoning
+          if ! echo "$PR_NUMBER" | grep -qE '^[1-9][0-9]*$'; then
+            echo "::error::Invalid PR number in artifact: not a positive integer"
+            exit 1
+          fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
@@ -58,12 +63,20 @@ jobs:
       - name: Post or update PR comment
         if: steps.pr.outputs.skip != 'true' && steps.report.outputs.skip != 'true'
         uses: actions/github-script@v7
+        env:
+          REPORT_PATH: ${{ steps.report.outputs.path }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const fs = require('fs');
             const marker = '<!-- rnw-perf-results -->';
-            const reportPath = '${{ steps.report.outputs.path }}';
-            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+            const reportPath = process.env.REPORT_PATH;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('Invalid PR number from artifact — possible artifact poisoning.');
+              return;
+            }
 
             const markdown = fs.readFileSync(reportPath, 'utf-8');
             const body = `${marker}\n${markdown}`;


### PR DESCRIPTION
## Description

Follow GitHub's recommended best practices for `workflow_run` triggered workflows that consume artifacts from untrusted runs.

### Type of Change

- Validate PR number: Add a strict numeric check `(^[1-9][0-9]*$)` in the shell step before setting the output, so malformed artifact data is rejected early.
- Use environment variables instead of expression interpolation: Pass `PR_NUMBER and REPORT_PATH via env: block instead of inlining ${{ }} expressions in the actions/github-script body. This aligns with the GitHub security hardening guide for github-script.
- Add defense-in-depth integer check in JS: Validate prNumber is a positive integer before using it in API calls.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16174)