### PR TITLE
Move the current latest release 0.82-stable to legacy

### DIFF
--- a/change/@office-iss-react-native-win32-f4e80613-3c9f-4701-af4a-cf362aca593c.json
+++ b/change/@office-iss-react-native-win32-f4e80613-3c9f-4701-af4a-cf362aca593c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-4589b99a-ca33-4c3a-81d2-3b7ad0e55afa.json
+++ b/change/@react-native-windows-automation-4589b99a-ca33-4c3a-81d2-3b7ad0e55afa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/automation",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-4b040e53-267a-4d2c-bdf8-4ee94f1007c4.json
+++ b/change/@react-native-windows-automation-channel-4b040e53-267a-4d2c-bdf8-4ee94f1007c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-commands-20b72e77-daac-4b66-b2e0-8fe2cd5b3593.json
+++ b/change/@react-native-windows-automation-commands-20b72e77-daac-4b66-b2e0-8fe2cd5b3593.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-cf8ac5b8-7c89-4a5c-bbc6-4b67d4ac0fbd.json
+++ b/change/@react-native-windows-cli-cf8ac5b8-7c89-4a5c-bbc6-4b67d4ac0fbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/cli",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-9a8f3818-1999-4fa8-8b6c-7dc3703636ee.json
+++ b/change/@react-native-windows-codegen-9a8f3818-1999-4fa8-8b6c-7dc3703636ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/codegen",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-d24189d2-9bf7-4ce0-9ee4-5e0b53e2c278.json
+++ b/change/@react-native-windows-find-repo-root-d24189d2-9bf7-4ce0-9ee4-5e0b53e2c278.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-44af77dd-e2b9-4013-b824-c10d7fdc7735.json
+++ b/change/@react-native-windows-fs-44af77dd-e2b9-4013-b824-c10d7fdc7735.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/fs",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-f7bbb339-c764-4314-974b-4211629687d3.json
+++ b/change/@react-native-windows-package-utils-f7bbb339-c764-4314-974b-4211629687d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-2c287f3d-5b56-4ee1-ad29-efcf65a2ccd9.json
+++ b/change/@react-native-windows-telemetry-2c287f3d-5b56-4ee1-ad29-efcf65a2ccd9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-09f74feb-b2ea-459f-8bf6-c3e5916cadeb.json
+++ b/change/react-native-platform-override-09f74feb-b2ea-459f-8bf6-c3e5916cadeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "react-native-platform-override",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-491b3dce-0559-434a-8125-e27238e09ce3.json
+++ b/change/react-native-windows-491b3dce-0559-434a-8125-e27238e09ce3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-a605214d-6432-4b03-a19c-8a1eba6cc1cd.json
+++ b/change/react-native-windows-init-a605214d-6432-4b03-a19c-8a1eba6cc1cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.82 to legacy",
+  "packageName": "react-native-windows-init",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -99,7 +99,7 @@
     "react-native": "^0.82.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/automation-channel/package.json
+++ b/packages/@react-native-windows/automation-channel/package.json
@@ -42,7 +42,7 @@
     "!packages*.lock.json"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/automation-commands/package.json
+++ b/packages/@react-native-windows/automation-commands/package.json
@@ -38,7 +38,7 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/automation/package.json
+++ b/packages/@react-native-windows/automation/package.json
@@ -49,7 +49,7 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -73,7 +73,7 @@
     "src/powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -33,7 +33,7 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -37,7 +37,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -35,7 +35,7 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -52,7 +52,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -73,7 +73,7 @@
     "react-native": "*"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -62,7 +62,7 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -96,7 +96,7 @@
     "react-native": "^0.82.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.82-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
## Description
Ahead of the 0.83 release, we are updating the current latest stable version to the legacy.

### Type of Change
- This change requires a documentation update

### Why
Move the current latest release 0.82-stable to legacy

### What
Refer https://github.com/microsoft/react-native-windows/wiki/How-to-promote-a-release#promoting-a-preview-to-latest

1. Move the current latest release 0.XX-stable to legacy
To prevent older branches from being published as latest we need to change the tag they publish as. To do that:

- Check out the current branch for latest (the one before preview) (i.e. git checkout 0.XX-stable)
- Make sure your branch is up-to-date with the microsoft/react-native-windows repo
- Create a new branch for the PR (i.e. git checkout -b promoteXX)
- Run yarn promote-release --release legacy --rnVersion 0.XX
- Create a PR with the generated commits to the latest branch (i.e. git push -u origin promoteXX)
- After the PR is merged, wait for (or kick off, if you haven't set the automatic trigger) a new [Publish run](https://dev.azure.com/microsoft/ReactNative/_build?definitionId=63081&_a=summary) for the 0.XX-stable branch
- After the Publish completes, wait for (or kick off, if you haven't set the automatic trigger) a new [NuGet Release run](https://dev.azure.com/microsoft/ReactNative/_build?definitionId=163759) for the 0.XX-stable branch (be sure, when running this manually, to select the correct Publish pipeline run under Resources > Publish [Publish])

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16180)