### PR TITLE
Promote 0.83.0 to stable

### DIFF
--- a/change/@office-iss-react-native-win32-76abb966-7985-4ba0-bd21-222d2dc2bd8d.json
+++ b/change/@office-iss-react-native-win32-76abb966-7985-4ba0-bd21-222d2dc2bd8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-72c25d95-7cd9-43c0-b2b6-c65319ff46bd.json
+++ b/change/@react-native-windows-automation-72c25d95-7cd9-43c0-b2b6-c65319ff46bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/automation",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-ba427f20-206a-4d17-84f9-5535c01e12a7.json
+++ b/change/@react-native-windows-automation-channel-ba427f20-206a-4d17-84f9-5535c01e12a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-commands-6eb80bfd-d596-43ec-8f16-eefa26179517.json
+++ b/change/@react-native-windows-automation-commands-6eb80bfd-d596-43ec-8f16-eefa26179517.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-e6ad978c-2bff-4f2e-8dfc-6e6f908fcb06.json
+++ b/change/@react-native-windows-cli-e6ad978c-2bff-4f2e-8dfc-6e6f908fcb06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/cli",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-06652f3b-00cb-4e4d-a963-eb31f7a1574b.json
+++ b/change/@react-native-windows-codegen-06652f3b-00cb-4e4d-a963-eb31f7a1574b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/codegen",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-00df98de-4135-4cea-b992-b2c94318898f.json
+++ b/change/@react-native-windows-find-repo-root-00df98de-4135-4cea-b992-b2c94318898f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-07c9b7fb-f6c9-4548-b7ae-8f18b894fff3.json
+++ b/change/@react-native-windows-fs-07c9b7fb-f6c9-4548-b7ae-8f18b894fff3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/fs",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-5831638f-2760-4b34-98c2-80b43db568b6.json
+++ b/change/@react-native-windows-package-utils-5831638f-2760-4b34-98c2-80b43db568b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-b9246e92-056c-4e1b-a102-e8bd4bde4a0c.json
+++ b/change/@react-native-windows-perf-testing-b9246e92-056c-4e1b-a102-e8bd4bde4a0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-4ba043ff-664d-49b5-ba3f-d0f7db235f01.json
+++ b/change/@react-native-windows-telemetry-4ba043ff-664d-49b5-ba3f-d0f7db235f01.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-f028380e-ad0d-4b97-b4c8-75bae60090ac.json
+++ b/change/react-native-platform-override-f028380e-ad0d-4b97-b4c8-75bae60090ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "react-native-platform-override",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-70f6af64-ca41-4479-8629-e5204baca057.json
+++ b/change/react-native-windows-70f6af64-ca41-4479-8629-e5204baca057.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-10a58219-7136-4536-a804-af87793b8517.json
+++ b/change/react-native-windows-init-10a58219-7136-4536-a804-af87793b8517.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to latest",
+  "packageName": "react-native-windows-init",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -100,11 +100,11 @@
     "react-native": "^0.83.0"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/automation-channel/package.json
+++ b/packages/@react-native-windows/automation-channel/package.json
@@ -43,11 +43,11 @@
     "!packages*.lock.json"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/automation-commands/package.json
+++ b/packages/@react-native-windows/automation-commands/package.json
@@ -38,11 +38,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/automation/package.json
+++ b/packages/@react-native-windows/automation/package.json
@@ -49,11 +49,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -73,11 +73,11 @@
     "src/powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -58,11 +58,11 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -33,11 +33,11 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -37,11 +37,11 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -35,11 +35,11 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/perf-testing/package.json
+++ b/packages/@react-native-windows/perf-testing/package.json
@@ -50,11 +50,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -52,11 +52,11 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -73,11 +73,11 @@
     "react-native": "*"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -62,11 +62,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -96,11 +96,11 @@
     "react-native": "^0.83.0"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"


### PR DESCRIPTION
## Description
Promoting version 0.83.0 from preview status to the stable release

### Type of Change
- This change requires a documentation update


### Why
To promote 0.83 preview to stable

### What

- Create a new branch for the PR (i.e. git checkout -b promoteYY)
- Run yarn promote-release --release latest --rnVersion 0.YY
- Integrate the final published RN version (yarn integrate-rn 0.YY.0 and any commands in wiki integration instructions)
- Create a PR with the results (i.e. git push -u origin promoteYY)
- After the PR is merged, wait for (or kick off) a new [Publish run](https://dev.azure.com/microsoft/ReactNative/_build?definitionId=63081&_a=summary) for the 0.YY-stable branch

 Refer https://github.com/microsoft/react-native-windows/wiki/How-to-promote-a-release

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16181)