### PR TITLE
[0.81] fix: Unicode Text length Calculation

### DIFF
--- a/change/react-native-windows-363573e0-b320-4ecb-a1c0-ad9eac1b6845.json
+++ b/change/react-native-windows-363573e0-b320-4ecb-a1c0-ad9eac1b6845.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix Unicode length Calculation in Text Component",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -149,11 +149,13 @@ facebook::react::SharedViewEventEmitter ParagraphComponentView::eventEmitterAtPo
       uint32_t textPosition = metrics.textPosition;
 
       for (auto fragment : m_attributedStringBox.getValue().getFragments()) {
-        if (textPosition < fragment.string.length()) {
+        uint32_t utf16Length =
+            static_cast<uint32_t>(::Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string).length());
+        if (textPosition < utf16Length) {
           return std::static_pointer_cast<const facebook::react::ViewEventEmitter>(
               fragment.parentShadowView.eventEmitter);
         }
-        textPosition -= static_cast<uint32_t>(fragment.string.length());
+        textPosition -= utf16Length;
       }
     }
   }
@@ -206,10 +208,12 @@ bool ParagraphComponentView::IsTextSelectableAtPoint(facebook::react::Point pt) 
 
       // Finds which fragment contains this text position
       for (auto fragment : m_attributedStringBox.getValue().getFragments()) {
-        if (textPosition < fragment.string.length()) {
+        uint32_t utf16Length =
+            static_cast<uint32_t>(::Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string).length());
+        if (textPosition < utf16Length) {
           return true;
         }
-        textPosition -= static_cast<uint32_t>(fragment.string.length());
+        textPosition -= utf16Length;
       }
     }
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextDrawing.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextDrawing.cpp
@@ -66,7 +66,7 @@ void RenderText(
   unsigned int position = 0;
   unsigned int length = 0;
   for (auto fragment : attributedString.getFragments()) {
-    length = static_cast<UINT32>(fragment.string.length());
+    length = static_cast<UINT32>(::Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string).length());
     DWRITE_TEXT_RANGE range = {position, length};
     if (fragment.textAttributes.foregroundColor &&
             (fragment.textAttributes.foregroundColor != textAttributes.foregroundColor) ||

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
@@ -262,7 +262,7 @@ void WindowsTextLayoutManager::GetTextLayout(
       attachments.push_back(attachment);
       position += 1;
     } else {
-      unsigned int length = static_cast<UINT32>(fragment.string.length());
+      unsigned int length = static_cast<UINT32>(Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string).length());
       DWRITE_TEXT_RANGE range = {position, length};
       TextAttributes attributes = fragment.textAttributes;
       DWRITE_FONT_STYLE fragmentStyle = DWRITE_FONT_STYLE_NORMAL;


### PR DESCRIPTION
## Description
The length of text that is being rendered is not calculated for Unicode characters, this change will fix it

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Text Highlight for Unicode is not working

- Resolves #15828 


## Screenshots
<img width="1945" height="1130" alt="image" src="https://github.com/user-attachments/assets/e24eff66-8523-49e3-916e-e50ee8f09c4a" />


## Testing
Tested in Playground


## Changelog
Should this change be included in the release notes: _yes_

(fix: Unicode Text length Calculation)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16185)