### PR TITLE
[0.81] Race condition can cause the callinvoker to get a null runtime during…

### DIFF
--- a/change/react-native-windows-73a8efbe-5a83-4ea1-900e-969399459c00.json
+++ b/change/react-native-windows-73a8efbe-5a83-4ea1-900e-969399459c00.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Race condition can cause the callinvoker to get a null runtime during shutdown.  Which should just skip the invoke.",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CallInvoker.cpp
+++ b/vnext/Microsoft.ReactNative/CallInvoker.cpp
@@ -19,13 +19,23 @@ CallInvoker::CallInvoker(
     : m_callInvoker(callInvoker), m_context(&reactContext) {}
 
 void CallInvoker::InvokeAsync(CallFunc func) noexcept {
-  m_callInvoker->invokeAsync(
-      [reactContext = m_context, func](facebook::jsi::Runtime & /*runtime*/) { func(reactContext->JsiRuntime()); });
+  m_callInvoker->invokeAsync([reactContext = m_context, func](facebook::jsi::Runtime & /*runtime*/) {
+    auto runtime = reactContext->JsiRuntime();
+    if (!runtime)
+      return;
+
+    func(runtime);
+  });
 }
 
 void CallInvoker::InvokeSync(CallFunc func) noexcept {
-  m_callInvoker->invokeSync(
-      [reactContext = m_context, func](facebook::jsi::Runtime & /*runtime*/) { func(reactContext->JsiRuntime()); });
+  m_callInvoker->invokeSync([reactContext = m_context, func](facebook::jsi::Runtime & /*runtime*/) {
+    auto runtime = reactContext->JsiRuntime();
+    if (!runtime)
+      return;
+
+    func(runtime);
+  });
 }
 
 winrt::Microsoft::ReactNative::CallInvoker CallInvoker::FromProperties(


### PR DESCRIPTION
Port #16186 to 0.81

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16187)