### PR TITLE
Support Windows Platform.constants.Release

### DIFF
--- a/change/react-native-windows-108cd0f8-12f4-4de6-ae3c-4c3f049028ee.json
+++ b/change/react-native-windows-108cd0f8-12f4-4de6-ae3c-4c3f049028ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Platform.constants.Release on Windows",
+  "packageName": "react-native-windows",
+  "email": "vivekjm77@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/PlatformConstantsWinModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PlatformConstantsWinModule.cpp
@@ -7,8 +7,22 @@
 #include <VersionHelpers.h>
 #include <cxxreact/ReactNativeVersion.h>
 #include <winrt/Windows.Foundation.Metadata.h>
+#include <winrt/Windows.System.Profile.h>
 
 namespace Microsoft::ReactNative {
+
+static std::string GetReleaseVersion() noexcept {
+  try {
+    const auto versionInfo = winrt::Windows::System::Profile::AnalyticsInfo::VersionInfo();
+    const auto version = std::stoull(winrt::to_string(versionInfo.DeviceFamilyVersion()));
+    return std::to_string((version & 0xFFFF000000000000ULL) >> 48) + "." +
+        std::to_string((version & 0x0000FFFF00000000ULL) >> 32) + "." +
+        std::to_string((version & 0x00000000FFFF0000ULL) >> 16) + "." +
+        std::to_string(version & 0x000000000000FFFFULL);
+  } catch (...) {
+    return "";
+  }
+}
 
 ReactNativeSpecs::PlatformConstantsWindowsSpec_PlatformConstantsWindows PlatformConstants::GetConstants() noexcept {
   ReactNativeSpecs::PlatformConstantsWindowsSpec_PlatformConstantsWindows constants;
@@ -42,6 +56,8 @@ ReactNativeSpecs::PlatformConstantsWindowsSpec_PlatformConstantsWindows Platform
       }
     }
   }
+
+  constants.Release = GetReleaseVersion();
 
   return constants;
 }

--- a/vnext/src-win/Libraries/Utilities/Platform.windows.js
+++ b/vnext/src-win/Libraries/Utilities/Platform.windows.js
@@ -35,6 +35,7 @@ const Platform: PlatformType = {
       patch: number,
     },
     osVersion: number,
+    Release: string,
   } {
     // $FlowFixMe[object-this-reference]
     if (this.__constants == null) {

--- a/vnext/src-win/Libraries/Utilities/PlatformTypes.js
+++ b/vnext/src-win/Libraries/Utilities/PlatformTypes.js
@@ -118,6 +118,7 @@ type WindowsPlatform = {
       patch: number,
     },
     osVersion: number,
+    Release: string,
   },
   // $FlowFixMe[unsafe-getters-setters]
   get isTesting(): boolean,

--- a/vnext/src-win/src/private/specs_DEPRECATED/modules/NativePlatformConstantsWindows.js
+++ b/vnext/src-win/src/private/specs_DEPRECATED/modules/NativePlatformConstantsWindows.js
@@ -29,6 +29,7 @@ export type PlatformConstantsWindows = {|
     patch: number,
   |},
   osVersion: number,
+  Release: string,
 |};
 
 export interface Spec extends TurboModule {


### PR DESCRIPTION
## Summary
- Add `Release` to the Windows Platform constants spec and Flow type surfaces
- Populate `Platform.constants.Release` from `AnalyticsInfo.VersionInfo.DeviceFamilyVersion()` as `major.minor.build.revision`
- Add a Beachball change file for `react-native-windows`

Fixes #11012

## Test plan
- `git diff --check`
- `../react-native-windows/node_modules/.bin/prettier --plugin ../react-native-windows/node_modules/prettier-plugin-hermes-parser/dist/index.js --check vnext/src-win/src/private/specs_DEPRECATED/modules/NativePlatformConstantsWindows.js vnext/src-win/Libraries/Utilities/Platform.windows.js vnext/src-win/Libraries/Utilities/PlatformTypes.js`
- `node -e` sanity check for decoding a sample Windows device family version into `10.0.22631.4602`

Not run: Windows native build/tests, because this automation ran on macOS.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16200)