### PR TITLE
[0.81] Fix FAIL_FAST crash in Desktop Timing module on shutdown

### DIFF
--- a/change/react-native-windows-372904d5-277e-4372-a337-171de273d071.json
+++ b/change/react-native-windows-372904d5-277e-4372-a337-171de273d071.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix crash in Timing module on shutdown",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/Modules/DesktopTimingModule.cpp
+++ b/vnext/Desktop/Modules/DesktopTimingModule.cpp
@@ -81,10 +81,15 @@ void Timing::Initialize(winrt::Microsoft::ReactNative::ReactContext const &react
 }
 
 void Timing::OnTimerRaised() noexcept {
-  // Make sure we execute it on native thread for native modules
-  // Capture weak_ptr "this" because callback will be executed on native
-  // thread even if "this" is destroyed.
-  m_reactContext.JSDispatcher().Post([weakThis = std::weak_ptr<Timing>(shared_from_this())]() {
+  // Hop to the native thread before touching module state.
+  //
+  // This callback can race with the last shared_ptr to this Timing being
+  // released, so use weak_from_this() rather than shared_from_this(): once the
+  // use-count hits zero shared_from_this() throws bad_weak_ptr, which would
+  // escape this noexcept callback and crash. weak_from_this() instead yields an
+  // expired weak_ptr and the lock() below bails out. Touching "this" is safe
+  // because ~Timing() blocks in WaitForThreadpoolTimerCallbacks until we return.
+  m_reactContext.JSDispatcher().Post([weakThis = weak_from_this()]() {
     auto strongThis = weakThis.lock();
     if (!strongThis) {
       return;


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The Desktop `Timing` native module fail-fasts the process (`0xC0000409`) during
teardown. `Timing::OnTimerRaised()` is a `noexcept` threadpool-timer callback
that can run concurrently with the release of the last `shared_ptr` owning the
module. Once the shared use-count reaches zero, the `shared_from_this()` call
inside it throws `std::bad_weak_ptr`; the exception escapes the `noexcept`
boundary and terminates the process. Seen in a crash dump from `msoadfsb.exe`
(react-native-win32 0.74.58.0).

### What
In `vnext/Desktop/Modules/DesktopTimingModule.cpp`, `OnTimerRaised()` now uses
`weak_from_this()` instead of `std::weak_ptr<Timing>(shared_from_this())`.
`weak_from_this()` is `noexcept` and returns an already-expired `weak_ptr` when
the object is being destroyed, so the existing `weakThis.lock()` guard simply
bails out instead of throwing. The object remains valid for the duration of the
call because `~Timing()` blocks in `WaitForThreadpoolTimerCallbacks`. Behavior
is unchanged in the normal case (the captured reference was always meant to be
weak). Updated the surrounding comment to document the lifetime invariant.

## Testing
Verified the fix against the crash dump's stack. Audited all `shared_from_this()`
uses under `vnext/` and confirmed this was the only call executed inside an
async/`noexcept` callback body during teardown; all other sites capture at
setup time (live owner present) or already use `weak_from_this()`.

## Changelog
Yes.

Fix process crash (FAIL_FAST `0xC0000409`) on shutdown in the Desktop `Timing`
module caused by `shared_from_this()` throwing `bad_weak_ptr` in the threadpool
timer callback.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16206)