### PR TITLE
Upgrade to GoogleTest Adapter 1.8.1.8

### DIFF
--- a/change/react-native-windows-f8f860c1-f597-4280-aaf2-f3250f196760.json
+++ b/change/react-native-windows-f8f860c1-f597-4280-aaf2-f3250f196760.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade to GoogleTest adapter 1.8.1.8",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -162,7 +162,7 @@
   <ItemGroup>
     <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)"
       Condition="'$(OverrideWinUIPackage)'!='true'" />
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.8" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.experimentalwinui3.lock.json
@@ -4,9 +4,9 @@
     "native,Version=v0.0": {
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.lock.json
@@ -4,9 +4,9 @@
     "native,Version=v0.0": {
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -190,7 +190,7 @@
   <ItemGroup>
     <PackageReference Include="boost" Version="1.84.0.0" />
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn"
-      Version="1.8.1.7" />
+      Version="1.8.1.8" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)"
       PrivateAssets="all" />

--- a/vnext/Microsoft.ReactNative.IntegrationTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",

--- a/vnext/Microsoft.ReactNative.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -183,7 +183,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn"
-      Version="1.8.1.7" />
+      Version="1.8.1.8" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)"
       PrivateAssets="all" />
   </ItemGroup>

--- a/vnext/Mso.UnitTests/packages.experimentalwinui3.lock.json
+++ b/vnext/Mso.UnitTests/packages.experimentalwinui3.lock.json
@@ -4,9 +4,9 @@
     "native,Version=v0.0": {
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",

--- a/vnext/Mso.UnitTests/packages.lock.json
+++ b/vnext/Mso.UnitTests/packages.lock.json
@@ -4,9 +4,9 @@
     "native,Version=v0.0": {
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "Microsoft.Windows.CppWinRT": {
         "type": "Direct",

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -43,8 +43,8 @@
 
   <PropertyGroup Label="ExternalDependencies">
     <!-- Google Test Adapter -->
-    <!-- Property sheets in the adapter's NuGet doesn't consider PlatformToolset=v143 -->
-    <Force-Enable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn>false</Force-Enable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn>
+    <!-- If ApplicationType is set, adapter include paths won't be set for MSVC 14.0 (v140) or later -->
+    <Force-Enable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn>true</Force-Enable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn>
   </PropertyGroup>
 
   <!--

--- a/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
+++ b/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
@@ -181,7 +181,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.84.0.0" />
-    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.7" />
+    <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.8" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/vnext/ReactCommon.UnitTests/packages.experimentalwinui3.lock.json
+++ b/vnext/ReactCommon.UnitTests/packages.experimentalwinui3.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Direct",

--- a/vnext/ReactCommon.UnitTests/packages.lock.json
+++ b/vnext/ReactCommon.UnitTests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn": {
         "type": "Direct",
-        "requested": "[1.8.1.7, )",
-        "resolved": "1.8.1.7",
-        "contentHash": "FxNwT4YpsGdqforqFSTGc5f/e+qfRJ+1wf5G1w0nEEkT5pr5M95E5+fOuswpPUGXPZIXM+M7BSVGnCRcQZjomA=="
+        "requested": "[1.8.1.8, )",
+        "resolved": "1.8.1.8",
+        "contentHash": "RHZUuFTnYzkHPRM5muZfw4SRL/EIHFz7nIkKl1mJKPISvzi1wWtK7k/oJIpw3pWVkdFyEfnBQP8vX1fFpe7Mpw=="
       },
       "ReactNative.V8Jsi.Windows": {
         "type": "Direct",


### PR DESCRIPTION
## Description

Bump the adapter to the latest version.

### Type of Change

* Bug fix (non-breaking change which fixes an issue)

### Why

Current version does not support MSVC 14.5

### What

* Upgrade NuGet package `Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn` to version `1.8.1.8`.
* Correct usage and documentaion of MSBuild property `Force-Enable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-dyn`.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16218)