### PR TITLE
Update CI verdaccio to 6.7.2

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -165,7 +165,7 @@ extends:
           - task: CmdLine@2
             inputs:
               script: |
-                npm install --global yarn@1.22.22 midgard-yarn@1.23.34 verdaccio@5.2.0
+                npm install --global yarn@1.22.22 midgard-yarn@1.23.34 verdaccio@6.7.2
             displayName: Install Node base packages
 
           - template: .ado/templates/compute-beachball-branch-name.yml@self

--- a/.ado/templates/strict-yarn-install.yml
+++ b/.ado/templates/strict-yarn-install.yml
@@ -20,7 +20,7 @@ steps:
   - task: CmdLine@2
     inputs:
       script: |
-        npm install --global yarn@1.22.22 midgard-yarn@1.23.34 verdaccio@5.2.0
+        npm install --global yarn@1.22.22 midgard-yarn@1.23.34 verdaccio@6.7.2
     displayName: Install Node base packages
 
   - script: yarn install --immutable

--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -13,7 +13,7 @@ steps:
   - task: CmdLine@2
     inputs:
       script: |
-        npm install --global yarn@1.22.22 midgard-yarn@1.23.34 verdaccio@5.2.0
+        npm install --global yarn@1.22.22 midgard-yarn@1.23.34 verdaccio@6.7.2
     displayName: Install Node base packages
 
   - script: yarn --cwd ${{ parameters.workingDirectory }} install --immutable


### PR DESCRIPTION
## Description
Updates verdaccio version for CI runs.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Current `verdaccio` version `5.2.0` is deprecated. Upgrading to the latest stable.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16223)