### PR TITLE
Upgrade projects to .NET 10

### DIFF
--- a/change/react-native-windows-2fe39775-b224-4fbb-bf3c-af9bccca23a5.json
+++ b/change/react-native-windows-2fe39775-b224-4fbb-bf3c-af9bccca23a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade projects to .NET 10",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.CsWinRT/Microsoft.ReactNative.CsWinRT.csproj
+++ b/vnext/Microsoft.ReactNative.CsWinRT/Microsoft.ReactNative.CsWinRT.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <Platforms>x86;x64;arm64</Platforms>

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.experimentalwinui3.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.experimentalwinui3.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows10.0.22621": {
+    "net10.0-windows10.0.22621": {
       "Microsoft.Windows.CsWinRT": {
         "type": "Direct",
         "requested": "[2.2.0, )",

--- a/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.CsWinRT/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows10.0.22621": {
+    "net10.0-windows10.0.22621": {
       "Microsoft.Windows.CsWinRT": {
         "type": "Direct",
         "requested": "[2.2.0, )",

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
 
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
     <PackageReference Include="RuntimeContracts" Version="0.3.0" />
 
-    <!-- 
-      NuGet decides to pull in packages with issues. There is no seeming way to diagnose why NuGet is pulling in those versions. 
+    <!--
+      NuGet decides to pull in packages with issues. There is no seeming way to diagnose why NuGet is pulling in those versions.
       Running restore with -Verbosity Detailed and environment variables:
        * NUGET_RESTORE_MSBUILD_ARGS=/bl:c:\temp\nuget.binlog
        * NUGET_RESTORE_MSBUILD_VERBOSITY=diag
@@ -42,7 +42,7 @@
      <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
-  <!-- 
+  <!--
     This target is used to ensure the tool is deployed and can be used from source.
     It will return all deployed files so the caller can implement incrementality properly
    -->
@@ -53,7 +53,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- 
+  <!--
     This target returns the location of the deployed executable.
   -->
   <Target Name="GetPublishedToolPath" DependsOnTargets="PublishTool" Returns="@(_PublishedToolExecutable)">
@@ -62,13 +62,13 @@
     </ItemGroup>
   </Target>
 
-  <!-- 
+  <!--
     This is used during the PR build to ensure we have the artifacts published during the build.
   -->
-  <Target 
-    Name="PublishToolDuringBuild" 
-    DependsOnTargets="Publish" 
-    AfterTargets="Build" 
+  <Target
+    Name="PublishToolDuringBuild"
+    DependsOnTargets="Publish"
+    AfterTargets="Build"
     Condition="'$(PublishToolDuringBuild)' == 'true'">
   </Target>
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Debug.pubxml
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Debug.pubxml
@@ -6,7 +6,7 @@
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Debug</Configuration>
     <Platform>x64</Platform>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PublishDir>$(OutDir)publish</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Release.pubxml
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Properties/PublishProfiles/DeployAsTool-Release.pubxml
@@ -6,7 +6,7 @@
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PublishDir>$(OutDir)publish</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>

--- a/vnext/TestWebSite/Microsoft.ReactNative.Test.Website.csproj
+++ b/vnext/TestWebSite/Microsoft.ReactNative.Test.Website.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Platform>AnyCPU</Platform>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IntDir>$(IntDir)$(TargetFramework)\</IntDir>

--- a/vnext/TestWebSite/packages.lock.json
+++ b/vnext/TestWebSite/packages.lock.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0": {}
+    "net10.0": {}
   }
 }


### PR DESCRIPTION
## Description
Upgrade to .NET 10.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
This project's development environment has been upgraded to Visual Studio 2026, which relies on .NET 10 as its LTS version.

### What
Upgrade MSBuild projects and package lock files to the new .NET version.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16226)