### PR TITLE
Fix crash attempting to get runtime when shutting down instance

### DIFF
--- a/change/react-native-windows-7a98fbf7-0186-4130-b6ab-409caa188bee.json
+++ b/change/react-native-windows-7a98fbf7-0186-4130-b6ab-409caa188bee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash attempting to get runtime when shutting down instance",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -527,7 +527,8 @@ struct ModuleJsiInitMethodInfo<void (TModule::*)(ReactContext const &, facebook:
     return
         [module = static_cast<ModuleType *>(module), method](
             ReactContext const &reactContext, winrt::Windows::Foundation::IInspectable const &runtimeHandle) noexcept {
-          (module->*method)(reactContext, GetOrCreateContextRuntime(reactContext, runtimeHandle));
+          if (runtimeHandle)
+            (module->*method)(reactContext, GetOrCreateContextRuntime(reactContext, runtimeHandle));
         };
   }
 };


### PR DESCRIPTION
If the instance is shutting down, the runtime can be cleared on the instance while JS code is running. If the JS triggers a turbomodule with a JSI Init function, then when it attempts to get the runtime to call the REACT_INIT function with it will crash.

Fix is to simply skip the REACT_INIT function if we are already shutting down the instance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16238)