### PR TITLE
No hermes explicit microtasks in paper

### DIFF
--- a/change/react-native-windows-2dec8121-9429-4301-8e69-be082ed11bc9.json
+++ b/change/react-native-windows-2dec8121-9429-4301-8e69-be082ed11bc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Turn off explicit hermes microtasks in paper",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -813,6 +813,7 @@ void ReactInstanceWin::InitializeWithBridge() noexcept {
           };
 
           devSettings->useWebSocketTurboModule = getBoolProperty(nullptr, L"UseWebSocketTurboModule", false);
+          devSettings->hermesSetExplicitMicrotasks = false;
 
           std::vector<facebook::react::NativeModuleDescription> cxxModules;
           auto nmp = std::make_shared<winrt::Microsoft::ReactNative::NativeModulesProvider>();

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -116,6 +116,8 @@ struct DevSettings {
   // Enable concurrent mode by installing runtimeScheduler
   bool useRuntimeScheduler{false};
 
+  bool hermesSetExplicitMicrotasks{true};
+
   // The HostTarget instance for Fusebox
   facebook::react::jsinspector_modern::HostTarget *inspectorHostTarget;
 };

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -271,8 +271,7 @@ void HermesRuntimeHolder::initRuntime() noexcept {
   CRASH_ON_ERROR(api.jsr_create_config(&config));
   CRASH_ON_ERROR(api.hermes_config_enable_default_crash_handler(config, devSettings->enableDefaultCrashHandler));
   CRASH_ON_ERROR(api.jsr_config_enable_inspector(config, devSettings->useDirectDebugger));
-  CRASH_ON_ERROR(api.jsr_config_set_explicit_microtasks(
-      config, facebook::react::ReactNativeFeatureFlags::enableBridgelessArchitecture()));
+  CRASH_ON_ERROR(api.jsr_config_set_explicit_microtasks(config, devSettings->hermesSetExplicitMicrotasks));
 
   if (m_jsQueue) {
     HermesTaskRunner::Create(config, m_jsQueue);


### PR DESCRIPTION
## Description
The legacy paper renderer is not setup to explicitly drain microtasks.  But we are always configuring hermes into explicit microtask mode.  In core this is controlled by  facebook::react::ReactNativeFeatureFlags::enableBridgelessArchitecture().  But that is a global setting, not a per instance setting, which is what we need for Office.
Instead we set a property on the devSettings object to control if we should use explicit microtasks or not.

This fixes an issue where in some cases await calls would not get flushed until another message came though the queue. Which would cause the app to appear hung, and then unfreeze on a mouse move.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16249)