### PR TITLE
Move the current latest release 0.83-stable to legacy

### DIFF
--- a/change/@office-iss-react-native-win32-a94ee502-9086-4dac-8386-b7f5565ab915.json
+++ b/change/@office-iss-react-native-win32-a94ee502-9086-4dac-8386-b7f5565ab915.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-60ef74d8-9564-48f3-b7bf-86c4d5d7fc88.json
+++ b/change/@react-native-windows-automation-channel-60ef74d8-9564-48f3-b7bf-86c4d5d7fc88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-commands-697796d6-ffc4-4d91-ac04-5129e86a5e3a.json
+++ b/change/@react-native-windows-automation-commands-697796d6-ffc4-4d91-ac04-5129e86a5e3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-f1ce3335-b055-4d15-a99d-e25e9f8ce7b1.json
+++ b/change/@react-native-windows-automation-f1ce3335-b055-4d15-a99d-e25e9f8ce7b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/automation",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-47cb18cd-028b-470b-92d8-aae49fabbc63.json
+++ b/change/@react-native-windows-cli-47cb18cd-028b-470b-92d8-aae49fabbc63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/cli",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-9272ff6d-5203-40f7-936f-83f710a0f31c.json
+++ b/change/@react-native-windows-codegen-9272ff6d-5203-40f7-936f-83f710a0f31c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/codegen",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-dotnet-tools-1f126471-78b8-44fe-9bc1-c637d1679245.json
+++ b/change/@react-native-windows-find-dotnet-tools-1f126471-78b8-44fe-9bc1-c637d1679245.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/find-dotnet-tools",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-dotnet-tools-7018a5fe-0791-4fb7-ae1d-c95620216ddc.json
+++ b/change/@react-native-windows-find-dotnet-tools-7018a5fe-0791-4fb7-ae1d-c95620216ddc.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Migrate to PowerShell 7",
-  "packageName": "@react-native-windows/find-dotnet-tools",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@react-native-windows-find-repo-root-c2fc4dbe-c115-445e-aa42-84a5156e718b.json
+++ b/change/@react-native-windows-find-repo-root-c2fc4dbe-c115-445e-aa42-84a5156e718b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-30b2959e-1d7b-4403-93a1-54d6feef77bc.json
+++ b/change/@react-native-windows-fs-30b2959e-1d7b-4403-93a1-54d6feef77bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/fs",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-0206ad0f-69e7-4b4e-b4b1-b1437660ad45.json
+++ b/change/@react-native-windows-package-utils-0206ad0f-69e7-4b4e-b4b1-b1437660ad45.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-708337b3-322f-4eee-b830-b5e9ea4a8c6c.json
+++ b/change/@react-native-windows-perf-testing-708337b3-322f-4eee-b830-b5e9ea4a8c6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-8f931873-d6eb-46ce-b2a7-0784c40ffc70.json
+++ b/change/@react-native-windows-telemetry-8f931873-d6eb-46ce-b2a7-0784c40ffc70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-689a824e-2884-46a5-8b90-7e7c7ed8b939.json
+++ b/change/react-native-platform-override-689a824e-2884-46a5-8b90-7e7c7ed8b939.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "react-native-platform-override",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e8981575-3acc-41e3-9dc1-a0cbf74e41b7.json
+++ b/change/react-native-windows-e8981575-3acc-41e3-9dc1-a0cbf74e41b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-f816ae56-9016-45cd-bf01-c13ae6bd8a87.json
+++ b/change/react-native-windows-init-f816ae56-9016-45cd-bf01-c13ae6bd8a87.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.83 to legacy",
+  "packageName": "react-native-windows-init",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -100,7 +100,7 @@
     "react-native": "^0.83.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/automation-channel/package.json
+++ b/packages/@react-native-windows/automation-channel/package.json
@@ -43,7 +43,7 @@
     "!packages*.lock.json"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/automation-commands/package.json
+++ b/packages/@react-native-windows/automation-commands/package.json
@@ -38,7 +38,7 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/automation/package.json
+++ b/packages/@react-native-windows/automation/package.json
@@ -49,7 +49,7 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -73,7 +73,7 @@
     "src/powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -58,7 +58,7 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-dotnet-tools/package.json
+++ b/packages/@react-native-windows/find-dotnet-tools/package.json
@@ -31,11 +31,11 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -33,7 +33,7 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -37,7 +37,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -35,7 +35,7 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/perf-testing/package.json
+++ b/packages/@react-native-windows/perf-testing/package.json
@@ -50,7 +50,7 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -52,7 +52,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -73,7 +73,7 @@
     "react-native": "*"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -62,7 +62,7 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -96,7 +96,7 @@
     "react-native": "^0.83.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.83-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
## Description
Ahead of the 0.84 release, we are updating the current latest stable version to the legacy.

### Type of Change
- This change requires a documentation update

### Why
Move the current latest release 0.82-stable to legacy

### What
Refer https://github.com/microsoft/react-native-windows/wiki/How-to-promote-a-release#promoting-a-preview-to-latest

1. Move the current latest release 0.XX-stable to legacy
To prevent older branches from being published as latest we need to change the tag they publish as. To do that:

- Check out the current branch for latest (the one before preview) (i.e. git checkout 0.XX-stable)
- Make sure your branch is up-to-date with the microsoft/react-native-windows repo
- Create a new branch for the PR (i.e. git checkout -b promoteXX)
- Run yarn promote-release --release legacy --rnVersion 0.XX
- Create a PR with the generated commits to the latest branch (i.e. git push -u origin promoteXX)
- After the PR is merged, wait for (or kick off, if you haven't set the automatic trigger) a new [Publish run](https://dev.azure.com/microsoft/ReactNative/_build?definitionId=63081&_a=summary) for the 0.XX-stable branch
- After the Publish completes, wait for (or kick off, if you haven't set the automatic trigger) a new [NuGet Release run](https://dev.azure.com/microsoft/ReactNative/_build?definitionId=163759) for the 0.XX-stable branch (be sure, when running this manually, to select the correct Publish pipeline run under Resources > Publish [Publish])

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16255)