### PR TITLE
Promote 0.84.0 to stable

### DIFF
--- a/change/@office-iss-react-native-win32-29d8ba36-08ff-4ce5-a98b-d2bdea298a5f.json
+++ b/change/@office-iss-react-native-win32-29d8ba36-08ff-4ce5-a98b-d2bdea298a5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-4f020795-8a2a-42a8-9fb9-1b7a60f64e57.json
+++ b/change/@react-native-windows-automation-4f020795-8a2a-42a8-9fb9-1b7a60f64e57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/automation",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-6563f06b-42ac-4251-8340-912b0689b17b.json
+++ b/change/@react-native-windows-automation-channel-6563f06b-42ac-4251-8340-912b0689b17b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-commands-0616f5dc-b4f0-4f46-8795-1e25383f15c5.json
+++ b/change/@react-native-windows-automation-commands-0616f5dc-b4f0-4f46-8795-1e25383f15c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/automation-commands",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-584fc251-1992-47df-86fc-d0f7e2dc1d9d.json
+++ b/change/@react-native-windows-cli-584fc251-1992-47df-86fc-d0f7e2dc1d9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/cli",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-21e18e36-e271-4aef-aaff-6ce654a13e09.json
+++ b/change/@react-native-windows-codegen-21e18e36-e271-4aef-aaff-6ce654a13e09.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/codegen",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-dotnet-tools-6e370fc5-ccb7-48c4-8258-5db9c9d6aa07.json
+++ b/change/@react-native-windows-find-dotnet-tools-6e370fc5-ccb7-48c4-8258-5db9c9d6aa07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/find-dotnet-tools",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-0bfc88ac-7faf-4549-ba89-8724f6bc0e1a.json
+++ b/change/@react-native-windows-find-repo-root-0bfc88ac-7faf-4549-ba89-8724f6bc0e1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-29400984-a6ae-466e-9a2d-266fc8e4fb52.json
+++ b/change/@react-native-windows-fs-29400984-a6ae-466e-9a2d-266fc8e4fb52.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/fs",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-bf7ec79f-9d1b-4b05-8341-63d6b6754f9d.json
+++ b/change/@react-native-windows-package-utils-bf7ec79f-9d1b-4b05-8341-63d6b6754f9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-perf-testing-8d865587-2b77-4269-badf-b2d81d47f243.json
+++ b/change/@react-native-windows-perf-testing-8d865587-2b77-4269-badf-b2d81d47f243.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/perf-testing",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-2900ae88-a3a1-4b8d-8a89-7378bf8f5ce7.json
+++ b/change/@react-native-windows-telemetry-2900ae88-a3a1-4b8d-8a89-7378bf8f5ce7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-95223736-8cb2-40d2-b631-7f4a65b76f6a.json
+++ b/change/react-native-platform-override-95223736-8cb2-40d2-b631-7f4a65b76f6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "react-native-platform-override",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-1f9f3048-5571-4192-bbe5-2b7f63c9fcab.json
+++ b/change/react-native-windows-1f9f3048-5571-4192-bbe5-2b7f63c9fcab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-8442dee8-fbfb-49ab-b773-3b9e9679b2d3.json
+++ b/change/react-native-windows-init-8442dee8-fbfb-49ab-b773-3b9e9679b2d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.84 to latest",
+  "packageName": "react-native-windows-init",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -101,11 +101,11 @@
     "react-native": "0.84.1"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/automation-channel/package.json
+++ b/packages/@react-native-windows/automation-channel/package.json
@@ -43,11 +43,11 @@
     "!packages*.lock.json"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/automation-commands/package.json
+++ b/packages/@react-native-windows/automation-commands/package.json
@@ -38,11 +38,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/automation/package.json
+++ b/packages/@react-native-windows/automation/package.json
@@ -49,11 +49,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -74,11 +74,11 @@
     "src/powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -58,11 +58,11 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/find-dotnet-tools/package.json
+++ b/packages/@react-native-windows/find-dotnet-tools/package.json
@@ -31,11 +31,11 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -33,11 +33,11 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -37,11 +37,11 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -35,11 +35,11 @@
     "typescript": "5.0.4"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/perf-testing/package.json
+++ b/packages/@react-native-windows/perf-testing/package.json
@@ -50,11 +50,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -52,11 +52,11 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -73,11 +73,11 @@
     "react-native": "*"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -62,11 +62,11 @@
     "README.md"
   ],
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -97,11 +97,11 @@
     "react-native": "0.84.1"
   },
   "beachball": {
-    "defaultNpmTag": "preview",
+    "defaultNpmTag": "latest",
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch",
+      "prerelease",
       "premajor",
       "preminor",
       "prepatch"


### PR DESCRIPTION
## Description
Promoting version 0.84.0 from preview status to the stable release

### Type of Change
- This change requires a documentation update


### Why
To promote 0.84 preview to stable

### What

- Create a new branch for the PR (i.e. git checkout -b promoteYY)
- Run yarn promote-release --release latest --rnVersion 0.YY
- Integrate the final published RN version (yarn integrate-rn 0.YY.0 and any commands in wiki integration instructions)
- Create a PR with the results (i.e. git push -u origin promoteYY)
- After the PR is merged, wait for (or kick off) a new [Publish run](https://dev.azure.com/microsoft/ReactNative/_build?definitionId=63081&_a=summary) for the 0.YY-stable branch

 Refer https://github.com/microsoft/react-native-windows/wiki/How-to-promote-a-release

## Changelog
Should this change be included in the release notes: _no_