### PR TITLE
Raise UIA TextSelectionChanged in TextInput so screen readers announce caret navigation

### DIFF
--- a/change/react-native-windows-b55776cc-2475-4854-b426-d55aed0fddb3.json
+++ b/change/react-native-windows-b55776cc-2475-4854-b426-d55aed0fddb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Raise a UIA TextSelectionChanged event when the TextInput caret/selection moves, so Narrator and braille displays announce character/word/line navigation during keyboard caret movement",
+  "packageName": "react-native-windows",
+  "email": "clintc@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1457,6 +1457,17 @@ void WindowsTextInputComponentView::OnSelectionChanged(LONG start, LONG end) noe
     onSelectionChangeArgs.selection.end = end;
     emitter->onSelectionChange(onSelectionChangeArgs);
   }
+
+  // Notify UI Automation clients (e.g. Narrator and braille displays) that the caret or
+  // selection moved, so they re-read the current character/word/line during keyboard
+  // navigation. Without this, arrowing through the text is silent for screen readers.
+  // Mirrors the focus- and value-changed raises elsewhere in the Composition layer.
+  if (UiaClientsAreListening()) {
+    auto spProviderSimple = EnsureUiaProvider().try_as<IRawElementProviderSimple>();
+    if (spProviderSimple != nullptr) {
+      UiaRaiseAutomationEvent(spProviderSimple.get(), UIA_Text_TextSelectionChangedEventId);
+    }
+  }
 }
 
 std::string WindowsTextInputComponentView::GetTextFromRichEdit() const noexcept {


### PR DESCRIPTION
## Description

The Composition (Fabric) `WindowsTextInput` never raises a UI Automation **TextSelectionChanged** event when the caret/selection moves. As a result, screen readers — **Narrator** and **braille displays** — stay silent while the user arrows through text. Focus is announced on entering the field, but per-character / word / line caret navigation produces no UIA event for assistive technology to re-read.

This raises `UIA_Text_TextSelectionChangedEventId` from `WindowsTextInputComponentView::OnSelectionChanged`, guarded by `UiaClientsAreListening()`, mirroring the existing focus-changed and value-changed raises in the Composition layer (`CompositionViewComponentView.cpp` → `UIA_AutomationFocusChangedEventId`; `OnTextUpdated` → `UIA_ValueValuePropertyId`).

### Root cause

The control already exposes the UIA Text pattern (TextPattern/TextPattern2) with a working `GetSelection`, but `OnSelectionChanged` only emits the JS `onSelectionChange` event — it never calls `UiaRaiseAutomationEvent`. Across the Composition layer, `UiaRaiseAutomationEvent` is currently called only for `Invoke` and `FocusChanged`, never for text selection. This matches the symptom exactly: Narrator reads the field on focus but is silent on caret navigation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification with **Accessibility Insights for Windows** (Events listener) confirming `TextSelectionChanged` now fires on arrow navigation, and **Narrator** announcing each character/word while moving the caret.

## Changelog

Include in release notes: **yes**

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16276)