### PR TITLE
Fix validate-overrides for react-native GitHub org rename

### DIFF
--- a/change/react-native-platform-override-8955b0be-3b2f-4956-a970-8d6e98eca3b5.json
+++ b/change/react-native-platform-override-8955b0be-3b2f-4956-a970-8d6e98eca3b5.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Update GitHub org from facebook/react-native to react/react-native",
+  "email": "anuagra@microsoft.com",
+  "dependentChangeType": "patch",
+  "type": "prerelease",
+  "packageName": "react-native-platform-override"
+}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prettier-plugin-hermes-parser": "0.21.1",
     "react": "19.2.3",
     "react-native": "0.85.0-nightly-20260128-36f07a1b2",
-    "react-native-platform-override": "0.0.0-canary.1017",
+    "react-native-platform-override": "workspace:*",
     "typescript": "5.0.4"
   },
   "resolutions": {

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -16,7 +16,7 @@ import {VersionedReactFileRepository} from './FileRepository';
 import {getNpmPackage} from './PackageUtils';
 import {fetchFullRef} from './refFromVersion';
 
-const RN_GITHUB_URL = 'https://github.com/facebook/react-native.git';
+const RN_GITHUB_URL = 'https://github.com/react/react-native.git';
 
 /**
  * Retrieves React Native files using the React Native Github repo. Switching

--- a/packages/react-native-platform-override/src/refFromVersion.ts
+++ b/packages/react-native-platform-override/src/refFromVersion.ts
@@ -97,7 +97,7 @@ async function fetchFullCommitHash(
   // We cannot get abbreviated hash directly from a remote, so query Github's
   // API for it.
   const commitInfo = await fetch(
-    `https://api.github.com/repos/facebook/react-native/commits/${abbrevHash}`,
+    `https://api.github.com/repos/react/react-native/commits/${abbrevHash}`,
     {
       headers: {
         'Content-Type': 'application/json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4175,7 +4175,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-windows/fs@npm:0.0.0-canary.72, @react-native-windows/fs@npm:^0.0.0-canary.70, @react-native-windows/fs@npm:^0.0.0-canary.72, @react-native-windows/fs@workspace:packages/@react-native-windows/fs":
+"@react-native-windows/fs@npm:0.0.0-canary.72, @react-native-windows/fs@npm:^0.0.0-canary.72, @react-native-windows/fs@workspace:packages/@react-native-windows/fs":
   version: 0.0.0-use.local
   resolution: "@react-native-windows/fs@workspace:packages/@react-native-windows/fs"
   dependencies:
@@ -4194,7 +4194,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-windows/package-utils@npm:0.0.0-canary.98, @react-native-windows/package-utils@npm:^0.0.0-canary.96, @react-native-windows/package-utils@npm:^0.0.0-canary.98, @react-native-windows/package-utils@workspace:packages/@react-native-windows/package-utils":
+"@react-native-windows/package-utils@npm:0.0.0-canary.98, @react-native-windows/package-utils@npm:^0.0.0-canary.98, @react-native-windows/package-utils@workspace:packages/@react-native-windows/package-utils":
   version: 0.0.0-use.local
   resolution: "@react-native-windows/package-utils@workspace:packages/@react-native-windows/package-utils"
   dependencies:
@@ -16324,38 +16324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-platform-override@npm:0.0.0-canary.1017":
-  version: 0.0.0-canary.1017
-  resolution: "react-native-platform-override@npm:0.0.0-canary.1017"
-  dependencies:
-    "@react-native-windows/fs": "npm:^0.0.0-canary.70"
-    "@react-native-windows/package-utils": "npm:^0.0.0-canary.96"
-    "@typescript-eslint/eslint-plugin": "npm:^7.1.1"
-    "@typescript-eslint/parser": "npm:^7.1.1"
-    async: "npm:^3.2.3"
-    chalk: "npm:^4.1.0"
-    fp-ts: "npm:^2.5.0"
-    globby: "npm:^11.1.0"
-    inquirer: "npm:^7.1.0"
-    io-ts: "npm:^2.1.1"
-    isutf8: "npm:^3.0.0"
-    lodash: "npm:^4.17.15"
-    node-fetch: "npm:^2.6.7"
-    ora: "npm:^3.4.0"
-    semver: "npm:^7.3.2"
-    simple-git: "npm:^3.3.0"
-    source-map-support: "npm:^0.5.19"
-    upath: "npm:^1.2.0"
-    yargs: "npm:^16.2.0"
-  peerDependencies:
-    react-native: "*"
-  bin:
-    react-native-platform-override: bin.js
-  checksum: 10c0/406b6e4ec9e1902d1fd1acb55f721bad779c30bbcddef9d64ca3cdb1efd833f28f763221c6beaa714ea53ae0a1dab3e393dc1ca2b62e3b3acdcefaf3f6844450
-  languageName: node
-  linkType: hard
-
-"react-native-platform-override@npm:0.0.0-canary.1022, react-native-platform-override@workspace:packages/react-native-platform-override":
+"react-native-platform-override@npm:0.0.0-canary.1022, react-native-platform-override@workspace:*, react-native-platform-override@workspace:packages/react-native-platform-override":
   version: 0.0.0-use.local
   resolution: "react-native-platform-override@workspace:packages/react-native-platform-override"
   dependencies:
@@ -16476,7 +16445,7 @@ __metadata:
     prettier-plugin-hermes-parser: "npm:0.21.1"
     react: "npm:19.2.3"
     react-native: "npm:0.85.0-nightly-20260128-36f07a1b2"
-    react-native-platform-override: "npm:0.0.0-canary.1017"
+    react-native-platform-override: "workspace:*"
     typescript: "npm:5.0.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description
The upstream React Native repo moved from facebook/react-native to react/react-native. This broke yarn validate-overrides because the react-native-platform-override tool has hardcoded GitHub URLs that now return 301 redirects. For PRs like [#16245](https://github.com/microsoft/react-native-windows/pull/16245) that update the override TEMP files, validate-overrides kicks in and tries to validate these files against their base version in the RN repo. But since the path has changed, the network call now fails repeatedly. 

This PR updates the hardcoded GitHub URLs in react-native-platform-override tool to use the new org path.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
For PRs like [#16245](https://github.com/microsoft/react-native-windows/pull/16245) that update the override TEMP files, validate-overrides kicks in and tries to validate these files against their base version in the RN repo. But since the path has changed, the network call now fails repeatedly. 

### What
 This PR updates the 2 hardcoded URLs in the tool's source:
   - src/GitReactFileRepository.ts:19 — git clone URL used to fetch upstream files
  - src/refFromVersion.ts:100 — GitHub API URL used to resolve abbreviated commit hashes
 
 Why only source files are checked in - 
 The compiled output (lib-commonjs/) is in .gitignore and is not checked into the repo. During CI, yarn build compiles all packages including react-native-platform-override, regenerating lib-commonjs/ from the TypeScript source before yarn validate-overrides runs. So only the .ts source changes are needed.

## Testing
  1. Local build:
  - Ran yarn build in packages/react-native-platform-override/ → succeeded (4.26s)
  - Confirmed regenerated lib-commonjs/*.js files contain updated URLs
  2. Local validation:
  - Ran yarn validate-overrides from repo root → all 6 override manifests pass
   3.. Verified new URLs work:
  - https://api.github.com/repos/react/react-native/commits/36f07a1b2
  - https://github.com/react/react-native.git → git ls-remote succeeds

## Changelog
No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16280)