### PR TITLE
[0.81] - Fix Focus Outline for Programmatical focus

### DIFF
--- a/change/react-native-windows-85a3d26d-f9c2-4888-9e32-a6a3f9f4a2b9.json
+++ b/change/react-native-windows-85a3d26d-f9c2-4888-9e32-a6a3f9f4a2b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove Focus Outline for Programmatical Focus",
+  "packageName": "react-native-windows",
+  "email": "66076509+vineethkuttan@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -100,7 +100,7 @@ void RootComponentView::SetFocusedComponent(
     m_focusedComponent = value;
     if (focusState == winrt::Microsoft::ReactNative::FocusState::Programmatic) {
       focusState =
-          (!m_useKeyboardForProgrammaticFocus || m_focusState == winrt::Microsoft::ReactNative::FocusState::Pointer)
+          (!m_useKeyboardForProgrammaticFocus || m_focusState != winrt::Microsoft::ReactNative::FocusState::Keyboard)
           ? winrt::Microsoft::ReactNative::FocusState::Pointer
           : winrt::Microsoft::ReactNative::FocusState::Keyboard;
     }
@@ -185,9 +185,10 @@ bool RootComponentView::TrySetFocusedComponent(
 
 bool RootComponentView::TryMoveFocus(bool next, winrt::Microsoft::ReactNative::FocusState focusState) noexcept {
   if (!m_focusedComponent) {
-    return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
-        next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-             : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+    return NavigateFocus(
+        winrt::Microsoft::ReactNative::FocusNavigationRequest(
+            next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+                 : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
   }
 
   Mso::Functor<bool(const winrt::Microsoft::ReactNative::ComponentView &)> fn =
@@ -227,9 +228,10 @@ bool RootComponentView::TryMoveFocus(bool next, winrt::Microsoft::ReactNative::F
   }
 
   // Wrap focus around if nothing outside the island takes focus
-  return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
-      next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-           : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+  return NavigateFocus(
+      winrt::Microsoft::ReactNative::FocusNavigationRequest(
+          next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+               : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
 }
 
 HRESULT RootComponentView::GetFragmentRoot(IRawElementProviderFragmentRoot **pRetVal) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -185,10 +185,9 @@ bool RootComponentView::TrySetFocusedComponent(
 
 bool RootComponentView::TryMoveFocus(bool next, winrt::Microsoft::ReactNative::FocusState focusState) noexcept {
   if (!m_focusedComponent) {
-    return NavigateFocus(
-        winrt::Microsoft::ReactNative::FocusNavigationRequest(
-            next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-                 : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+    return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
+        next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+             : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
   }
 
   Mso::Functor<bool(const winrt::Microsoft::ReactNative::ComponentView &)> fn =
@@ -228,10 +227,9 @@ bool RootComponentView::TryMoveFocus(bool next, winrt::Microsoft::ReactNative::F
   }
 
   // Wrap focus around if nothing outside the island takes focus
-  return NavigateFocus(
-      winrt::Microsoft::ReactNative::FocusNavigationRequest(
-          next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
-               : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
+  return NavigateFocus(winrt::Microsoft::ReactNative::FocusNavigationRequest(
+      next ? winrt::Microsoft::ReactNative::FocusNavigationReason::First
+           : winrt::Microsoft::ReactNative::FocusNavigationReason::Last));
 }
 
 HRESULT RootComponentView::GetFragmentRoot(IRawElementProviderFragmentRoot **pRetVal) noexcept {


### PR DESCRIPTION
## Description
When a component receives programmatic focus (via autoFocus or ref.focus()) during app startup, the focus outline/rectangle is displayed. This should not happen — programmatic focus should not trigger the focus visual, only keyboard-initiated focus should.

The same component focused programmatically at any other time (e.g., triggered by a button press) correctly does not show the focus outline. The issue is isolated to the initial app start focus.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

- resolves #16177


## Testing
Tested in playground

## Changelog
Should this change be included in the release notes: _yes_

Fix Focus Outline for Programmatical focus

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16282)