### PR TITLE
Fix: text input scaling with different screen scales

### DIFF
--- a/change/react-native-windows-7d9b1431-48aa-416e-b5eb-712e0d1c34be.json
+++ b/change/react-native-windows-7d9b1431-48aa-416e-b5eb-712e0d1c34be.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes misalginment with TextInput on different display scales",
+  "packageName": "react-native-windows",
+  "email": "dlucas@seabird.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1329,7 +1329,7 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
     facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept {
   // Set Position & Size Properties
 
-  if ((layoutMetrics.pointScaleFactor != m_layoutMetrics.pointScaleFactor)) {
+  if (m_textServices && layoutMetrics.pointScaleFactor > 0) {
     LRESULT res;
     winrt::check_hresult(m_textServices->TxSendMessage(
         (WM_USER + 328), // EM_SETDPI


### PR DESCRIPTION
## Description

Fixes issue with TextInput text rendering when working with monitors with different screen scales.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Without this fix, rendering a textinput on a screen with a different resolution from the "primary" monitor can cause the text in TextInputs to appear blank, or large offset from correct position.

Resolves [https://github.com/microsoft/react-native-windows/issues/16141]

### What
Fixed logic for updating textinput layout

## Screenshots
Before, in E2E-test-app-fabric:
Note that there is text in these inputs, but it is invisible (but the cursor is in the right place still)
<img width="768" height="623" alt="textinput-bug" src="https://github.com/user-attachments/assets/635fa83d-425d-4726-83c2-2bbedf836990" />


After, in E2E-test-app-fabric:
<img width="355" height="350" alt="textinput" src="https://github.com/user-attachments/assets/93ddd877-7aa9-4dee-a8a9-b55c03e2e5a5" />


## Testing
Locally tested rendering TextInput on different monitor scales

## Changelog
Should this change be included in the release notes: yes

Resolved issue with TextInput text rendering when working with monitors with different screen scales.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16288)