### PR TITLE
[0.82] fix text input scaling

### DIFF
--- a/change/react-native-windows-44914240-0fc4-422e-911a-2d3dfc287603.json
+++ b/change/react-native-windows-44914240-0fc4-422e-911a-2d3dfc287603.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixes misalignment with TextInput on different display scales",
+  "packageName": "react-native-windows",
+  "email": "dlucas@seabird.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1274,7 +1274,7 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
     facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept {
   // Set Position & Size Properties
 
-  if ((layoutMetrics.pointScaleFactor != m_layoutMetrics.pointScaleFactor)) {
+  if (m_textServices && layoutMetrics.pointScaleFactor > 0) {
     LRESULT res;
     winrt::check_hresult(m_textServices->TxSendMessage(
         (WM_USER + 328), // EM_SETDPI


### PR DESCRIPTION
## Description
Fixes issue with TextInput text rendering when working with monitors with different screen scales.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Without this fix, rendering a textinput on a screen with a different resolution from the "primary" monitor can cause the text in TextInputs to appear blank, or large offset from correct position.

Resolves [https://github.com/https://github.com/microsoft/react-native-windows/issues/16141]

### What
Fixed logic for updating textinput layout

## Screenshots
Before, in E2E-test-app-fabric:
Note that there is text in these inputs, but it is invisible (but the cursor is in the right place still)
<img width="768" height="623" alt="textinput-bug" src="https://github.com/user-attachments/assets/21e68c45-41ac-436d-9cfe-c5fbb1b6cb36" />

After, in E2E-test-app-fabric:
<img width="355" height="350" alt="textinput" src="https://github.com/user-attachments/assets/53517f31-0001-46d6-92d6-a4c53e6b6367" />


## Testing
Locally tested rendering TextInput on different monitor scales

## Changelog
Should this change be included in the release notes: yes

Resolved issue with TextInput text rendering when working with monitors with different screen scales.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16292)