### PR TITLE
[0.83] fix(textinput): center single-line text correctly at >100% display scale

### DIFF
--- a/change/react-native-windows-fix-textinput-centering-dpi.json
+++ b/change/react-native-windows-fix-textinput-centering-dpi.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix single-line TextInput text/caret sitting low and bottom-clipped at >100% display scale (GetContentSize DPI normalization)",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -55,6 +55,12 @@ std::string BstrToStdString(BSTR bstr, int cp = CP_UTF8) {
   return str;
 }
 
+// GetDeviceCaps (used in GetContentSize to normalize RichEdit's device-pixel
+// measurements to DIPs) is exported from Gdi32. Microsoft.ReactNative does not
+// otherwise reference Gdi32, so link it explicitly to avoid an unresolved
+// external symbol (LNK2019) in builds that don't already pull it in transitively.
+#pragma comment(lib, "Gdi32.lib")
+
 MSO_CLASS_GUID(ITextHost, "13E670F4-1A5A-11cf-ABEB-00AA00B65EA1") // IID_ITextHost
 MSO_CLASS_GUID(ITextServices, "8D33F740-CF58-11CE-A89D-00AA006CADC5") // IID_ITextServices
 MSO_CLASS_GUID(ITextServices2, "8D33F741-CF58-11CE-A89D-00AA006CADC5") // IID_ITextServices2
@@ -1314,13 +1320,25 @@ std::pair<float, float> WindowsTextInputComponentView::GetContentSize() const no
 
   // Use the layout width as the constraint (always multiline)
   float availableWidth = m_layoutMetrics.frame.size.width;
-  float scale = m_layoutMetrics.pointScaleFactor;
-  float dpi = m_layoutMetrics.pointScaleFactor * GetDpiForSystem();
+
+  // TxGetNaturalSize measures in the *device pixels of `hdc`*. GetDC(nullptr)
+  // returns a screen DC whose logical DPI (GetDeviceCaps LOGPIXELS) is the system
+  // DPI - typically 96 - and is unrelated to the per-monitor display scale carried
+  // in pointScaleFactor. The previous code conflated the two
+  // (dpi = pointScaleFactor * GetDpiForSystem()) and then divided the returned
+  // natural size by pointScaleFactor, so at any display scale > 100% the measured
+  // content height came back short by exactly that scale and
+  // calculateContentVerticalOffset() over-centered the text (parked low /
+  // bottom-clipped). Normalize both conversions by the DC's real DPI instead. DIPs
+  // are 1/96in by definition, so the DIP<->HIMETRIC leg always uses 96.
+  const int hdcDpiX = GetDeviceCaps(hdc, LOGPIXELSX);
+  const int hdcDpiY = GetDeviceCaps(hdc, LOGPIXELSY);
   constexpr float HIMETRIC_PER_INCH = 2540.0f;
+  constexpr float DIPS_PER_INCH = 96.0f;
 
   SIZE extentHimetric = {
-      static_cast<LONG>(availableWidth * scale * HIMETRIC_PER_INCH / dpi),
-      static_cast<LONG>(std::numeric_limits<LONG>::max() * HIMETRIC_PER_INCH / dpi)};
+      static_cast<LONG>(availableWidth * HIMETRIC_PER_INCH / DIPS_PER_INCH),
+      static_cast<LONG>(std::numeric_limits<LONG>::max() * HIMETRIC_PER_INCH / DIPS_PER_INCH)};
 
   SIZE naturalSize = {0, 0};
 
@@ -1340,8 +1358,10 @@ std::pair<float, float> WindowsTextInputComponentView::GetContentSize() const no
     return {0.0f, 0.0f};
   }
 
-  float contentWidth = static_cast<float>(naturalSize.cx) / scale;
-  float contentHeight = static_cast<float>(naturalSize.cy) / scale;
+  // naturalSize is in the DC's device pixels; convert device px -> DIPs using the
+  // DC's actual DPI (px * 96 / hdcDpi), not pointScaleFactor.
+  float contentWidth = static_cast<float>(naturalSize.cx) * DIPS_PER_INCH / hdcDpiX;
+  float contentHeight = static_cast<float>(naturalSize.cy) * DIPS_PER_INCH / hdcDpiY;
 
   return {contentWidth, contentHeight};
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -55,12 +55,6 @@ std::string BstrToStdString(BSTR bstr, int cp = CP_UTF8) {
   return str;
 }
 
-// GetDeviceCaps (used in GetContentSize to normalize RichEdit's device-pixel
-// measurements to DIPs) is exported from Gdi32. Microsoft.ReactNative does not
-// otherwise reference Gdi32, so link it explicitly to avoid an unresolved
-// external symbol (LNK2019) in builds that don't already pull it in transitively.
-#pragma comment(lib, "Gdi32.lib")
-
 MSO_CLASS_GUID(ITextHost, "13E670F4-1A5A-11cf-ABEB-00AA00B65EA1") // IID_ITextHost
 MSO_CLASS_GUID(ITextServices, "8D33F740-CF58-11CE-A89D-00AA006CADC5") // IID_ITextServices
 MSO_CLASS_GUID(ITextServices2, "8D33F741-CF58-11CE-A89D-00AA006CADC5") // IID_ITextServices2
@@ -1322,23 +1316,33 @@ std::pair<float, float> WindowsTextInputComponentView::GetContentSize() const no
   float availableWidth = m_layoutMetrics.frame.size.width;
 
   // TxGetNaturalSize measures in the *device pixels of `hdc`*. GetDC(nullptr)
-  // returns a screen DC whose logical DPI (GetDeviceCaps LOGPIXELS) is the system
-  // DPI - typically 96 - and is unrelated to the per-monitor display scale carried
-  // in pointScaleFactor. The previous code conflated the two
-  // (dpi = pointScaleFactor * GetDpiForSystem()) and then divided the returned
-  // natural size by pointScaleFactor, so at any display scale > 100% the measured
-  // content height came back short by exactly that scale and
-  // calculateContentVerticalOffset() over-centered the text (parked low /
-  // bottom-clipped). Normalize both conversions by the DC's real DPI instead. DIPs
-  // are 1/96in by definition, so the DIP<->HIMETRIC leg always uses 96.
-  const int hdcDpiX = GetDeviceCaps(hdc, LOGPIXELSX);
-  const int hdcDpiY = GetDeviceCaps(hdc, LOGPIXELSY);
+  // returns a screen DC whose logical DPI is the system DPI - typically 96 - and
+  // is unrelated to the per-monitor display scale carried in pointScaleFactor.
+  // The previous code conflated the two (dpi = pointScaleFactor *
+  // GetDpiForSystem()) and then divided the returned natural size by
+  // pointScaleFactor, so at any display scale > 100% the measured content height
+  // came back short by exactly that scale and calculateContentVerticalOffset()
+  // over-centered the text (parked low / bottom-clipped). Normalize by the
+  // screen DC's real DPI instead. DIPs are 1/96in by definition, so the
+  // DIP<->HIMETRIC leg always uses 96.
+  //
+  // GetDpiForSystem() (user32) reports exactly what GetDeviceCaps(hdc,
+  // LOGPIXELSX/Y) reports for a GetDC(nullptr) screen DC - both return the
+  // system DPI for the caller's DPI-awareness context - so this avoids taking a
+  // Gdi32 dependency for the measurement. RNW already calls GetDpiForSystem
+  // elsewhere in this file. Windows reports square logical DPI for the screen
+  // (LOGPIXELSX == LOGPIXELSY), so one value covers both axes.
+  const UINT hdcDpi = GetDpiForSystem();
   constexpr float HIMETRIC_PER_INCH = 2540.0f;
   constexpr float DIPS_PER_INCH = 96.0f;
 
+  // Height is deliberately unconstrained. Do NOT scale LONG_MAX into HIMETRIC:
+  // LONG_MAX * 2540 / 96 is ~5.7e10, far outside LONG, and converting an
+  // out-of-range floating-point value back to an integer type is undefined
+  // behavior. LONG_MAX already means "unbounded" to RichEdit.
   SIZE extentHimetric = {
       static_cast<LONG>(availableWidth * HIMETRIC_PER_INCH / DIPS_PER_INCH),
-      static_cast<LONG>(std::numeric_limits<LONG>::max() * HIMETRIC_PER_INCH / DIPS_PER_INCH)};
+      std::numeric_limits<LONG>::max()};
 
   SIZE naturalSize = {0, 0};
 
@@ -1360,8 +1364,8 @@ std::pair<float, float> WindowsTextInputComponentView::GetContentSize() const no
 
   // naturalSize is in the DC's device pixels; convert device px -> DIPs using the
   // DC's actual DPI (px * 96 / hdcDpi), not pointScaleFactor.
-  float contentWidth = static_cast<float>(naturalSize.cx) * DIPS_PER_INCH / hdcDpiX;
-  float contentHeight = static_cast<float>(naturalSize.cy) * DIPS_PER_INCH / hdcDpiY;
+  float contentWidth = static_cast<float>(naturalSize.cx) * DIPS_PER_INCH / hdcDpi;
+  float contentHeight = static_cast<float>(naturalSize.cy) * DIPS_PER_INCH / hdcDpi;
 
   return {contentWidth, contentHeight};
 }


### PR DESCRIPTION
## Problem
On a single-line `<TextInput>` at any display scale > 100% (125%, 250%, …), the text and caret sit too low in the control and are clipped at the bottom.

## Root cause
`WindowsTextInputComponentView::GetContentSize()` measures RichEdit content via `TxGetNaturalSize`, which returns sizes in the device pixels of the measuring DC. The DC comes from `GetDC(nullptr)` — a screen DC whose logical DPI (`GetDeviceCaps(hdc, LOGPIXELS)`) is the system DPI (typically 96), unrelated to the per-monitor scale in `pointScaleFactor`. The code conflated the two: it built the HIMETRIC extent with `dpi = pointScaleFactor * GetDpiForSystem()` and divided the returned natural size by `pointScaleFactor`. Net: measured content height is short by exactly the display scale, so `calculateContentVerticalOffset()` centers with an undersized `contentHeight` and pushes the text down and off the bottom.

## Fix
Normalize both conversions by the DC's real DPI: DIP↔HIMETRIC always uses 96 (DIPs are 1/96in by definition); device px → DIP uses `px * 96 / GetDeviceCaps(hdc, LOGPIXELS)`. `pointScaleFactor`/`GetDpiForSystem()` are no longer used in the measurement. `Gdi32.lib` is linked explicitly (`#pragma comment`) — `GetDeviceCaps` is a Gdi32 export and Microsoft.ReactNative does not otherwise reference it (LNK2019 without it in a framework source build).

## Validation
Bug reproduced in a **production RNW 0.83.2 new-arch app** (Facilitron FIT — an Expo monorepo app shipping a full Windows target) on Windows 11 ARM64, Debug, physical panel at a true **250% display scale**. A stock single-line TextInput (deep `Libraries/Components/TextInput/TextInput` import, 44-DIP box, fontSize 18) parks its text on the bottom border and clips, while the app-side workaround this patch obsoletes (bottom padding `fontSize*2.3*(1-1/scale)`) centers the same input:

![before: raw vs shimmed at 250%](https://raw.githubusercontent.com/FacilitronWorks/upstream-evidence/main/rnw-textinput-centering-BEFORE-raw-vs-shim-250pct.png)

This diff has been compiled into Microsoft.ReactNative from source on this machine (yarn-patch framework source build; the changed measurement verified present in the built binary — and the `Gdi32.lib` pragma requirement was found that way). Remaining for upstream: CI build + pixel-level after-shots at 100/125/150/250%.

**Caveats for reviewers:** base commit `8e869d7` is itself "[0.83] fix text input scaling (#16291)" — please confirm this refines (does not regress) that change. Authored against `0.83-stable` to match our production app; happy to re-cut onto `main` if preferred. Separately noted (not addressed here): `pointScaleFactor` can go stale across monitor moves (no WM_DPICHANGED refresh).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16302)