### PR TITLE
[0.83] fix(textinput): correct placeholder layout constraints (px vs DIP) and no-op NaN fontSize guard

### DIFF
--- a/change/react-native-windows-fix-textinput-placeholder.json
+++ b/change/react-native-windows-fix-textinput-placeholder.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix placeholder layout constraints fed physical px instead of DIPs; fix no-op NaN fontSize guard in CreatePlaceholderLayout",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1690,7 +1690,7 @@ winrt::com_ptr<::IDWriteTextLayout> WindowsTextInputComponentView::CreatePlaceho
   const auto &props = windowsTextInputProps();
   facebook::react::TextAttributes textAttributes = props.textAttributes;
   if (std::isnan(props.textAttributes.fontSize)) {
-    facebook::react::TextAttributes::defaultTextAttributes().fontSize;
+    textAttributes.fontSize = facebook::react::TextAttributes::defaultTextAttributes().fontSize;
   }
   textAttributes.fontSizeMultiplier = m_fontSizeMultiplier;
   fragment1.string = props.placeholder;
@@ -1698,8 +1698,13 @@ winrt::com_ptr<::IDWriteTextLayout> WindowsTextInputComponentView::CreatePlaceho
   attributedString.appendFragment(std::move(fragment1));
 
   facebook::react::LayoutConstraints constraints;
-  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth);
-  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight);
+  // m_imgWidth/m_imgHeight are physical pixels (frame * pointScaleFactor), but
+  // LayoutConstraints are expressed in DIPs. Feeding physical px laid the
+  // placeholder out in a box pointScaleFactor x too large, so the placeholder was
+  // measured/positioned at a different height than the typed text. Convert to DIPs.
+  const float scale = m_layoutMetrics.pointScaleFactor != 0.0f ? m_layoutMetrics.pointScaleFactor : 1.0f;
+  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth) / scale;
+  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight) / scale;
 
   facebook::react::WindowsTextLayoutManager::GetTextLayout(
       facebook::react::AttributedStringBox(attributedString), {} /*TODO*/, constraints, textLayout);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1702,9 +1702,8 @@ winrt::com_ptr<::IDWriteTextLayout> WindowsTextInputComponentView::CreatePlaceho
   // LayoutConstraints are expressed in DIPs. Feeding physical px laid the
   // placeholder out in a box pointScaleFactor x too large, so the placeholder was
   // measured/positioned at a different height than the typed text. Convert to DIPs.
-  const float scale = m_layoutMetrics.pointScaleFactor != 0.0f ? m_layoutMetrics.pointScaleFactor : 1.0f;
-  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth) / scale;
-  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight) / scale;
+  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth) / m_layoutMetrics.pointScaleFactor;
+  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight) / m_layoutMetrics.pointScaleFactor;
 
   facebook::react::WindowsTextLayoutManager::GetTextLayout(
       facebook::react::AttributedStringBox(attributedString), {} /*TODO*/, constraints, textLayout);


### PR DESCRIPTION
## Problem
The native placeholder renders at a different height/size than typed text; a placeholder with no explicit `fontSize` gets a NaN size that is never repaired.

## Root cause
In `CreatePlaceholderLayout()`: (1) `LayoutConstraints` are in DIPs, but the code feeds `m_imgWidth`/`m_imgHeight`, which are physical pixels (`frame * pointScaleFactor`) — the placeholder is laid out in a box `pointScaleFactor`× too large. (2) The NaN-fontSize guard is a no-op: `TextAttributes::defaultTextAttributes().fontSize;` is a discarded expression (missing assignment), so NaN is never replaced.

## Fix
Divide the constraint by `pointScaleFactor` to get DIPs; actually assign the default into `textAttributes.fontSize`.

## Validation (honest)
Probed in a production RNW 0.83.2 new-arch app (Facilitron FIT, Windows 11 ARM64, Debug, 250% scale) with stock deep-import TextInputs and no app shims:

![placeholder vs typed at 250%](https://raw.githubusercontent.com/FacilitronWorks/upstream-evidence/main/rnw-placeholder-BEFORE-raw-vs-typed-250pct.png)

Findings stated plainly: the fontSize no-op is an unambiguous code bug (discarded expression), though on 0.83.2 a no-fontSize placeholder still renders at a plausible default — so that part is correctness/robustness, not a visible-crash fix. At this probe geometry (44-DIP box, fontSize 18) placeholder and typed text measured pixel-identical glyph rows (both parked low — dominated by the `GetContentSize` centering bug, companion PR #), so the oversized constraint did not produce a visible offset in this configuration; the mismatch that motivated the fix was observed in product forms before we suppressed native placeholders app-wide. The DIP conversion mirrors how `m_imgWidth`/`m_imgHeight` are derived (verified in 0.83.2 source). Needs upstream CI + placeholder-vs-typed comparison at >100% scale across box/font sizes, with and without explicit placeholder fontSize. Authored against `0.83-stable`; happy to re-cut onto `main`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16303)