### PR TITLE
[0.83] fix(scrollview): honor programmatic scrollTo when scrollEnabled={false}

### DIFF
--- a/change/react-native-windows-fix-scrollview-programmatic.json
+++ b/change/react-native-windows-fix-scrollview-programmatic.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Honor programmatic scrollTo when scrollEnabled=false (gestures remain blocked), matching iOS/Android semantics",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -1179,10 +1179,13 @@ void ScrollViewComponentView::HandleCommand(const winrt::Microsoft::ReactNative:
 }
 
 void ScrollViewComponentView::scrollTo(winrt::Windows::Foundation::Numerics::float3 offset, bool animate) noexcept {
-  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return;
-  }
-
+  // scrollEnabled={false} must only disable *user* scroll gestures, matching
+  // iOS and Android where setContentOffset / scrollToOffset still work when
+  // scrolling is disabled. Programmatic scrolls - the scrollTo command, and
+  // scrollToIndex / scrollToOffset which route through it - previously hit a
+  // scrollEnabled early-return here and were silently dropped. User-gesture input
+  // is gated separately (m_scrollVisual.ScrollEnabled, set from scrollEnabled in
+  // updateProps), so it is safe to always honor a programmatic scroll here.
   m_scrollVisual.TryUpdatePosition(offset, animate);
 }
 


### PR DESCRIPTION
## Problem
On a `ScrollView`/`FlatList` with `scrollEnabled={false}`, imperative `scrollTo` / `scrollToOffset` / `scrollToIndex` do nothing on RNW. On iOS/Android, `scrollEnabled` blocks only user gestures — programmatic scrolls still apply.

## Root cause
`ScrollViewComponentView::scrollTo()` early-returns when `scrollEnabled` is false. `scrollToIndex`/`scrollToOffset` route through the `scrollTo` command, so all imperative scrolls are dropped.

## Fix
Remove the early-return. User-gesture scrolling remains gated by `m_scrollVisual.ScrollEnabled(...)` (set from `scrollEnabled` in `updateProps`), so this only re-enables programmatic scrolls — matching iOS/Android semantics.

## Validation
Bug reproduced in a production RNW 0.83.2 new-arch app (Facilitron FIT, Windows 11 ARM64, Debug, 250% scale): a `scrollEnabled={false}` ScrollView with 800-DIP content in a 110-DIP viewport ignores `scrollTo({y:500, animated:false})` — the call fires, no scroll event is emitted, content stays at Row 0. The probe renders its own status line:

![scrollTo fired, did not move](https://raw.githubusercontent.com/FacilitronWorks/upstream-evidence/main/rnw-scrollto-scrollEnabledFalse-BEFORE-noscroll-250pct.png)

Expected after-state per the diff: `TryUpdatePosition` applies the offset and `onScroll` reports y=500. Needs upstream CI + the same probe on a framework source build.

**Intentionally not touched:** `StartBringIntoView()` and `scrollToEnd()`/`scrollToStart()` carry an analogous gate but also serve keyboard/focus paths — changing those would alter keyboard-scroll semantics, so they're flagged for maintainer discussion instead. Authored against `0.83-stable`; happy to re-cut onto `main`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16304)