### PR TITLE
Fix a crash calling CallInvoker during shutdown

### DIFF
--- a/change/react-native-windows-4672fa37-ea7f-4ffd-82cd-40e7d8b41de5.json
+++ b/change/react-native-windows-4672fa37-ea7f-4ffd-82cd-40e7d8b41de5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix a crash calling CallInvoker during shutdown",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.cpp
@@ -15,7 +15,7 @@ struct AbiCallInvoker final : facebook::react::CallInvoker {
   void invokeAsync(facebook::react::CallFunc &&func) noexcept override {
     auto callInvoker = m_context.CallInvoker();
     if (callInvoker) {
-      callInvoker->InvokeAsync(
+      callInvoker.InvokeAsync(
           [context = m_context, func = std::move(func)](const winrt::Windows::Foundation::IInspectable &runtimeHandle) {
             func(GetOrCreateContextRuntime(context, runtimeHandle));
           });
@@ -25,7 +25,7 @@ struct AbiCallInvoker final : facebook::react::CallInvoker {
   void invokeSync(facebook::react::CallFunc &&func) override {
     auto callInvoker = m_context.CallInvoker();
     if (callInvoker) {
-      callInvoker->InvokeSync(
+      callInvoker.InvokeSync(
           [context = m_context, func = std::move(func)](const winrt::Windows::Foundation::IInspectable &runtimeHandle) {
             func(GetOrCreateContextRuntime(context, runtimeHandle));
           });

--- a/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.cpp
@@ -13,17 +13,23 @@ struct AbiCallInvoker final : facebook::react::CallInvoker {
   AbiCallInvoker(IReactContext const &context) : m_context(context) {}
 
   void invokeAsync(facebook::react::CallFunc &&func) noexcept override {
-    m_context.CallInvoker().InvokeAsync(
-        [context = m_context, func = std::move(func)](const winrt::Windows::Foundation::IInspectable &runtimeHandle) {
-          func(GetOrCreateContextRuntime(context, runtimeHandle));
-        });
+    auto callInvoker = m_context.CallInvoker();
+    if (callInvoker) {
+      callInvoker->InvokeAsync(
+          [context = m_context, func = std::move(func)](const winrt::Windows::Foundation::IInspectable &runtimeHandle) {
+            func(GetOrCreateContextRuntime(context, runtimeHandle));
+          });
+    }
   }
 
   void invokeSync(facebook::react::CallFunc &&func) override {
-    m_context.CallInvoker().InvokeSync(
-        [context = m_context, func = std::move(func)](const winrt::Windows::Foundation::IInspectable &runtimeHandle) {
-          func(GetOrCreateContextRuntime(context, runtimeHandle));
-        });
+    auto callInvoker = m_context.CallInvoker();
+    if (callInvoker) {
+      callInvoker->InvokeSync(
+          [context = m_context, func = std::move(func)](const winrt::Windows::Foundation::IInspectable &runtimeHandle) {
+            func(GetOrCreateContextRuntime(context, runtimeHandle));
+          });
+    }
   }
 
  private:


### PR DESCRIPTION
## Description
CallInvoker gets set to null during shutdown, protect against it being null.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16310)