### PR TITLE
fix(island): prefer ContentIsland.RasterizationScale for island scale factor and re-sync on window move/resize

### DIFF
--- a/change/react-native-windows-fix-island-scale-rasterization.json
+++ b/change/react-native-windows-fix-island-scale-rasterization.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prefer ContentIsland.RasterizationScale over GetDpiForWindow for island scale factor, and re-sync scale on window move/resize",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeWindow.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeWindow.cpp
@@ -116,6 +116,13 @@ void ReactNativeWindow::AppWindow(const winrt::Microsoft::UI::Windowing::AppWind
 void ReactNativeWindow::AppWindow_Changed(
     winrt::Microsoft::UI::Windowing::AppWindow const &window,
     winrt::Microsoft::UI::Windowing::AppWindowChangedEventArgs const &args) noexcept {
+  // Re-sync the island scale factor on moves/resizes. The scale was previously
+  // set only once (island attach / bridge creation), so dragging the window to
+  // a monitor with a different scale factor left the island rendering at the
+  // launch monitor's scale.
+  if (args.DidPositionChange() || args.DidSizeChange()) {
+    UpdateIslandScaleFactor();
+  }
   if (args.DidSizeChange() || args.DidVisibilityChange()) {
     UpdateRootViewSizeToAppWindow(m_island, m_appWindow);
   }
@@ -179,8 +186,21 @@ winrt::Microsoft::UI::Content::IContentSiteBridge ReactNativeWindow::ContentSite
 
 void ReactNativeWindow::UpdateIslandScaleFactor() noexcept {
   if (m_island) {
-    auto scaleFactor = GetDpiForWindow(winrt::Microsoft::UI::GetWindowFromWindowId(m_appWindow.Id())) /
-        static_cast<float>(USER_DEFAULT_SCREEN_DPI);
+    // Prefer the ContentIsland's RasterizationScale - the compositor's ground
+    // truth for how this content is actually rasterized. GetDpiForWindow can
+    // return a stale or wrong DPI on virtual/remote displays (measured: a
+    // screen-share display reporting 96 while the monitor's effective scale is
+    // 1.25x under PerMonitorV2 awareness), which mis-scales the island so text
+    // rasterizes into a larger canvas than the visible box. Fall back to
+    // GetDpiForWindow when no ContentIsland is attached yet.
+    float scaleFactor = 0.0f;
+    if (auto contentIsland = m_island.Island()) {
+      scaleFactor = contentIsland.RasterizationScale();
+    }
+    if (scaleFactor <= 0.0f) {
+      scaleFactor = GetDpiForWindow(winrt::Microsoft::UI::GetWindowFromWindowId(m_appWindow.Id())) /
+          static_cast<float>(USER_DEFAULT_SCREEN_DPI);
+    }
     m_island.ScaleFactor(scaleFactor);
   }
 }


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
`ReactNativeWindow::UpdateIslandScaleFactor()` derives the island scale exclusively from `GetDpiForWindow()`, and computes it only once (at island attach / bridge creation). Two problems:

1. **`GetDpiForWindow()` can return a stale or wrong DPI on virtual/remote displays**, even when the process is PerMonitorV2 DPI-aware. Measured on-device: a screen-share (virtual) display reports 96 DPI from `GetDpiForWindow()` while the monitor's effective scale is 1.25x. The `ReactNativeIsland` is then rasterized at the wrong scale, so content draws into a canvas larger than the visible box — RichEdit-backed `TextInput` text visibly "hides" at the top-left of its frame.

2. **The scale is never recomputed after window moves/resizes.** Dragging the window to a monitor with a different scale factor leaves the island rendering at the launch monitor's scale.

`ContentIsland.RasterizationScale` is the compositor's ground truth for how the island content is actually rasterized, and is correct in the cases above.

### What
Two changes in `vnext/Microsoft.ReactNative/Fabric/Composition/ReactNativeWindow.cpp`:

1. `UpdateIslandScaleFactor()` now prefers `m_island.Island().RasterizationScale()` and falls back to the existing `GetDpiForWindow() / USER_DEFAULT_SCREEN_DPI` computation only when no `ContentIsland` is attached yet (or the reported scale is not positive).
2. `AppWindow_Changed()` now calls `UpdateIslandScaleFactor()` when `DidPositionChange()` or `DidSizeChange()` is set, so moving the window across monitors with different scale factors re-syncs the island scale.

## Screenshots
N/A (behavioral fix; before-state is text rasterized outside its visible box on a mis-scaled island).

## Testing
- Compiled into a framework source build and validated in a production Fabric app (react-native-windows 0.83, new architecture):
  - On a virtual (screen-share) display where `GetDpiForWindow()` reports 96 but effective scale is 1.25x: text previously drew outside the visible box; with this change the island rasterizes at the correct scale and text renders inside its frame.
  - Dragging the window between monitors with different scale factors now re-rasterizes at the destination monitor's scale instead of keeping the launch monitor's scale.
- Fallback path (no `ContentIsland` attached yet) exercises the original `GetDpiForWindow` computation, so bridge-creation-time behavior is unchanged.

## Changelog
Should this change be included in the release notes: yes

Fix ReactNativeWindow island scale on virtual/remote displays and on cross-monitor window moves by preferring ContentIsland.RasterizationScale over GetDpiForWindow.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16314)