### PR TITLE
fix(textinput): correct placeholder layout constraints (px vs DIP) and no-op NaN fontSize guard

### DIFF
--- a/change/react-native-windows-fix-textinput-placeholder-main.json
+++ b/change/react-native-windows-fix-textinput-placeholder-main.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Fix placeholder layout constraints fed physical px instead of DIPs; fix no-op NaN fontSize guard in CreatePlaceholderLayout",
   "packageName": "react-native-windows",
   "email": "collindanielschneide@gmail.com",

--- a/change/react-native-windows-fix-textinput-placeholder-main.json
+++ b/change/react-native-windows-fix-textinput-placeholder-main.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix placeholder layout constraints fed physical px instead of DIPs; fix no-op NaN fontSize guard in CreatePlaceholderLayout",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1743,7 +1743,7 @@ winrt::com_ptr<::IDWriteTextLayout> WindowsTextInputComponentView::CreatePlaceho
   const auto &props = windowsTextInputProps();
   facebook::react::TextAttributes textAttributes = props.textAttributes;
   if (std::isnan(props.textAttributes.fontSize)) {
-    facebook::react::TextAttributes::defaultTextAttributes().fontSize;
+    textAttributes.fontSize = facebook::react::TextAttributes::defaultTextAttributes().fontSize;
   }
   textAttributes.fontSizeMultiplier = m_fontSizeMultiplier;
   fragment1.string = props.placeholder;
@@ -1751,8 +1751,12 @@ winrt::com_ptr<::IDWriteTextLayout> WindowsTextInputComponentView::CreatePlaceho
   attributedString.appendFragment(std::move(fragment1));
 
   facebook::react::LayoutConstraints constraints;
-  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth);
-  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight);
+  // m_imgWidth/m_imgHeight are physical pixels (frame * pointScaleFactor), but
+  // LayoutConstraints are expressed in DIPs. Feeding physical px laid the
+  // placeholder out in a box pointScaleFactor x too large, so the placeholder was
+  // measured/positioned at a different height than the typed text. Convert to DIPs.
+  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth) / m_layoutMetrics.pointScaleFactor;
+  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight) / m_layoutMetrics.pointScaleFactor;
 
   facebook::react::WindowsTextLayoutManager::GetTextLayout(
       facebook::react::AttributedStringBox(attributedString), {} /*TODO*/, constraints, textLayout);


### PR DESCRIPTION
Forward-port of #16303 (which targets `0.83-stable`) to `main`, per @acoates-ms:

> yeah, we should get a main check-in too otherwise it wont make it into future releases.

Both defects are present on `main` today, in `WindowsTextInputComponentView::CreatePlaceholderLayout()`.

### 1. Placeholder layout constraints were fed physical pixels, not DIPs

`m_imgWidth`/`m_imgHeight` are physical pixels (`frame * pointScaleFactor`), but `facebook::react::LayoutConstraints` are expressed in DIPs. The placeholder was therefore laid out inside a box `pointScaleFactor`x too large, so it measured and positioned at a different height than the typed text — visible as the placeholder sitting at a different baseline than the value the user types, and worsening as scale increases.

```diff
-  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth);
-  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight);
+  constraints.maximumSize.width = static_cast<FLOAT>(m_imgWidth) / m_layoutMetrics.pointScaleFactor;
+  constraints.maximumSize.height = static_cast<FLOAT>(m_imgHeight) / m_layoutMetrics.pointScaleFactor;
```

This version divides directly, with no `!= 0` guard — per review feedback on #16303. `LayoutMetrics::pointScaleFactor` has a default member initializer of `1.0` and `EmptyLayoutMetrics` only designates `.frame`, so even the pre-layout sentinel inherits `1.0`; there is no path here where it is `0`.

### 2. The NaN `fontSize` guard was a no-op

The guard evaluated `defaultTextAttributes().fontSize` as a discarded expression statement rather than assigning it, so a placeholder with no explicit `fontSize` never actually picked up the default:

```diff
   if (std::isnan(props.textAttributes.fontSize)) {
-    facebook::react::TextAttributes::defaultTextAttributes().fontSize;
+    textAttributes.fontSize = facebook::react::TextAttributes::defaultTextAttributes().fontSize;
   }
```

### Testing

Verified on the `0.83-stable` version of this change (#16303): compiled into a framework source build (binary-gated) and re-probed in a production app at 250% scale — no regression, the NaN-fontSize guard now actually assigns (a no-fontSize placeholder renders at the default size), and placeholder-vs-typed are pixel-comparable at that geometry. Evidence attached to #16303.

This `main` port is the identical change applied to the current `main` source; it has not been separately run on-device, so CI is the gate here.

Related: #16303 (`0.83-stable`).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16317)