### PR TITLE
Add 0.85-stable to Release pipeline branch allowlist

### DIFF
--- a/.ado/release-pipeline.yml
+++ b/.ado/release-pipeline.yml
@@ -39,6 +39,7 @@ resources:
         - '0.82-stable'
         - '0.83-stable'
         - '0.84-stable'
+        - '0.85-stable'
   repositories:
   - repository: 1ESPipelineTemplates
     type: git

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -34,6 +34,7 @@ resources:
         - '0.82-stable'
         - '0.83-stable'
         - '0.84-stable'
+        - '0.85-stable'
   repositories:
   - repository: 1ESPipelineTemplates
     type: git


### PR DESCRIPTION
## What
Adds 0.85-stable to the Release pipeline branch allowlist in both `.ado/release.yml` and `.ado/release-pipeline.yml`.

## Why
The Release pipeline's `resources.pipelines[].trigger.branches.include` list is an explicit allowlist . Without `0.85-stable` in it, the Release pipeline will not trigger on `RELEASE:` commits to the `0.85-stable` branch, so preview builds won't publish. Mirrors how prior stable branches (0.82/0.83/0.84) are listed.

## Validation
- Both YAML files parse cleanly; `include` list now ends with `0.85-stable`.
- Base is `main` (consistent with all prior allowlist edits: #15821, #15881, #15902).

Part of the 0.85 release branch bring-up.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16318)