### PR TITLE
Backport @xmldom/xmldom 0.8.13 to 0.81-stable

### DIFF
--- a/change/@react-native-windows-cli-e6119ddf-e352-4c27-9367-51b99e16d6bc.json
+++ b/change/@react-native-windows-cli-e6119ddf-e352-4c27-9367-51b99e16d6bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump @xmldom/xmldom from 0.7.13 to 0.8.13",
+  "packageName": "@react-native-windows/cli",
+  "email": "223556219+Copilot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-dd5b7f1f-39b0-4539-bc0f-af70d13a645d.json
+++ b/change/@react-native-windows-telemetry-dd5b7f1f-39b0-4539-bc0f-af70d13a645d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump @xmldom/xmldom from 0.7.13 to 0.8.13",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "223556219+Copilot@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -22,7 +22,7 @@
     "@react-native-windows/fs": "0.81.1",
     "@react-native-windows/package-utils": "0.81.1",
     "@react-native-windows/telemetry": "0.81.2",
-    "@xmldom/xmldom": "^0.7.7",
+    "@xmldom/xmldom": "^0.8.13",
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "envinfo": "^7.5.0",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -21,7 +21,7 @@
     "@microsoft/1ds-core-js": "^4.3.0",
     "@microsoft/1ds-post-js": "^4.3.0",
     "@react-native-windows/fs": "0.81.1",
-    "@xmldom/xmldom": "^0.7.7",
+    "@xmldom/xmldom": "^0.8.13",
     "ci-info": "^3.2.0",
     "envinfo": "^7.8.1",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3605,10 +3605,10 @@
   dependencies:
     "@wdio/logger" "6.10.10"
 
-"@xmldom/xmldom@^0.7.7":
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.13.tgz#ff34942667a4e19a9f4a0996a76814daac364cf3"
-  integrity sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==
+"@xmldom/xmldom@^0.8.13":
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
+  integrity sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Summary

- Backport the dependency update from #16038 to `0.81-stable`
- Update `@react-native-windows/cli` and `@react-native-windows/telemetry` to `@xmldom/xmldom` `^0.8.13`
- Regenerate the Yarn 1 lockfile and add stable-branch patch change files

The incidental `.config/1espt/PipelineAutobaseliningConfig.yml` line-ending change from the upstream PR is intentionally excluded.

## Validation

- Scoped Lage build for CLI, telemetry, and dependencies
- Package lint and formatting checks
- Beachball change-file check against `origin/0.81-stable`
- Frozen Yarn install and xmldom parse/serialize smoke test

Package tests are Windows-only and were skipped by the existing test scripts on macOS.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16328)