### PR TITLE
fix(scrollview): honor programmatic scrollTo when scrollEnabled={false}

### DIFF
--- a/change/react-native-windows-scrollto-scrollenabled-main.json
+++ b/change/react-native-windows-scrollto-scrollenabled-main.json
@@ -1,0 +1,1 @@
+{"type":"prerelease","dependentChangeType":"patch","email":"collindanielschneide@gmail.com","packageName":"react-native-windows","comment":"Honor programmatic scrollTo when scrollEnabled={false}, matching iOS/Android"}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -1192,10 +1192,14 @@ void ScrollViewComponentView::HandleCommand(const winrt::Microsoft::ReactNative:
 }
 
 void ScrollViewComponentView::scrollTo(winrt::Windows::Foundation::Numerics::float3 offset, bool animate) noexcept {
-  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
-    return;
-  }
-
+  // scrollEnabled={false} must only disable *user* scroll gestures, matching
+  // iOS and Android where setContentOffset / scrollToOffset still work when
+  // scrolling is disabled. Programmatic scrolls - the scrollTo command, and
+  // scrollToIndex / scrollToOffset which route through it - previously hit a
+  // scrollEnabled early-return here and were silently dropped. User-gesture
+  // input is gated separately (m_scrollVisual.ScrollEnabled, set from
+  // scrollEnabled in updateProps), so it is safe to always honor a
+  // programmatic scroll here.
   m_scrollVisual.TryUpdatePosition(offset, animate);
 }
 


### PR DESCRIPTION
## Problem

`scrollTo` (and `scrollToIndex` / `scrollToOffset`, which route through it) is silently dropped when `scrollEnabled={false}` — the command hits an early return in `ScrollViewComponentView::scrollTo` and nothing happens.

On iOS and Android, `scrollEnabled={false}` only disables **user** scroll gestures; programmatic scrolls still work. Common patterns that rely on this — a paged carousel driven by buttons, a chat view pinned to bottom on new messages while user scrolling is locked, a tab strip synced to a PagerView — work on the other platforms and no-op on Windows.

## Root cause

```cpp
void ScrollViewComponentView::scrollTo(winrt::Windows::Foundation::Numerics::float3 offset, bool animate) noexcept {
  if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(viewProps())->scrollEnabled) {
    return;
  }
  m_scrollVisual.TryUpdatePosition(offset, animate);
}
```

The gate is redundant for its apparent purpose: user-gesture input is already gated separately via `m_scrollVisual.ScrollEnabled`, set from `scrollEnabled` in `updateProps`. So removing this check re-enables nothing for the user — it only lets the programmatic path through.

## Fix

Remove the early return; always honor a programmatic scroll. One file, no header or API change.

## Validation

- Verified in a production RNW 0.83.2 new-arch app (Facilitron FIT), compiled from source, where the same change (as #16304) fixed button-driven scrolling of a locked list; user gestures remained disabled.
- **Not verified on this branch:** no CI has run (gated behind a maintainer `/azp run`), and I have not built `main` with this change. The diff is context-identical to the 0.83-stable version apart from surrounding-code drift.

**Caveats for reviewers:**

- This is the `main` twin of #16304 (0.83-stable), per the convention requested on #16303 (its twin is #16317).
- Change file uses `type: prerelease` to match main-line convention; happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16336)