### PR TITLE
fix(pointer): crash (0xc0000005) when the pointer-capturing component has been unmounted

### DIFF
--- a/change/react-native-windows-capture-null-guard-main.json
+++ b/change/react-native-windows-capture-null-guard-main.json
@@ -1,0 +1,1 @@
+{"type":"prerelease","dependentChangeType":"patch","email":"collindanielschneide@gmail.com","packageName":"react-native-windows","comment":"Null-check the capturing component view before notifying OnPointerCaptureLost (crash when the capturing component was unmounted)"}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1510,8 +1510,16 @@ bool CompositionEventHandler::CapturePointer(
       auto targetComponentView =
           fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(m_pointerCapturingComponentTag).view;
 
-      winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetComponentView)
-          ->OnPointerCaptureLost();
+      // Guard against a stale capturing tag. If the previously-capturing component
+      // was unmounted (e.g. list/ScrollView virtualization recycled it during a pan)
+      // without releasing capture, componentViewDescriptorWithTag returns a
+      // descriptor whose .view is null - and the unguarded get_self(...) call then
+      // dereferences null and crashes the process (0xc0000005). Skip the notify when
+      // the view is gone; the tag is overwritten just below.
+      if (targetComponentView) {
+        winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetComponentView)
+            ->OnPointerCaptureLost();
+      }
     }
   }
 
@@ -1540,8 +1548,13 @@ bool CompositionEventHandler::releasePointerCapture(PointerId pointerId, faceboo
       auto targetComponentView =
           fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(m_pointerCapturingComponentTag).view;
 
-      winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetComponentView)
-          ->OnPointerCaptureLost();
+      // Same stale-tag null-view guard as CapturePointer above: a pointer release
+      // after the capturing component was unmounted would otherwise dereference a
+      // null view and crash (0xc0000005).
+      if (targetComponentView) {
+        winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetComponentView)
+            ->OnPointerCaptureLost();
+      }
     }
 
     if (m_capturedPointers.empty()) {


### PR DESCRIPTION
## Problem

A Fabric/Composition app crashes with an access violation (`0xc0000005`) during ordinary list interaction on a touch device: pan a virtualized list so the row currently holding pointer capture is recycled, then press or release again.

## Root cause

Both capture paths in `CompositionEventHandler` look the capturing component up by its cached tag and dereference the result without checking it:

```cpp
auto targetComponentView =
    fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(m_pointerCapturingComponentTag).view;

winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetComponentView)
    ->OnPointerCaptureLost();
```

`m_pointerCapturingComponentTag` can outlive the component it names. If the capturing component is unmounted without releasing capture — exactly what list/ScrollView virtualization does when it recycles a row mid-pan — `componentViewDescriptorWithTag` returns a descriptor whose `.view` is null, and the call dereferences it. The same unguarded pattern appears in `CapturePointer` (when a new capture displaces a previous one) and `releasePointerCapture`.

## Fix

Null-check `targetComponentView` before notifying, at both sites. When the view is gone there is nothing to notify — `CapturePointer` overwrites the stale tag immediately below, and `releasePointerCapture` clears it via the existing `m_capturedPointers.empty()` branch. One file, no header or API change.

## Validation

- Root-caused and fixed in a production RNW **0.83.2** new-arch app (Facilitron FIT), compiled from source (`UseExperimentalNuget=false`). Before: panning the FIT inspection list and interacting with a recycled row terminated the process with `0xc0000005`, reproducibly. After: an automated soak drove the guarded paths with real `PT_TOUCH` contacts (`InjectTouchInput`) — 10 press-a-row-then-pan-far-while-held events (the exact recycle-under-capture sequence), plus expand/collapse mount churn and hard flicks — with no crash and the process responsive throughout.
- **Honest limit:** the binary under test already contained the guard, so the soak is consistent with the fix but does not prove causation (that would need an otherwise-identical unguarded build). The root cause is plain from the code above.
- **Not verified on this branch:** no CI has run (gated behind a maintainer `/azp run`), and I have not built `main` with this change. The guard is context-adapted to `main` (`m_capturedPointers.insert` / `.empty()`), diff verified against `main` at `c69cf55`.

**Caveats for reviewers:**

- `main` twin of #16334 (0.83-stable), per the twin convention from #16303/#16317.
- Silently skipping the notify means a component unmounted while holding capture never observes `OnPointerCaptureLost`. If you would rather RNW proactively released capture in the component teardown path so the tag can never go stale, that is a larger but arguably more correct fix and I am happy to take that direction instead.
- Change file uses `type: prerelease`; happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16337)