### PR TITLE
fix(pointer): label a touch/pen contact as the primary button so JS press handling fires

### DIFF
--- a/change/react-native-windows-touch-primary-button-main.json
+++ b/change/react-native-windows-touch-primary-button-main.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix(fabric): dispatch touch/pen contacts with the W3C primary button (button 0, buttons 1) instead of button -1 / buttons 0, so pointer-event-driven press handling responds to finger taps the same as mouse left-clicks",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -1413,6 +1413,16 @@ void CompositionEventHandler::onPointerPressed(
         break;
     }
 
+    // A touch (or pen) contact has no mouse PointerUpdateKind, so it fell
+    // through to button = -1 — and the derived W3C buttons bitmask became 0.
+    // The dispatched pointerdown therefore told JS "no button is pressed", so
+    // press machinery driven by pointer events ignored finger taps while
+    // identical mouse clicks (button 0 / buttons 1) worked. Per W3C
+    // pointer-event semantics a touch/pen contact IS the primary button.
+    if (pointerPoint.PointerDeviceType() != Composition::Input::PointerDeviceType::Mouse && activeTouch.button < 0) {
+      activeTouch.button = 0;
+    }
+
     while (targetComponentView) {
       if (auto eventEmitter =
               winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetComponentView)


### PR DESCRIPTION
# fix(pointer): label a touch/pen contact as the primary button so JS press handling fires

Tracks #16332. This is the `main` counterpart of the **primary-button labeling** change in #16333 (which targets `0.83-stable`).

## Problem

On real touch hardware, finger taps on `Pressable` / `TouchableOpacity` are ignored by pointer-event-driven press machinery, while identical **mouse** clicks on the same element work.

## Root cause

In `vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp`, `onPointerPressed` maps `ActiveTouch.button` exclusively from `PointerUpdateKind` — a mouse-only concept:

```cpp
default:
  activeTouch.button = -1;
  break;
```

A touch or pen contact has no mouse `PointerUpdateKind`, so it falls through to `default:` and gets `button = -1`; the derived W3C `buttons` bitmask then becomes `0`. The dispatched `pointerdown` tells JS "no button is pressed", so press logic driven by pointer events discards finger contacts. Per [W3C pointer-events](https://www.w3.org/TR/pointerevents/#the-button-property), a touch/pen contact **is** the primary button: `button 0`, `buttons 1`.

## Fix

After the existing switch: if the device is not a mouse and `activeTouch.button` fell through to a negative value, set `activeTouch.button = 0` (yielding `buttons = 1` while the contact is down). Mouse behaviour is unchanged, and the `< 0` guard leaves untouched any non-mouse contact that somehow carried a real button mapping.

Baseline: `main` @ `c69cf55f67f9b03f467502dac1007ac2d9ebe209`. One hunk, +10 lines, no header or API change.

## Scope — what this PR deliberately does *not* port

`main` already addresses the other problems #16333 covers, by different means, so this PR ports only the button-labeling change:

- The `tag == -1` release leak and the stale-pointer-reuse leak were fixed on `main` by **#16048** (*Fix touch event handling, improve reliability, and optimize performance*, merged 2026-04-24). Note `main` dispatches a **synthesized touch Cancel** for these, not a touch End.
- `main` also cancels capture loss per-pointer and has `onPointerRoutedAway`.

#16333 additionally contains a cancel-all-active-touches loop in `onPointerCaptureLost`, an `IsPrimary` self-heal purge, and a stale-touch time backstop. **None of those exist on `main`, and I have not assessed whether they are still needed there** — `main`'s at-source cleanups may subsume them. I have left them out rather than port hardening whose necessity I cannot demonstrate on this branch. Happy to do that assessment as a follow-up if it would be useful.

## Validation

This exact logic — identical condition and assignment, the only textual difference being that this PR spells the enum via the `Composition::Input::` alias `main` already uses in this function — is running in production as part of #16333 on RNW **0.83.2**: compiled into `Microsoft.ReactNative` from source (`UseExperimentalNuget=false`), x64 Release, new-arch app (Facilitron FIT), on a physical Surface-class touch tablet. There, finger taps on press targets went from ignored to firing, matching mouse clicks. Validated with real `PT_TOUCH` injection (`InitializeTouchInjection` / `InjectTouchInput`), not simulated mouse input — the mouse path does not exercise the touch pipeline at all.

Diff verified against the pinned base: exactly one hunk, +10 lines, LF endings preserved, and the file's current tip is byte-identical to that base (no drift).

**Not verified — please weigh before merging:**

- **No CI has run on this branch.** Azure Pipelines here is gated behind a maintainer comment, so I cannot start it; a `/azp run` would be appreciated.
- **I have not built `main` with this change**, nor exercised it on a device on `main`. The behavioural evidence above comes from the 0.83.2 app.
- Lint/format gates are unrun locally. The added block was written to match the file's existing style (the `Composition::Input::` alias used elsewhere in the function; the condition line is 117 columns, within this repo's `ColumnLimit: 120`) — by inspection, not by running the tools.
- That `main`'s surrounding code is materially identical to the 0.83 code this was validated on rests on reading `main`'s `CompositionEventHandler.cpp` at the baseline commit (same switch, same `default: button = -1`), not on differential testing on `main`.

**Caveats for reviewers:**

- Change file uses `type: prerelease` to match the convention in `main`'s pending change files; happy to adjust.
- The inserted comment narrates the bug in past tense (carried over verbatim from #16333's wording). Say the word if you would prefer something terser and present-tense.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16338)