### PR TITLE
fix(text): resolve app-bundled font families by passing a DirectWrite font collection

### DIFF
--- a/change/react-native-windows-fix-app-bundled-fonts.json
+++ b/change/react-native-windows-fix-app-bundled-fonts.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fabric: resolve app-bundled fonts (Assets, Assets\\Fonts) during text layout by merging them with the system font set into the DirectWrite font collection used by WindowsTextLayoutManager",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.cpp
@@ -5,6 +5,11 @@
 
 #include "DWriteHelpers.h"
 
+#include <dwrite_3.h>
+#include <windows.h>
+#include <cstdint>
+#include <string>
+
 namespace Microsoft::ReactNative {
 
 winrt::com_ptr<::IDWriteFactory> DWriteFactory() noexcept {
@@ -14,6 +19,105 @@ winrt::com_ptr<::IDWriteFactory> DWriteFactory() noexcept {
         DWRITE_FACTORY_TYPE_SHARED, __uuidof(s_dwriteFactory), reinterpret_cast<::IUnknown **>(s_dwriteFactory.put())));
   }
   return s_dwriteFactory;
+}
+
+namespace {
+
+// Directory that contains the running module, including the trailing separator: the
+// package root for packaged (MSIX) apps and the directory next to the .exe for
+// unpackaged apps. Bundled font assets are deployed below this directory.
+std::wstring AppDirectory() noexcept {
+  wchar_t modulePath[MAX_PATH]{};
+  const DWORD length = ::GetModuleFileNameW(nullptr, modulePath, MAX_PATH);
+  if (length == 0 || length >= MAX_PATH) {
+    return {};
+  }
+  std::wstring path(modulePath, length);
+  const auto lastSeparator = path.find_last_of(L"\\/");
+  if (lastSeparator == std::wstring::npos) {
+    return {};
+  }
+  path.resize(lastSeparator + 1);
+  return path;
+}
+
+// Adds every file matching <directory> + <pattern> to the font-set builder and returns
+// the number of files added. Per-file failures are skipped so that one bad font file
+// cannot break font resolution for the rest of the app.
+uint32_t AddFontFiles(
+    ::IDWriteFactory5 *factory,
+    ::IDWriteFontSetBuilder1 *builder,
+    const std::wstring &directory,
+    const wchar_t *pattern) noexcept {
+  uint32_t count = 0;
+  const std::wstring searchPattern = directory + pattern;
+  WIN32_FIND_DATAW findData{};
+  const HANDLE findHandle = ::FindFirstFileW(searchPattern.c_str(), &findData);
+  if (findHandle == INVALID_HANDLE_VALUE) {
+    return count;
+  }
+  do {
+    if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      const std::wstring fontPath = directory + findData.cFileName;
+      winrt::com_ptr<::IDWriteFontFile> fontFile;
+      if (SUCCEEDED(factory->CreateFontFileReference(fontPath.c_str(), nullptr, fontFile.put())) &&
+          SUCCEEDED(builder->AddFontFile(fontFile.get()))) {
+        ++count;
+      }
+    }
+  } while (::FindNextFileW(findHandle, &findData));
+  ::FindClose(findHandle);
+  return count;
+}
+
+winrt::com_ptr<::IDWriteFontCollection> CreateAppFontCollection() noexcept {
+  try {
+    const std::wstring appDirectory = AppDirectory();
+    if (appDirectory.empty()) {
+      return nullptr;
+    }
+
+    const auto factory5 = DWriteFactory().as<::IDWriteFactory5>();
+
+    winrt::com_ptr<::IDWriteFontSetBuilder1> builder;
+    winrt::check_hresult(factory5->CreateFontSetBuilder(builder.put()));
+
+    // Include the system font set so that system families keep resolving when this
+    // collection is used in place of the system collection.
+    winrt::com_ptr<::IDWriteFontSet> systemFontSet;
+    winrt::check_hresult(factory5->GetSystemFontSet(systemFontSet.put()));
+    winrt::check_hresult(builder->AddFontSet(systemFontSet.get()));
+
+    uint32_t fontFileCount = 0;
+    for (const auto *subdirectory : {L"Assets\\", L"Assets\\Fonts\\"}) {
+      for (const auto *pattern : {L"*.ttf", L"*.otf"}) {
+        fontFileCount += AddFontFiles(factory5.get(), builder.get(), appDirectory + subdirectory, pattern);
+      }
+    }
+    if (fontFileCount == 0) {
+      // Nothing bundled: report "no app collection" so callers pass nullptr to DirectWrite
+      // and keep using DirectWrite's own (cached, updatable) system font collection.
+      return nullptr;
+    }
+
+    winrt::com_ptr<::IDWriteFontSet> fontSet;
+    winrt::check_hresult(builder->CreateFontSet(fontSet.put()));
+    winrt::com_ptr<::IDWriteFontCollection1> collection;
+    winrt::check_hresult(factory5->CreateFontCollectionFromFontSet(fontSet.get(), collection.put()));
+    return collection.as<::IDWriteFontCollection>();
+  } catch (...) {
+    // Fail closed: callers fall back to the system font collection (previous behavior).
+    return nullptr;
+  }
+}
+
+} // namespace
+
+winrt::com_ptr<::IDWriteFontCollection> DWriteAppFontCollection() noexcept {
+  // Thread-safe (magic static) one-time initialization. Bundled font assets cannot
+  // change for the lifetime of the process, so the collection never needs rebuilding.
+  static const winrt::com_ptr<::IDWriteFontCollection> s_appFontCollection = CreateAppFontCollection();
+  return s_appFontCollection;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.cpp
@@ -1,23 +1,30 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#pragma once
-
 #include "DWriteHelpers.h"
 
 #include <dwrite_3.h>
 #include <windows.h>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace Microsoft::ReactNative {
 
 winrt::com_ptr<::IDWriteFactory> DWriteFactory() noexcept {
-  static winrt::com_ptr<::IDWriteFactory> s_dwriteFactory;
-  if (!s_dwriteFactory) {
+  // Function-local static with a dynamic initializer: initialized exactly once,
+  // and concurrent first callers wait for that initialization rather than racing
+  // it ([stmt.dcl]/4, on by default in MSVC as /Zc:threadSafeInit). The previous
+  // `if (!s_dwriteFactory) { ...assign... }` pattern was a first-use data race:
+  // two threads could both observe the empty pointer and both create/assign a
+  // factory. DWriteAppFontCollection() below is reachable from more than one
+  // thread on first use, which makes that race live rather than theoretical.
+  static const winrt::com_ptr<::IDWriteFactory> s_dwriteFactory = [] {
+    winrt::com_ptr<::IDWriteFactory> factory;
     winrt::check_hresult(::DWriteCreateFactory(
-        DWRITE_FACTORY_TYPE_SHARED, __uuidof(s_dwriteFactory), reinterpret_cast<::IUnknown **>(s_dwriteFactory.put())));
-  }
+        DWRITE_FACTORY_TYPE_SHARED, __uuidof(factory), reinterpret_cast<::IUnknown **>(factory.put())));
+    return factory;
+  }();
   return s_dwriteFactory;
 }
 
@@ -41,39 +48,53 @@ std::wstring AppDirectory() noexcept {
   return path;
 }
 
-// Adds every file matching <directory> + <pattern> to the font-set builder and returns
-// the number of files added. Per-file failures are skipped so that one bad font file
-// cannot break font resolution for the rest of the app.
-uint32_t AddFontFiles(
-    ::IDWriteFactory5 *factory,
-    ::IDWriteFontSetBuilder1 *builder,
-    const std::wstring &directory,
-    const wchar_t *pattern) noexcept {
-  uint32_t count = 0;
+// Appends every file matching <directory> + <pattern> to `paths`. Pure file-system
+// enumeration - no DirectWrite objects are created here, so the result is cacheable
+// independently of any factory or collection lifetime.
+void AppendFontFiles(std::vector<std::wstring> &paths, const std::wstring &directory, const wchar_t *pattern) noexcept {
   const std::wstring searchPattern = directory + pattern;
   WIN32_FIND_DATAW findData{};
   const HANDLE findHandle = ::FindFirstFileW(searchPattern.c_str(), &findData);
   if (findHandle == INVALID_HANDLE_VALUE) {
-    return count;
+    return;
   }
   do {
     if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-      const std::wstring fontPath = directory + findData.cFileName;
-      winrt::com_ptr<::IDWriteFontFile> fontFile;
-      if (SUCCEEDED(factory->CreateFontFileReference(fontPath.c_str(), nullptr, fontFile.put())) &&
-          SUCCEEDED(builder->AddFontFile(fontFile.get()))) {
-        ++count;
-      }
+      paths.emplace_back(directory + findData.cFileName);
     }
   } while (::FindNextFileW(findHandle, &findData));
   ::FindClose(findHandle);
-  return count;
 }
 
+// The cached list of bundled font files. The directory searches run exactly once per
+// process, on whichever thread gets here first (thread-safe static initialization);
+// every later caller - including any future path that rebuilds a collection - reads
+// this list and never touches the file system again. Bundled assets cannot change
+// while the process runs, so the list can never go stale.
+const std::vector<std::wstring> &AppFontFilePaths() noexcept {
+  static const std::vector<std::wstring> s_paths = [] {
+    std::vector<std::wstring> paths;
+    const std::wstring appDirectory = AppDirectory();
+    if (!appDirectory.empty()) {
+      for (const auto *subdirectory : {L"Assets\\", L"Assets\\Fonts\\"}) {
+        for (const auto *pattern : {L"*.ttf", L"*.otf"}) {
+          AppendFontFiles(paths, appDirectory + subdirectory, pattern);
+        }
+      }
+    }
+    return paths;
+  }();
+  return s_paths;
+}
+
+// Builds the merged collection from the cached file list. Contains no directory
+// enumeration by construction - see AppFontFilePaths().
 winrt::com_ptr<::IDWriteFontCollection> CreateAppFontCollection() noexcept {
   try {
-    const std::wstring appDirectory = AppDirectory();
-    if (appDirectory.empty()) {
+    const auto &fontFiles = AppFontFilePaths();
+    if (fontFiles.empty()) {
+      // Nothing bundled: report "no app collection" so callers pass nullptr to DirectWrite
+      // and keep using DirectWrite's own (cached, updatable) system font collection.
       return nullptr;
     }
 
@@ -88,15 +109,17 @@ winrt::com_ptr<::IDWriteFontCollection> CreateAppFontCollection() noexcept {
     winrt::check_hresult(factory5->GetSystemFontSet(systemFontSet.put()));
     winrt::check_hresult(builder->AddFontSet(systemFontSet.get()));
 
+    // Per-file failures are skipped so that one bad font file cannot break font
+    // resolution for the rest of the app.
     uint32_t fontFileCount = 0;
-    for (const auto *subdirectory : {L"Assets\\", L"Assets\\Fonts\\"}) {
-      for (const auto *pattern : {L"*.ttf", L"*.otf"}) {
-        fontFileCount += AddFontFiles(factory5.get(), builder.get(), appDirectory + subdirectory, pattern);
+    for (const auto &fontPath : fontFiles) {
+      winrt::com_ptr<::IDWriteFontFile> fontFile;
+      if (SUCCEEDED(factory5->CreateFontFileReference(fontPath.c_str(), nullptr, fontFile.put())) &&
+          SUCCEEDED(builder->AddFontFile(fontFile.get()))) {
+        ++fontFileCount;
       }
     }
     if (fontFileCount == 0) {
-      // Nothing bundled: report "no app collection" so callers pass nullptr to DirectWrite
-      // and keep using DirectWrite's own (cached, updatable) system font collection.
       return nullptr;
     }
 
@@ -114,14 +137,10 @@ winrt::com_ptr<::IDWriteFontCollection> CreateAppFontCollection() noexcept {
 } // namespace
 
 ::IDWriteFontCollection *DWriteAppFontCollection() noexcept {
-  // One-time initialization, thread-safe by construction: a function-local static
-  // with a dynamic initializer is initialized exactly once, and concurrent callers
-  // that arrive during that window wait for it to complete rather than racing or
-  // repeating it ([stmt.dcl]/4). So the directory enumeration and the font-file
-  // references behind CreateAppFontCollection() happen on the first call only,
-  // whichever thread gets there first - subsequent calls never touch the file
-  // system. Bundled font assets cannot change while the process runs, so the
-  // collection never needs rebuilding.
+  // One-time initialization, thread-safe by construction (same mechanism as the
+  // statics above): concurrent first callers wait rather than race or repeat. The
+  // underlying directory searches are cached separately in AppFontFilePaths(), so
+  // even a future change that rebuilds the collection can never re-run them.
   //
   // Held by value for the lifetime of the process and handed out as a non-owning
   // raw pointer: GetTextLayout() calls this on every text measure, and returning a

--- a/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.cpp
@@ -113,11 +113,21 @@ winrt::com_ptr<::IDWriteFontCollection> CreateAppFontCollection() noexcept {
 
 } // namespace
 
-winrt::com_ptr<::IDWriteFontCollection> DWriteAppFontCollection() noexcept {
-  // Thread-safe (magic static) one-time initialization. Bundled font assets cannot
-  // change for the lifetime of the process, so the collection never needs rebuilding.
+::IDWriteFontCollection *DWriteAppFontCollection() noexcept {
+  // One-time initialization, thread-safe by construction: a function-local static
+  // with a dynamic initializer is initialized exactly once, and concurrent callers
+  // that arrive during that window wait for it to complete rather than racing or
+  // repeating it ([stmt.dcl]/4). So the directory enumeration and the font-file
+  // references behind CreateAppFontCollection() happen on the first call only,
+  // whichever thread gets there first - subsequent calls never touch the file
+  // system. Bundled font assets cannot change while the process runs, so the
+  // collection never needs rebuilding.
+  //
+  // Held by value for the lifetime of the process and handed out as a non-owning
+  // raw pointer: GetTextLayout() calls this on every text measure, and returning a
+  // com_ptr by value would add an AddRef/Release pair to that path for no benefit.
   static const winrt::com_ptr<::IDWriteFontCollection> s_appFontCollection = CreateAppFontCollection();
-  return s_appFontCollection;
+  return s_appFontCollection.get();
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.h
@@ -10,4 +10,11 @@ namespace Microsoft::ReactNative {
 
 winrt::com_ptr<::IDWriteFactory> DWriteFactory() noexcept;
 
+// Font collection that merges the system font set with every font file bundled in the
+// application's Assets\ and Assets\Fonts\ directories (*.ttf / *.otf), so app-bundled
+// font families resolve during text layout exactly like installed fonts. Built once on
+// first use. Returns nullptr when the app bundles no fonts or when the collection
+// cannot be built; callers should treat nullptr as "use the system font collection".
+winrt::com_ptr<::IDWriteFontCollection> DWriteAppFontCollection() noexcept;
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/DWriteHelpers.h
@@ -12,9 +12,19 @@ winrt::com_ptr<::IDWriteFactory> DWriteFactory() noexcept;
 
 // Font collection that merges the system font set with every font file bundled in the
 // application's Assets\ and Assets\Fonts\ directories (*.ttf / *.otf), so app-bundled
-// font families resolve during text layout exactly like installed fonts. Built once on
-// first use. Returns nullptr when the app bundles no fonts or when the collection
-// cannot be built; callers should treat nullptr as "use the system font collection".
-winrt::com_ptr<::IDWriteFontCollection> DWriteAppFontCollection() noexcept;
+// font families resolve during text layout exactly like installed fonts. Returns
+// nullptr when the app bundles no fonts or when the collection cannot be built;
+// callers should treat nullptr as "use the system font collection".
+//
+// The collection - including the directory enumeration used to find the bundled font
+// files - is built exactly once per process, on first use, and is then owned for the
+// lifetime of the process. Initialization is thread-safe: concurrent first callers
+// resolve to the same instance.
+//
+// Returns a NON-OWNING raw pointer on purpose. GetTextLayout() calls this on every
+// text measure, so handing back a com_ptr by value would put an AddRef/Release pair
+// on that path for a pointer whose lifetime is already static. Callers must not
+// release it; take a com_ptr copy if they need to extend a reference.
+::IDWriteFontCollection *DWriteAppFontCollection() noexcept;
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
@@ -116,7 +116,9 @@ void WindowsTextLayoutManager::GetTextLayout(
       outerFragment.textAttributes.fontFamily.empty()
           ? L"Segoe UI"
           : Microsoft::Common::Unicode::Utf8ToUtf16(outerFragment.textAttributes.fontFamily).c_str(),
-      nullptr, // Font collection (nullptr sets it to use the system font collection).
+      // Bundled app fonts merged over the system font set (nullptr when the app bundles
+      // no fonts, which selects the system font collection as before).
+      Microsoft::ReactNative::DWriteAppFontCollection().get(),
       static_cast<DWRITE_FONT_WEIGHT>(outerFragment.textAttributes.fontWeight.value_or(
           static_cast<facebook::react::FontWeight>(DWRITE_FONT_WEIGHT_REGULAR))),
       style,

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/WindowsTextLayoutManager.cpp
@@ -118,7 +118,7 @@ void WindowsTextLayoutManager::GetTextLayout(
           : Microsoft::Common::Unicode::Utf8ToUtf16(outerFragment.textAttributes.fontFamily).c_str(),
       // Bundled app fonts merged over the system font set (nullptr when the app bundles
       // no fonts, which selects the system font collection as before).
-      Microsoft::ReactNative::DWriteAppFontCollection().get(),
+      Microsoft::ReactNative::DWriteAppFontCollection(),
       static_cast<DWRITE_FONT_WEIGHT>(outerFragment.textAttributes.fontWeight.value_or(
           static_cast<facebook::react::FontWeight>(DWRITE_FONT_WEIGHT_REGULAR))),
       style,


### PR DESCRIPTION
# Resolve app-bundled fonts in Fabric text layout

Fixes #16306. Fixes #16308. (Both issues turn out to have this single root cause — see below; both of
their filed diagnoses were wrong, and I am the person who filed them.)

## Problem

On the new architecture, **no app-bundled font family ever resolves.** `fontFamily: 'Ionicons'`,
`'Material Icons'`, `'FontAwesome'` and friends all fall back to Segoe UI and render glyph 0
(`.notdef`), whether the app ships the TTF in `Assets\Fonts\` or registers it through the
`windows.sharedFonts` package-manifest extension. Only fonts installed system-wide work.

## Root cause

`WindowsTextLayoutManager::GetTextLayout` passes `nullptr` as the font collection to
`CreateTextFormat` (`WindowsTextLayoutManager.cpp` L119):

```cpp
nullptr, // Font collection (nullptr sets it to use the system font collection).
```

`nullptr` means "resolve against the system font collection only". An app's own font files are not in
it, so the family is never found, DirectWrite falls back, and every icon codepoint maps to glyph 0.

That is the whole bug. It also explains why the two issues I filed looked like two different bugs and
were both misdiagnosed:

- **#16306 "spaces in family names fail".** Not true. Measured below: with a collection that contains
  the font, `"Material Icons"` resolves and draws glyph 782, and so do `"material icons"` and
  `"MATERIAL ICONS"`. DirectWrite's family lookup is case-insensitive and perfectly happy with
  interior spaces.
- **#16308 "stale TTF checksums are rejected".** Not true. Measured below: all eight stock
  `react-native-vector-icons@10.3.0` TTFs, byte-unmodified, pass `IDWriteFontFile::Analyze` with
  `supported=1`, are accepted by `IDWriteFontSetBuilder1::AddFontFile` with `hr=0`, and draw real
  glyph indices.
- The "blank, not tofu" distinction I drew between the two issues is also not a distinction. Both are
  `Segoe UI` glyph 0. Whether `.notdef` paints a hollow box or nothing at all is a property of the
  fallback face, not evidence of two different failures.

## Fix

Add `Microsoft::ReactNative::DWriteAppFontCollection()` to `DWriteHelpers`: on first use, build a
DirectWrite collection from the system font set merged with every `*.ttf` / `*.otf` under the app
directory's `Assets\` and `Assets\Fonts\`, and pass it at the `CreateTextFormat` call site instead of
`nullptr`.

Properties that matter for review:

- **Fails closed.** Returns `nullptr` on any failure and when the app bundles no fonts, and
  `nullptr` is exactly the current behaviour — so an app that ships no fonts, or a machine where the
  collection cannot be built, behaves precisely as it does today.
- **Built once**, via a function-local `static const` (thread-safe magic static). Bundled assets
  cannot change during the process lifetime.
- **System families keep working**, because the system font set is added to the builder first.
- **Per-file failures are skipped**, so one malformed font cannot break font resolution for the app.
- **Only the one `CreateTextFormat` call needed changing.** The per-fragment
  `SetFontFamilyName` at L274 resolves against the collection the layout already inherited from the
  text format, so it picks the app collection up for free.

## Validation

**What was actually measured.** I wrote a standalone DirectWrite probe that replays this exact call
sequence — `CreateTextFormat` (including the empty `localeName` the real code passes) →
`CreateTextLayout` → `Draw` with a recording `IDWriteTextRenderer` that reports the resolved face and
glyph indices — against the real stock TTFs. Built with VS 2022 (x64) and run on Windows 11
10.0.26200. Probe sources and raw output are attachable; here is the substance.

Every stock `react-native-vector-icons@10.3.0` font, unmodified:

| file | `Analyze` supported | `AddFontFile` | real family name (name table) | codepoint drawn | with a collection containing it | with `nullptr` (today) |
|---|---|---|---|---|---|---|
| MaterialIcons.ttf | 1 | `hr=0` accepted | `Material Icons` | U+E000 | **glyph 40** | Segoe UI, **glyph 0** |
| MaterialCommunityIcons.ttf | 1 | `hr=0` accepted | `Material Design Icons` | U+F0001 | **glyph 1** | Segoe UI, **glyph 0** |
| Ionicons.ttf | 1 | `hr=0` accepted | `Ionicons` | U+EA01 | **glyph 1** | Segoe UI, **glyph 0** |
| FontAwesome.ttf | 1 | `hr=0` accepted | `FontAwesome` | U+F000 | **glyph 13** | Segoe UI, **glyph 0** |
| Feather.ttf | 1 | `hr=0` accepted | `Feather` | U+F100 | **glyph 4** | Segoe UI, **glyph 0** |
| Octicons.ttf | 1 | `hr=0` accepted | `Octicons` | U+F10B | **glyph 4** | Segoe UI, **glyph 0** |
| EvilIcons.ttf | 1 | `hr=0` accepted | `EvilIcons` | U+F100 | **glyph 4** | Segoe UI, **glyph 0** |
| AntDesign.ttf | 1 | `hr=0` accepted | `anticon` | U+E600 | **glyph 2** | Segoe UI, **glyph 0** |

The codepoint in each row is taken from the face's own `IDWriteFontFace1::GetUnicodeRanges`, so it is
guaranteed to be one the font claims to map.

Family-string variants, holding the collection and the font constant and changing only the requested
string (MaterialIcons.ttf, drawing U+E7FD):

| requested `fontFamily` | `FindFamilyName` | draw result |
|---|---|---|
| `Material Icons` | exists | Material Icons, glyph 782 |
| `material icons` | exists | Material Icons, glyph 782 |
| `MATERIAL ICONS` | exists | Material Icons, glyph 782 |
| `MaterialIcons` | **not found** | Segoe UI, glyph 0 |
| `" Material Icons"` (leading space) | **not found** | Segoe UI, glyph 0 |
| `"Material Icons "` (trailing space) | **not found** | Segoe UI, glyph 0 |
| `Material  Icons` (doubled interior space) | **not found** | Segoe UI, glyph 0 |

Interior spaces are fine; case does not matter; **leading/trailing/duplicated whitespace is not
normalised** by DirectWrite and RNW does not trim the string either. Worth knowing, but not fixed
here — a separate, arguable question.

The API sequence this patch uses (`IDWriteFactory5::CreateFontSetBuilder` → `GetSystemFontSet` →
`AddFontSet` → `AddFontFile` → `CreateFontSet` → `CreateFontCollectionFromFontSet` → query for
`IDWriteFontCollection`) is the same sequence the probe compiled and ran successfully, so the API
usage is exercised rather than merely plausible.

**Honest limits — nothing in RNW was compiled or run:**

- The patch itself is **not compiled** and **not run**. `yarn lint`, `yarn format:verify`,
  clang-format, typecheck and the build are all **unrun**. The probe is separate standalone code, not
  this patch.
- Verified only mechanically: authored against the exact `raw.githubusercontent.com` bytes at
  `c69cf55f67f9b03f467502dac1007ac2d9ebe209`; `git apply --check` against a pristine scratch copy with
  `core.autocrlf false` → **exit 0**; real `git apply` → exit 0 with **0 CRLF sequences** in all three
  files; `git apply --check` against a CRLF-converted working copy with `core.autocrlf true` (what a
  normal checkout produces, since `.gitattributes` declares `*.cpp text eol=crlf`) → **exit 0**.
  Longest added line is 107 columns, within the 120-column `ColumnLimit` — hand-counted, not
  clang-format-verified.
- **I did not reproduce the original `windows.sharedFonts` state.** The probe machine has none of
  these fonts installed, so its `nullptr` rows fail for the simple reason that the font is absent
  from the system collection. I therefore cannot claim to have measured the exact configuration in
  #16306/#16308, only to have shown that neither spaces nor checksums are the mechanism and that
  `nullptr` cannot resolve a font that is not installed.
- **The `Assets\` / `Assets\Fonts\` convention is a judgement call, not a measurement.** It matches
  where RNW app templates put font assets and where our production app puts them, but if maintainers
  would rather this be an explicit API (an app-settable collection, or something aligned with
  #15750's `IProvideFontInfo` direction) than a directory convention, that is a reasonable objection
  and I will rework it.
- **Startup cost is unmeasured.** `GetSystemFontSet` plus building a merged collection happens once,
  on the first text layout. I have not profiled it.
- `AppDirectory()` uses a `MAX_PATH` buffer and returns empty (→ `nullptr` → today's behaviour) if the
  module path is longer.
- **Out of scope:** the editable text of a `TextInput` goes through RichEdit, not DirectWrite text
  layout, so app-bundled fonts there are unaffected by this change. The *placeholder* is fixed,
  because `CreatePlaceholderLayout` routes through `WindowsTextLayoutManager::GetTextLayout`. The
  `nullptr` in `ScrollViewComponentView.cpp` L474 is fine as-is — it requests the system font
  `Segoe Fluent Icons`.

## Prior art

Our production app (Facilitron FIT, RNW 0.83.2) ships a near-identical patch as a `yarn` patch and it
resolves app-bundled font families without the `windows.sharedFonts` manifest extension — which
matters because that extension can be rejected during Store package acceptance. This PR is that patch
generalised and cleaned up for upstream. Related: #15316, #15750, #3463.

## Change file

`change/react-native-windows-fix-app-bundled-fonts.json`, `"type": "prerelease"` (correct for `main`,
whose `vnext/package.json` version is `0.0.0-canary.1057`; the repo's beachball transform downgrades
`prerelease` to `patch` automatically on released branches).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16339)