### PR TITLE
fix(textinput): show the touch keyboard on focus and on tap for the windowless island TextInput

### DIFF
--- a/change/react-native-windows-fix-textinput-touch-keyboard-main.json
+++ b/change/react-native-windows-fix-textinput-touch-keyboard-main.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix(textinput): show the touch keyboard on focus and on tap for the windowless island TextInput (no CoreWindow auto-invoke) via InputPane Win32 interop — re-tapping an already-focused field reopens a dismissed keyboard",
+  "packageName": "react-native-windows",
+  "email": "collindanielschneide@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -18,6 +18,8 @@
 #include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.ViewManagement.h>
+#include <inputpaneinterop.h>
 #include <mutex>
 #include "../Composition.Input.h"
 #include "../CompositionHelpers.h"
@@ -787,6 +789,10 @@ void WindowsTextInputComponentView::OnPointerPressed(
 
     emitter->onPressIn(pressInArgs);
   }
+
+  // Tapping the field brings up the touch keyboard — including when the input is already
+  // focused (e.g. after the user dismissed the keyboard), which does not fire onGotFocus.
+  ShowSoftKeyboard();
 }
 
 void WindowsTextInputComponentView::OnPointerReleased(
@@ -1122,6 +1128,43 @@ void WindowsTextInputComponentView::onLostFocus(
   }
 }
 
+void WindowsTextInputComponentView::ShowSoftKeyboard() noexcept {
+  // On a tablet with no physical keyboard the shell never auto-invokes the touch
+  // keyboard for a windowless RichEdit host: in the WinAppSDK island model there is no
+  // CoreWindow, and the RichEdit is hosted via ITextServices with no child input HWND,
+  // so the OS heuristic can't see a focused edit control and never fires. Request the
+  // touch keyboard explicitly via the InputPane Win32 interop, keyed off the island's
+  // top-level AppWindow HWND (rootComponentView()->GetHwndForParenting()). Gated to
+  // slate/tablet posture (SM_CONVERTIBLESLATEMODE == 0) so it does not pop on a
+  // laptop/convertible with a keyboard attached. Called on focus AND on pointer press,
+  // so tapping an already-focused input reopens a keyboard the user had dismissed (a tap
+  // on an already-focused field does not fire onGotFocus). Best-effort — never let
+  // keyboard invocation break input handling.
+  if (::GetSystemMetrics(SM_CONVERTIBLESLATEMODE) != 0)
+    return;
+  auto root = rootComponentView();
+  if (!root)
+    return;
+  HWND hwnd = root->GetHwndForParenting();
+  if (!hwnd)
+    return;
+  try {
+    auto interop =
+        winrt::get_activation_factory<winrt::Windows::UI::ViewManagement::InputPane>()
+            .as<::IInputPaneInterop>();
+    winrt::Windows::UI::ViewManagement::InputPane inputPane{nullptr};
+    if (interop &&
+        SUCCEEDED(interop->GetForWindow(
+            hwnd,
+            winrt::guid_of<winrt::Windows::UI::ViewManagement::InputPane>(),
+            winrt::put_abi(inputPane))) &&
+        inputPane) {
+      inputPane.TryShow();
+    }
+  } catch (...) {
+  }
+}
+
 void WindowsTextInputComponentView::onGotFocus(
     const winrt::Microsoft::ReactNative::Composition::Input::RoutedEventArgs &args) noexcept {
   m_hasFocus = true;
@@ -1138,6 +1181,9 @@ void WindowsTextInputComponentView::onGotFocus(
       m_textServices->TxSendMessage(EM_SETSEL, static_cast<WPARAM>(0), static_cast<WPARAM>(-1), &res);
     }
   }
+
+  // Bring up the touch keyboard when this input gains focus.
+  ShowSoftKeyboard();
 }
 
 std::string WindowsTextInputComponentView::DefaultControlType() const noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -123,6 +123,9 @@ struct WindowsTextInputComponentView
   void updateSpellCheck(bool value) noexcept;
   void ShowContextMenu(const winrt::Windows::Foundation::Point &position) noexcept;
   void calculateContentVerticalOffset() noexcept;
+  // Request the on-screen touch keyboard for this input (InputPane interop), called on
+  // focus and on tap. See the .cpp for the windowing-model rationale.
+  void ShowSoftKeyboard() noexcept;
 
   winrt::Windows::UI::Composition::CompositionSurfaceBrush m_brush{nullptr};
   winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual m_caretVisual{nullptr};


### PR DESCRIPTION
Fixes #16331.

Main-branch twin of #16330 (which was authored against `0.83-stable` — this PR is the re-cut onto `main` offered there). The change is identical; it was re-based onto `main` at base commit `c69cf55f67f9b03f467502dac1007ac2d9ebe209`.

## Problem
On a Windows tablet with no physical keyboard, tapping a single-line `<TextInput>` (e.g. a login field) never raises the touch keyboard. Additionally, after the keyboard is dismissed, re-tapping the (still-focused) field does not bring it back.

## Root cause
Fabric/Composition `TextInput` (`WindowsTextInputComponentView`) has no code that requests the touch keyboard on focus — `onGotFocus` never touches `InputPane`/`CoreInputView`. In a WinAppSDK Win32 **island** app there is no `CoreWindow`, and the RichEdit is hosted **windowless** via `ITextServices` (no child edit HWND), so the OS's own touch-keyboard auto-invoke heuristic never fires either. Net: the keyboard never appears. (The UWP-era PR #2029 for this was closed and relied on `GetForCurrentView()` APIs that don't apply to the island model.)

A tap on an **already-focused** field does not fire `onGotFocus`, so a focus-only trigger can't re-raise a keyboard the user has dismissed.

## Fix
New helper `ShowSoftKeyboard()` requests the touch keyboard via `InputPane`, obtained through the Win32 interop `IInputPaneInterop::GetForWindow()` keyed off the island's top-level AppWindow HWND (`rootComponentView()->GetHwndForParenting()`). Gated on slate/tablet posture (`SM_CONVERTIBLESLATEMODE == 0`) so it does not pop on a laptop/convertible with a keyboard attached; wrapped in `try/catch` so it can never break input handling.

It is called from **both**:
- `onGotFocus` — raise the keyboard when the field gains focus, and
- `OnPointerPressed` — raise it on tap, so **re-tapping an already-focused field reopens a dismissed keyboard**.

Focus is intentionally left untouched on keyboard dismissal (the field stays focused; the user reopens the keyboard by tapping it again — the platform-appropriate behavior here).

Uses `IInputPaneInterop` from `<inputpaneinterop.h>` and `winrt::Windows::UI::ViewManagement::InputPane` — both ship in the Windows SDK already referenced by Microsoft.ReactNative, so there are no `.vcxproj`/reference changes.

## Validation — honest limits
- **On-device validation happened on the 0.83 build, not on this main build.** This exact change (same hunks) was compiled into Microsoft.ReactNative from source in a production RNW **0.83.2** new-arch app (Facilitron FIT, the #16330 branch), x64 Release, deployed to a physical x64 tablet. With the hardware keyboard detached: tapping the login field raises the touch keyboard; dismissing the keyboard keeps the field focused; re-tapping the field reopens the keyboard. All three confirmed on-device **against 0.83-stable**.
- **This main port has not been compiled.** No build, lint, or typecheck has been run on the ported code. The port was validated textually against `main` @ `c69cf55f`: all four insertion contexts (include block, end of `OnPointerPressed`, between `onLostFocus`/`onGotFocus`, end of `onGotFocus`, plus the `.h` declaration site) are line-for-line identical to `0.83-stable`, with one benign drift — `main` has an extra `#include <mutex>` adjacent to the include insertion point. `RootComponentView::GetHwndForParenting()` exists on `main` and `rootComponentView()` returns `RootComponentView *` there, so the helper compiles against the same surface it used on 0.83 (inferred from headers, not proven by a build).
- Remaining for upstream: CI build across archs.

## Caveats for reviewers

- **The posture gate is the part I would most like a second opinion on.** `GetSystemMetrics(SM_CONVERTIBLESLATEMODE)` returns `0` for slate mode *and* for hardware that is not convertible at all, so on a conventional desktop PC the gate passes and `InputPane::TryShow()` would be called on focus/tap. On the tablets this was validated against that is correct behaviour; on a desktop with a physical keyboard it may be unwanted. I have not observed it on a desktop. If you would prefer a stricter signal — `UIViewSettings`/`UserInteractionMode`, gating on whether the focus was touch-initiated, or checking for an attached keyboard — say which and I will re-cut it. I kept this identical to #16330 so the two PRs review as the same change rather than silently diverging.
- Called from `OnPointerPressed` unconditionally, so a *mouse* click on a field also requests the keyboard when the device reports slate posture. Same question as above; easy to gate on pointer device type if you want that.
- Mirrors the existing TextInput fixes (#16302, #16303).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16342)