### PR TITLE
Route CI package restores through the CFS feed

### DIFF
--- a/.ado/build-template.yml
+++ b/.ado/build-template.yml
@@ -162,6 +162,8 @@ extends:
             displayName: Use Node.js 24.x
 
           # TODO: REMOVE. Should be included in image.
+          - template: .ado/templates/configure-npm-feed.yml@self
+
           - task: CmdLine@2
             inputs:
               script: |
@@ -184,6 +186,10 @@ extends:
             displayName: Strict yarn install @rnw-scripts/beachball-config
             condition: and(succeeded(), eq(variables['detectScenario.isReleaseBuild'], 'False'))
             retryCountOnTaskFailure: 2
+            env:
+              YARN_NPM_REGISTRY_SERVER: $(npmFeedRegistry)
+              YARN_NPM_ALWAYS_AUTH: 'true'
+              YARN_NPM_AUTH_TOKEN: $(npmFeedAuthToken)
 
           - script: npx lage build --scope @rnw-scripts/prepare-release --scope @rnw-scripts/beachball-config
             displayName: Build prepare-release and beachball-config

--- a/.ado/prepare-release-bot.yml
+++ b/.ado/prepare-release-bot.yml
@@ -60,9 +60,16 @@ jobs:
       - script: if not exist %APPDATA%\npm (mkdir %APPDATA%\npm)
         displayName: Ensure npm directory for npx commands
 
+      # Must run before any package is fetched so nothing is pulled from npmjs.org directly.
+      - template: templates/configure-npm-feed.yml
+
       - script: yarn install --immutable
         displayName: yarn install
         retryCountOnTaskFailure: 2
+        env:
+          YARN_NPM_REGISTRY_SERVER: $(npmFeedRegistry)
+          YARN_NPM_ALWAYS_AUTH: 'true'
+          YARN_NPM_AUTH_TOKEN: $(npmFeedAuthToken)
 
       - script: npx lage build --scope @rnw-scripts/prepare-release --scope @rnw-scripts/beachball-config
         displayName: Build prepare-release and dependencies

--- a/.ado/templates/configure-npm-feed.yml
+++ b/.ado/templates/configure-npm-feed.yml
@@ -1,0 +1,65 @@
+#
+# Routes all npm/npx/Yarn package restores through the Azure Artifacts (CFS) feed
+# instead of pulling straight from the public registry.npmjs.org.
+#
+# The feed is an upstream-caching proxy for npmjs.org, so package resolution is
+# unchanged -- packages are simply served from (and cached in) Azure Artifacts.
+#
+# IMPORTANT: this configuration is applied at build time only and must NOT be
+# committed to the repo (e.g. as a checked-in .npmrc or .yarnrc.yml). This repo is
+# public and its GitHub Actions workflows build fork pull requests, which have no
+# credentials for the ADO feed -- a committed registry would break all public CI.
+#
+# Outputs the pipeline variable `npmFeedAuthToken` (secret) for steps that need to
+# authenticate Yarn Berry or Verdaccio against the feed.
+#
+parameters:
+  - name: registry
+    type: string
+    default: https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/npm/registry/
+
+  - name: feedServiceConnection
+    type: string
+    default: ms/react-native-public npm Feed
+
+steps:
+  # Written to the user-level .npmrc rather than the repo so the working tree stays
+  # clean and every npm/npx invocation is covered regardless of its cwd.
+  - pwsh: |
+      $npmrc = Join-Path $env:USERPROFILE '.npmrc'
+      Set-Content -Path $npmrc -Encoding ascii -Value @(
+        'registry=${{ parameters.registry }}'
+        'always-auth=true'
+      )
+      Write-Host "Wrote $npmrc"
+      Write-Host "##vso[task.setvariable variable=npmUserConfig]$npmrc"
+      Write-Host "##vso[task.setvariable variable=npmFeedRegistry]${{ parameters.registry }}"
+    displayName: Point npm at the Azure Artifacts feed
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate npm against the Azure Artifacts feed
+    inputs:
+      workingFile: $(npmUserConfig)
+      customEndpoint: ${{ parameters.feedServiceConnection }}
+
+  # Yarn Berry ignores .npmrc entirely, and Verdaccio needs the raw token for its
+  # uplink, so lift the credential npmAuthenticate just wrote into a secret variable.
+  - pwsh: |
+      $npmrc = Get-Content -Raw -Path $env:NPM_USER_CONFIG
+
+      $password = [regex]::Match($npmrc, '(?m)^\s*//\S+:_password\s*=\s*(\S+)\s*$')
+      $authToken = [regex]::Match($npmrc, '(?m)^\s*//\S+:_authToken\s*=\s*(\S+)\s*$')
+
+      if ($password.Success) {
+        $token = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($password.Groups[1].Value))
+      } elseif ($authToken.Success) {
+        $token = $authToken.Groups[1].Value
+      } else {
+        Write-Host "##vso[task.logissue type=error]npmAuthenticate did not write credentials into $env:NPM_USER_CONFIG. Verify the '${{ parameters.feedServiceConnection }}' service connection exists and is authorized for this pipeline."
+        exit 1
+      }
+
+      Write-Host "##vso[task.setvariable variable=npmFeedAuthToken;issecret=true]$token"
+    displayName: Capture Azure Artifacts feed credential
+    env:
+      NPM_USER_CONFIG: $(npmUserConfig)

--- a/.ado/templates/strict-yarn-install.yml
+++ b/.ado/templates/strict-yarn-install.yml
@@ -16,6 +16,9 @@ steps:
       version: '24.x'
     displayName: Use Node.js 24.x
 
+  # Must run before any package is fetched so nothing is pulled from npmjs.org directly.
+  - template: configure-npm-feed.yml
+
   # TODO: REMOVE. Should be included in image.
   - task: CmdLine@2
     inputs:
@@ -26,3 +29,7 @@ steps:
   - script: yarn install --immutable
     displayName: Strict yarn install ${{ parameters.workspace }}
     retryCountOnTaskFailure: 2
+    env:
+      YARN_NPM_REGISTRY_SERVER: $(npmFeedRegistry)
+      YARN_NPM_ALWAYS_AUTH: 'true'
+      YARN_NPM_AUTH_TOKEN: $(npmFeedAuthToken)

--- a/.ado/templates/verdaccio-start.yml
+++ b/.ado/templates/verdaccio-start.yml
@@ -7,6 +7,9 @@ parameters:
 steps:
   - pwsh: start-process verdaccio.cmd -ArgumentList @('--config', './.ado/verdaccio/config.yaml')
     displayName: Launch test npm server (verdaccio)
+    env:
+      # Verdaccio's uplink is the Azure Artifacts feed, which requires authentication.
+      NPM_FEED_AUTH_TOKEN: $(npmFeedAuthToken)
 
   - script: node .ado/scripts/waitForVerdaccio.js
     displayName: Wait for verdaccio server to boot

--- a/.ado/templates/verdaccio-stop.yml
+++ b/.ado/templates/verdaccio-stop.yml
@@ -13,9 +13,12 @@ steps:
   # Verdaccio log artifact publishing moved to templateContext.outputs in cli-init-windows.yml (1ES compliance)
 
   - script: | 
-      call npm config delete registry
+      call npm config set registry %NPM_FEED_REGISTRY%
       call yarn config unset npmRegistryServer
       call yarn config unset unsafeHttpWhitelist
     displayName: Reset npm/yarn config to stop poiting at local verdaccio server
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      # Restore the Azure Artifacts feed rather than deleting the setting, which
+      # would silently fall back to the public registry.npmjs.org.
+      NPM_FEED_REGISTRY: $(npmFeedRegistry)

--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -9,6 +9,9 @@ steps:
       version: '24.x'
     displayName: Use Node.js 24.x
 
+  # Must run before any package is fetched so nothing is pulled from npmjs.org directly.
+  - template: configure-npm-feed.yml
+
   # TODO: REMOVE. Should be included in image.
   - task: CmdLine@2
     inputs:
@@ -19,3 +22,7 @@ steps:
   - script: yarn --cwd ${{ parameters.workingDirectory }} install --immutable
     displayName: yarn install (immutable)
     retryCountOnTaskFailure: 2
+    env:
+      YARN_NPM_REGISTRY_SERVER: $(npmFeedRegistry)
+      YARN_NPM_ALWAYS_AUTH: 'true'
+      YARN_NPM_AUTH_TOKEN: $(npmFeedAuthToken)

--- a/.ado/verdaccio/config.yaml
+++ b/.ado/verdaccio/config.yaml
@@ -4,7 +4,12 @@ auth:
     file: ./htpasswd
 uplinks:
   npmjs:
-    url: https://registry.npmjs.org/
+    # Azure Artifacts (CFS) feed, which upstreams to npmjs.org. Verdaccio must not
+    # reach registry.npmjs.org directly. The token is injected by verdaccio-start.yml.
+    url: https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/npm/registry/
+    auth:
+      type: bearer
+      token_env: NPM_FEED_AUTH_TOKEN
     max_fails: 40
     maxage: 30m
     timeout: 60s


### PR DESCRIPTION
## Why

MountainPass SR21 (SFI Network Isolation) requires pipelines to restore packages through
the Central Feed Service instead of public registries. This pipeline currently pulls from
`registry.npmjs.org`, which blocks it from running network-isolated.

## What

New `.ado/templates/configure-npm-feed.yml` writes an `.npmrc` pointing at the
`ms/react-native-public` feed and runs `npmAuthenticate@0`, exposing `npmFeedRegistry` and
a secret `npmFeedAuthToken`. It runs before any package is fetched in:

- `templates/yarn-install.yml`, `templates/strict-yarn-install.yml`
- `build-template.yml` (inlined copy in Setup)
- `prepare-release-bot.yml`

Yarn gets `YARN_NPM_REGISTRY_SERVER` / `_ALWAYS_AUTH` / `_AUTH_TOKEN` per step. Verdaccio's
uplink now points at the feed, and `verdaccio-stop.yml` restores the feed registry instead
of `npm config delete registry`, which was silently reverting to npmjs.org.

`windows-vs-pr.yml` and `publish.yml` need no changes — they extend `build-template.yml`.

## Notes

- Config is applied at build time, not committed: fork PRs in GitHub Actions have no ADO
  credentials, so a checked-in `.npmrc` would break external contributors.
- No `networkIsolationPolicy` here. Per the SR21 TSG, YAML policies *replace* auto-applied
  ones; onboarding happens via the automatic 7-day lock-in or the `AzRF.Onboard` tag.
- No `yarn.lock` changes needed (Yarn 4 resolutions carry no absolute URLs).

## Prerequisite

An **npm-type** service connection `ms/react-native-public npm Feed` must exist and be
authorized. The existing `ms/react-native-public ADO Feed` is NuGet-type and won't work.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16348)