### PR TITLE
[0.81] Win32 assets fix

### DIFF
--- a/change/@office-iss-react-native-win32-e4b48607-bcc3-4b10-b8cc-97918d0cc1e1.json
+++ b/change/@office-iss-react-native-win32-e4b48607-bcc3-4b10-b8cc-97918d0cc1e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix saveAssetPlugin",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/saveAssetPlugin.js
+++ b/packages/@office-iss/react-native-win32/saveAssetPlugin.js
@@ -1,6 +1,6 @@
 // @ts-check
-import path from 'path';
-import ensureShortPath from './Libraries/Image/assetPaths';
+const path = require('path');
+const ensureShortPath = require('./Libraries/Image/assetPaths');
 
 /**
  * @typedef {import("metro").AssetData} AssetData;

--- a/packages/@office-iss/react-native-win32/saveAssetPlugin.js
+++ b/packages/@office-iss/react-native-win32/saveAssetPlugin.js
@@ -1,6 +1,6 @@
 // @ts-check
 const path = require('path');
-const ensureShortPath = require('./Libraries/Image/assetPaths');
+const ensureShortPath = require('./Libraries/Image/assetPaths').default;
 
 /**
  * @typedef {import("metro").AssetData} AssetData;


### PR DESCRIPTION
Currently packages/@office-iss/react-native-win32/saveAssetPlugin.js mixes esm and commonjs and so fails to load.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16357)