### PR TITLE
Release/CI pipeline updates + feed warm-up

### DIFF
--- a/.ado/README.md
+++ b/.ado/README.md
@@ -10,9 +10,10 @@ setup and the network-isolation workarounds.
 
 | Pipeline | Entry file | ADO project | 1ES template | Notes |
 |----------|------------|-------------|--------------|-------|
-| CI | `ci-pipeline.yml` | `ISS` | `Office.Official` | signed Official build; `trigger`/`pr` are set in the ADO definition |
+| CI | `ci-pipeline.yml` | `ISS` | `Office.Official` | signed Official build; `trigger` branch filters and a weekly heartbeat `schedule` are defined in YAML |
 | PR | `pr-pipeline.yml` | public (`ms`) | `1ES.Unofficial` | validation build for GitHub PRs |
 | Release | `release-pipeline.yml` | `ISS` | `Office.Official` | triggered by CI completion; publishes packages and symbols |
+| Feed warm-up | `warm-feed-cache-pipeline.yml` | `ISS` | `Office.Unofficial` | scheduled; keeps `ms/react-native-public` populated for anonymous PR restores |
 
 CI and PR share all build/test/pack logic through `build-template.yml`; the
 `buildEnvironment` parameter (`Continuous` vs `PullRequest`) gates the
@@ -69,6 +70,11 @@ otherwise hide:
   CDN mid-build. This is an interim step; the durable fix is to bake it into the
   agent image.
 
+Public PR builds read this feed **anonymously**, so they can only restore versions
+an authenticated identity has already saved. `warm-feed-cache-pipeline.yml` (script:
+`vnext/Scripts/Warm-RnwFeedCache.ps1`) runs on a schedule to pre-populate the npm
+and NuGet dependency closures and keep those anonymous restores working.
+
 ## SDL and Component Governance
 
 The Office template runs SDL (CredScan, BinSkim, CodeQL, Component Governance,
@@ -86,6 +92,11 @@ root `package.json`), so nothing is suppressed.
 - NuGet → nuget.org (API key from `OGX-JSHost-KV`)
 - PDB symbols → Microsoft Symbol Server (`templates/publish-symbols.yml`)
 
-Two Release items are intentionally deferred to a follow-up change: the private-feed
-NuGet service connection (a placeholder `endpointId` remains in
-`release-pipeline.yml`) and a more authoritative publish-eligibility check.
+The nuget.org publish runs 1ES Network Isolation in report-only mode
+(`settings.networkIsolationMode: Audit`): `Enforce` blocks `api.nuget.org`, and the
+per-domain allow-list is not plumbed for release jobs, so mode is the only
+in-pipeline lever. Returning to `Enforce` requires adding nuget.org to the
+`CFSClean` isolation policy for this pipeline (follow-up).
+
+One item remains deferred: a more authoritative npm publish-eligibility check (the
+current check reads the feed anonymously and sees only cached versions).

--- a/.ado/ci-pipeline.yml
+++ b/.ado/ci-pipeline.yml
@@ -5,8 +5,28 @@
 
 name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
 
-trigger: none
+trigger:
+  branches:
+    include:
+    - main
+    - '0.81-stable'
+    - '0.82-stable'
+    - '0.83-stable'
+    - '0.84-stable'
+    - '0.85-stable'
+    - '0.86-stable'
+    - '0.87-stable'
 pr: none
+
+schedules:
+# Weekly heartbeat: keeps the pipeline from being auto-disabled after long
+# inactivity. 10:00 UTC ~= 02:00 Pacific (cron is UTC-only: 02:00 PST / 03:00 PDT).
+- cron: '0 10 * * Mon'
+  displayName: Weekly heartbeat (Mondays ~02:00 Pacific)
+  branches:
+    include:
+    - main
+  always: true
 
 parameters:
   - name: isReleaseBuild

--- a/.ado/release-pipeline.yml
+++ b/.ado/release-pipeline.yml
@@ -38,12 +38,13 @@ resources:
       branches:
         include:
         - main
-        - '0.74-stable'
         - '0.81-stable'
         - '0.82-stable'
         - '0.83-stable'
         - '0.84-stable'
         - '0.85-stable'
+        - '0.86-stable'
+        - '0.87-stable'
   repositories:
   - repository: OfficePipelineTemplates
     type: git
@@ -65,6 +66,9 @@ extends:
         enableExclusions: true
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.ado\guardian\sdl\.gdnsuppress
+    settings:
+      # Report-only network isolation so nuget.org publishing can egress (Enforce blocks it).
+      networkIsolationMode: Audit
     stages:
     #
     # Gate stage — runs unconditionally for every trigger.
@@ -239,10 +243,7 @@ extends:
         steps:
         - template: .ado/templates/publish-nuget-to-ado-feed.yml@self
           parameters:
-            # TODO(ISS): create an external NuGet service connection in the ISS
-            # project for the ms/react-native feed, then set endpointId to that
-            # connection's endpoint GUID and publishFeedCredentials to its name.
-            endpointId: '00000000-0000-0000-0000-000000000000'
+            endpointId: 'cfe2ce40-0448-46a1-b36d-4205330ca275'
             nugetFeedUrl: 'https://pkgs.dev.azure.com/ms/_packaging/react-native/nuget/v3/index.json'
             packageParentPath: '$(Pipeline.Workspace)/ReactWindows-final-nuget'
             packagesToPush: '$(Pipeline.Workspace)/ReactWindows-final-nuget/*.nupkg'

--- a/.ado/templates/publish-nuget-to-ado-feed.yml
+++ b/.ado/templates/publish-nuget-to-ado-feed.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: azureSubscription
   type: string
-  default: 'Office-React-Native-Windows-Bot'
+  default: 'Office-Hermes-Windows-Bot'
 - name: endpointId
   type: string
 - name: nugetFeedUrl

--- a/.ado/warm-feed-cache-pipeline.yml
+++ b/.ado/warm-feed-cache-pipeline.yml
@@ -1,0 +1,71 @@
+#
+# Scheduled feed-warming pipeline (office/ISS, non-production).
+#
+# Runs Warm-RnwFeedCache.ps1 to save the CLI-init toolchain closure into the
+# ms/react-native-public feed with an authenticated identity, so anonymous PR
+# builds restore cleanly instead of 404ing on a not-yet-cached transitive package.
+#
+# Runs every 6 hours; drop to hourly later if it stays light.
+#
+
+name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 0,6,12,18 * * *"
+    displayName: Every 6 hours
+    branches:
+      include:
+        - main
+    always: true
+
+resources:
+  repositories:
+  - repository: OfficePipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/OfficePipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/Office.Unofficial.PipelineTemplate.yml@OfficePipelineTemplates
+  parameters:
+    pool:
+      name: fabric-internal-pool-large
+      demands: ImageOverride -equals rnw-img-vs2026-node24
+    sdl:
+      bandit:
+        enabled: false
+      eslint:
+        enableExclusions: true
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.ado\guardian\sdl\.gdnsuppress
+    stages:
+    - stage: Warm
+      displayName: Warm feed cache
+      jobs:
+      - job: WarmFeed
+        displayName: Warm npm and NuGet feed cache
+        timeoutInMinutes: 60
+        steps:
+        - checkout: self
+          fetchDepth: 1
+
+        - task: UseNode@1
+          displayName: Use Node.js 24.x
+          inputs:
+            version: '24.x'
+
+        # Interim identity (shared with auth-npm-feed.yml); swap to the RNW managed
+        # identity once it is provisioned. AzureCLI@2 logs in az as this identity, so
+        # the script's `az account get-access-token` authenticates to the feed.
+        - task: AzureCLI@2
+          displayName: Warm ms/react-native-public feed
+          inputs:
+            azureSubscription: Office-Hermes-Windows-Bot
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $ErrorActionPreference = 'Stop'
+              & "$(Build.SourcesDirectory)/vnext/Scripts/Warm-RnwFeedCache.ps1"

--- a/.ado/warm-feed-cache-pipeline.yml
+++ b/.ado/warm-feed-cache-pipeline.yml
@@ -57,6 +57,16 @@ extends:
           inputs:
             version: '24.x'
 
+        # The agent image does not guarantee Yarn (build-template.yml installs it
+        # explicitly), and the warm script runs `yarn install`. Authenticate npm to
+        # the feed, then install the same pinned Yarn from it.
+        - template: .ado/templates/auth-npm-feed.yml@self
+
+        - task: CmdLine@2
+          displayName: Install pinned Yarn from the feed
+          inputs:
+            script: npm install --global yarn@1.22.22 --registry https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/npm/registry/
+
         # Interim identity (shared with auth-npm-feed.yml); swap to the RNW managed
         # identity once it is provisioned. AzureCLI@2 logs in az as this identity, so
         # the script's `az account get-access-token` authenticates to the feed.

--- a/change/react-native-windows-0d3e0585-cf54-41f6-b2a4-95b876015aad.json
+++ b/change/react-native-windows-0d3e0585-cf54-41f6-b2a4-95b876015aad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Release/CI pipeline updates + feed warm-up",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/Warm-RnwFeedCache.ps1
+++ b/vnext/Scripts/Warm-RnwFeedCache.ps1
@@ -1,0 +1,320 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Warm the ms/react-native-public Azure Artifacts feed with the npm and NuGet
+  packages the React Native Windows CI and CLI-init tests need.
+
+.DESCRIPTION
+  Public PR builds read the feed anonymously, and an Azure Artifacts upstream feed
+  only serves a version once it has been *saved* (pulled through by an authenticated
+  request). Any not-yet-saved transitive dependency therefore 404s on a PR build,
+  e.g. the CLI lib job failing on 'is-unc-path'.
+
+  The script warms two ways, both with your credentials:
+  - npm: it reproduces the base project generations the CLI-init tests run (a
+    create-react-native-library lib and a community-CLI app) and installs them, which
+    pulls the whole toolchain closure into the feed.
+  - NuGet: it downloads every package in the repo's packages.lock.json files (the
+    full resolved closure, incl. transitives) via the feed's flat2 endpoint.
+
+  Saving is idempotent, so re-warming is a no-op.
+
+  Auth (in order): -Pat / $env:ADO_PAT / $env:AZURE_DEVOPS_EXT_PAT, else an AAD token
+  from `az account get-access-token` (requires `az login` locally, or an AzureCLI@2
+  task with a managed identity in a pipeline).
+
+  Run it manually from a clone, or on a schedule from the ADO warm-up pipeline. It
+  does not touch your local checkout: all work happens in a throwaway work dir.
+
+.PARAMETER NpmRegistry
+  The feed npm registry to warm. Defaults to ms/react-native-public.
+
+.PARAMETER NuGetIndex
+  The feed NuGet v3 index.json to warm. Defaults to ms/react-native-public.
+
+.PARAMETER Pat
+  Optional ADO PAT (Packaging: Read on the feed's org). Falls back to env vars, then az.
+
+.PARAMETER WorkDir
+  Directory for the throwaway generated projects. Defaults to a new temp folder.
+
+.PARAMETER ReactNativeVersion
+  react-native version to generate against. Defaults to vnext/package.json.
+
+.PARAMETER ReactVersion
+  react version. Defaults to vnext/package.json.
+
+.PARAMETER CliVersion
+  @react-native-community/cli version. Defaults to vnext/package.json.
+
+.PARAMETER SkipLib
+  Skip the create-react-native-library warm pass.
+
+.PARAMETER SkipApp
+  Skip the community-CLI app warm pass.
+
+.PARAMETER SkipNuGet
+  Skip the NuGet warm pass.
+
+.PARAMETER KeepWorkDir
+  Keep the work dir instead of deleting it (for debugging).
+
+.EXAMPLE
+  ./Warm-RnwFeedCache.ps1
+
+.EXAMPLE
+  # Warm against explicit versions and keep the generated projects to inspect:
+  ./Warm-RnwFeedCache.ps1 -ReactNativeVersion 0.85.0-nightly-20260303-c26dbe286 -KeepWorkDir
+#>
+[CmdletBinding()]
+param(
+  [string]$NpmRegistry = 'https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/npm/registry/',
+  [string]$Pat,
+  [string]$WorkDir,
+  [string]$ReactNativeVersion,
+  [string]$ReactVersion,
+  [string]$CliVersion,
+  [string]$CreateLibraryVersion = '0.48.9',
+  [string]$TemplateVersion = '@react-native-community/template@0.84.1',
+  [string]$NuGetIndex = 'https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json',
+  [switch]$SkipLib,
+  [switch]$SkipApp,
+  [switch]$SkipNuGet,
+  [switch]$KeepWorkDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Azure DevOps resource id for AAD access tokens.
+$AdoResourceId = '499b84ac-1321-427f-aa17-267ca6975798'
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+$UpdateNightly = Join-Path $RepoRoot 'vnext\Scripts\UpdateNightlyDependencies.ps1'
+
+function Get-FeedToken {
+  param([string]$Pat)
+  $token = $Pat
+  if (-not $token) { $token = $env:ADO_PAT }
+  if (-not $token) { $token = $env:AZURE_DEVOPS_EXT_PAT }
+  if ($token) { return [pscustomobject]@{ Token = $token; Kind = 'pat' } }
+  $az = Get-Command az -CommandType Application -ErrorAction SilentlyContinue
+  if ($az) {
+    $aad = & az account get-access-token --resource $AdoResourceId --query accessToken -o tsv 2>$null
+    if ($LASTEXITCODE -eq 0 -and $aad) { return [pscustomobject]@{ Token = $aad.Trim(); Kind = 'aad' } }
+  }
+  throw "No Azure DevOps auth available. Run 'az login', or pass -Pat / set `$env:ADO_PAT."
+}
+
+function Get-RepoVersion {
+  param([object]$Pkg, [string]$Section, [string]$Name, [string]$Override)
+  if ($Override) { return $Override }
+  $deps = $Pkg.$Section
+  if ($deps) {
+    $prop = $deps.PSObject.Properties | Where-Object { $_.Name -eq $Name } | Select-Object -First 1
+    if ($prop) { return [string]$prop.Value }
+  }
+  throw "Could not find '$Name' in vnext/package.json '$Section'. Pass it explicitly."
+}
+
+function Invoke-Checked {
+  param([scriptblock]$Script, [string]$What)
+  & $Script
+  if ($LASTEXITCODE -ne 0) { throw "$What failed (exit $LASTEXITCODE)." }
+}
+
+# --- auth + versions ----------------------------------------------------------
+
+$token = Get-FeedToken -Pat $Pat
+$pkg = Get-Content (Join-Path $RepoRoot 'vnext\package.json') -Raw | ConvertFrom-Json
+$rnVersion = Get-RepoVersion -Pkg $pkg -Section 'devDependencies' -Name 'react-native' -Override $ReactNativeVersion
+$reactVersion = Get-RepoVersion -Pkg $pkg -Section 'devDependencies' -Name 'react' -Override $ReactVersion
+$cliVersion = Get-RepoVersion -Pkg $pkg -Section 'dependencies' -Name '@react-native-community/cli' -Override $CliVersion
+$isNightly = $rnVersion -match 'nightly'
+
+if (-not $WorkDir) { $WorkDir = Join-Path ([IO.Path]::GetTempPath()) "rnw-warm-$(Get-Random)" }
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+
+Write-Host "Feed:          $NpmRegistry" -ForegroundColor Cyan
+Write-Host "react-native:  $rnVersion" -ForegroundColor Cyan
+Write-Host "react:         $reactVersion  cli: $cliVersion" -ForegroundColor Cyan
+Write-Host "Work dir:      $WorkDir" -ForegroundColor Cyan
+
+# Point npm/npx and Yarn (classic + berry) at the feed with our token, via a
+# work-dir-local npm config so the caller's ~/.npmrc is untouched.
+$npmrc = Join-Path $WorkDir '.npmrc'
+$registryKey = ($NpmRegistry -replace '^https?:', '')
+Set-Content -LiteralPath $npmrc -Encoding ascii -Value @(
+  "registry=$NpmRegistry"
+  "${registryKey}:_authToken=$($token.Token)"
+  'always-auth=true'
+)
+
+$savedEnv = @{}
+foreach ($kv in @{
+    NPM_CONFIG_USERCONFIG          = $npmrc
+    NPM_CONFIG_REGISTRY            = $NpmRegistry
+    YARN_NPM_REGISTRY_SERVER       = $NpmRegistry
+    YARN_NPM_ALWAYS_AUTH           = 'true'
+    YARN_NPM_AUTH_TOKEN            = $token.Token
+    YARN_ENABLE_IMMUTABLE_INSTALLS = 'false'
+  }.GetEnumerator()) {
+  $savedEnv[$kv.Key] = [Environment]::GetEnvironmentVariable($kv.Key)
+  Set-Item "env:$($kv.Key)" $kv.Value
+}
+
+function Update-NightlyPackageJson {
+  param([string]$PackageJsonPath)
+  # UpdateNightlyDependencies.ps1 throws on error (ErrorActionPreference=Stop); no exit code to check.
+  if (-not $isNightly) { return }
+  & $UpdateNightly -PackageJsonPath $PackageJsonPath -ReactNativeVersion $rnVersion -ReactNativeCliVersion $cliVersion
+}
+
+# --- warm passes --------------------------------------------------------------
+
+function Warm-Lib {
+  Push-Location $WorkDir
+  try {
+    Invoke-Checked -What 'create-react-native-library' -Script {
+      & npx --yes "create-react-native-library@$CreateLibraryVersion" `
+        --slug warmlib --description warmlib `
+        --author-name 'React-Native-Windows Bot' `
+        --author-email '53619745+rnbot@users.noreply.github.com' `
+        --author-url 'http://example.com' --repo-url 'http://example.com' `
+        --languages kotlin-objc --local false --type turbo-module `
+        --react-native-version $rnVersion --example vanilla warmlib
+    }
+    Push-Location (Join-Path $WorkDir 'warmlib')
+    try {
+      Update-NightlyPackageJson -PackageJsonPath 'package.json'
+      if (Test-Path 'example\package.json') { Update-NightlyPackageJson -PackageJsonPath 'example\package.json' }
+      Invoke-Checked -What 'yarn install (lib)' -Script { & yarn install }
+    }
+    finally { Pop-Location }
+  }
+  finally { Pop-Location }
+}
+
+function Warm-App {
+  Push-Location $WorkDir
+  try {
+    Invoke-Checked -What 'react-native init (app)' -Script {
+      $templateArgs = if ($isNightly) { @('--template', $TemplateVersion) } else { @() }
+      & npx --yes "@react-native-community/cli@$cliVersion" init warmapp `
+        --version $rnVersion @templateArgs --skip-install --install-pods false --skip-git-init true
+    }
+    Push-Location (Join-Path $WorkDir 'warmapp')
+    try {
+      Update-NightlyPackageJson -PackageJsonPath 'package.json'
+      Invoke-Checked -What 'yarn install (app)' -Script { & yarn install }
+    }
+    finally { Pop-Location }
+  }
+  finally { Pop-Location }
+}
+
+# NuGet warm: save the resolved closure (packages.lock.json, incl. transitives)
+# from upstream into the feed via authenticated flat2 downloads. No VS/msbuild needed.
+function Get-NuGetAuthHeader {
+  param([object]$Token)
+  if ($Token.Kind -eq 'pat') {
+    $basic = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$($Token.Token)"))
+    return @{ Authorization = "Basic $basic" }
+  }
+  return @{ Authorization = "Bearer $($Token.Token)" }
+}
+
+function Get-Flat2Base {
+  param([string]$IndexUrl, [hashtable]$Headers)
+  $index = Invoke-RestMethod -Uri $IndexUrl -Headers $Headers
+  $res = $index.resources | Where-Object { $_.'@type' -match '^PackageBaseAddress' } | Select-Object -First 1
+  if (-not $res) { throw "NuGet index has no PackageBaseAddress (flat2) resource: $IndexUrl" }
+  return ($res.'@id').TrimEnd('/')
+}
+
+function Get-NuGetRefsFromLockFiles {
+  $refs = @{}
+  $lockFiles = Get-ChildItem -Recurse -File -Filter packages.lock.json -Path $RepoRoot -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -notmatch '[\\/]node_modules[\\/]' }
+  foreach ($lf in $lockFiles) {
+    $json = Get-Content -LiteralPath $lf.FullName -Raw | ConvertFrom-Json
+    if (-not $json.PSObject.Properties['dependencies']) { continue }
+    foreach ($framework in $json.dependencies.PSObject.Properties) {
+      foreach ($dep in $framework.Value.PSObject.Properties) {
+        $info = $dep.Value
+        if ($info.type -eq 'Project') { continue }
+        if (-not $info.PSObject.Properties['resolved']) { continue }
+        $refs["$($dep.Name)|$($info.resolved)"] = [pscustomobject]@{ Id = $dep.Name; Version = [string]$info.resolved }
+      }
+    }
+  }
+  return @($refs.Values | Sort-Object Id, Version)
+}
+
+function Save-UpstreamNupkg {
+  param([string]$Id, [string]$Version, [string]$Flat2Base, [hashtable]$Headers, [int]$MaxAttempts = 4)
+  $idLower = $Id.ToLowerInvariant(); $verLower = $Version.ToLowerInvariant()
+  $url = "$Flat2Base/$idLower/$verLower/$idLower.$verLower.nupkg"
+  $tmp = Join-Path $WorkDir "nuget-$idLower.$verLower.nupkg"
+  for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    try {
+      Invoke-WebRequest -Uri $url -Headers $Headers -OutFile $tmp -ErrorAction Stop | Out-Null
+      Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+      return
+    }
+    catch {
+      $code = $null; try { $code = [int]$_.Exception.Response.StatusCode } catch { }
+      if ($attempt -lt $MaxAttempts -and ($null -eq $code -or $code -in 202, 404, 408, 429, 500, 502, 503, 504)) {
+        Start-Sleep -Seconds ([Math]::Min(2 * $attempt, 10)); continue
+      }
+      throw "$Id $Version ($(if ($code) { "HTTP $code" } else { $_.Exception.Message }))"
+    }
+  }
+}
+
+function Warm-NuGet {
+  $refs = Get-NuGetRefsFromLockFiles
+  if ($refs.Count -eq 0) { Write-Host 'No packages.lock.json entries found.' -ForegroundColor Yellow; return }
+  $headers = Get-NuGetAuthHeader -Token $token
+  $flat2 = Get-Flat2Base -IndexUrl $NuGetIndex -Headers $headers
+  Write-Host "Saving $($refs.Count) NuGet package(s) via $flat2" -ForegroundColor Cyan
+  $failures = @()
+  foreach ($r in $refs) {
+    try { Save-UpstreamNupkg -Id $r.Id -Version $r.Version -Flat2Base $flat2 -Headers $headers }
+    catch { $failures += $_.Exception.Message }
+  }
+  if ($failures.Count) { throw "$($failures.Count)/$($refs.Count) NuGet package(s) failed: $($failures -join '; ')" }
+  Write-Host "Saved $($refs.Count) NuGet package(s)." -ForegroundColor Green
+}
+
+$passes = [ordered]@{}
+if (-not $SkipLib) { $passes['lib'] = ${function:Warm-Lib} }
+if (-not $SkipApp) { $passes['app'] = ${function:Warm-App} }
+if (-not $SkipNuGet) { $passes['nuget'] = ${function:Warm-NuGet} }
+
+$results = foreach ($name in $passes.Keys) {
+  Write-Host "`n=== Warming '$name' ===" -ForegroundColor Green
+  # Route each pass's native stdout to the host so only the status object lands in $results.
+  try { & $passes[$name] | Out-Host; [pscustomobject]@{ Pass = $name; Status = 'OK' } }
+  catch { Write-Host "##[error]$($_.Exception.Message)" -ForegroundColor Red; [pscustomobject]@{ Pass = $name; Status = "FAILED: $($_.Exception.Message)" } }
+}
+
+# --- cleanup + summary --------------------------------------------------------
+
+foreach ($k in $savedEnv.Keys) {
+  if ($null -eq $savedEnv[$k]) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
+  else { Set-Item "env:$k" $savedEnv[$k] }
+}
+if (-not $KeepWorkDir) { Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue }
+else { Write-Host "`nKept work dir: $WorkDir" -ForegroundColor Yellow }
+
+$results = @($results)
+Write-Host ''
+if ($results.Count -eq 0) { Write-Host 'Nothing warmed (all passes skipped).' -ForegroundColor Yellow; exit 0 }
+$results | Format-Table -AutoSize Pass, Status | Out-Host
+
+$failed = @($results | Where-Object { $_.Status -ne 'OK' })
+if ($failed.Count) {
+  Write-Host "$($failed.Count) of $($results.Count) warm pass(es) failed. A failed authenticated install usually means a package is missing upstream or the feed is unhealthy." -ForegroundColor Red
+  exit 1
+}
+Write-Host "Feed warmed. Anonymous PR builds should now restore these closures." -ForegroundColor Green

--- a/vnext/Scripts/Warm-RnwFeedCache.ps1
+++ b/vnext/Scripts/Warm-RnwFeedCache.ps1
@@ -70,6 +70,8 @@ param(
   [string]$WorkDir,
   [string]$ReactNativeVersion,
   [string]$CliVersion,
+  # CODESYNC: keep in step with vnext/Scripts/creaternwlib.cmd and creaternwapp.cmd,
+  # so the warm run reproduces the same generator/template versions the CLI-init tests use.
   [string]$CreateLibraryVersion = '0.48.9',
   [string]$TemplateVersion = '@react-native-community/template@0.84.1',
   [string]$NuGetIndex = 'https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json',
@@ -139,8 +141,11 @@ Write-Host "cli:           $cliVersion" -ForegroundColor Cyan
 Write-Host "Work dir:      $WorkDir" -ForegroundColor Cyan
 
 # Point npm/npx and Yarn (classic + berry) at the feed with our token, via a
-# work-dir-local npm config so the caller's ~/.npmrc is untouched.
+# work-dir-local npm config so the caller's ~/.npmrc is untouched. $npmrc and
+# $savedEnv are declared before the try so the finally can always undo them.
 $npmrc = Join-Path $WorkDir '.npmrc'
+$savedEnv = @{}
+try {
 $registryKey = ($NpmRegistry -replace '^https?:', '')
 Set-Content -LiteralPath $npmrc -Encoding ascii -Value @(
   "registry=$NpmRegistry"
@@ -148,7 +153,6 @@ Set-Content -LiteralPath $npmrc -Encoding ascii -Value @(
   'always-auth=true'
 )
 
-$savedEnv = @{}
 foreach ($kv in @{
     NPM_CONFIG_USERCONFIG          = $npmrc
     NPM_CONFIG_REGISTRY            = $NpmRegistry
@@ -254,20 +258,27 @@ function Save-UpstreamNupkg {
   $idLower = $Id.ToLowerInvariant(); $verLower = $Version.ToLowerInvariant()
   $url = "$Flat2Base/$idLower/$verLower/$idLower.$verLower.nupkg"
   $tmp = Join-Path $WorkDir "nuget-$idLower.$verLower.nupkg"
+  $lastError = 'unknown error'
   for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    $retryable = $true
     try {
-      Invoke-WebRequest -Uri $url -Headers $Headers -OutFile $tmp -ErrorAction Stop | Out-Null
+      # -PassThru returns the response even with -OutFile, so a 202 is visible here
+      # (a 2xx never throws, so the old catch reported a still-pending 202 as saved).
+      $resp = Invoke-WebRequest -Uri $url -Headers $Headers -OutFile $tmp -PassThru -ErrorAction Stop
       Remove-Item $tmp -Force -ErrorAction SilentlyContinue
-      return
+      # 202 = Azure Artifacts is still saving the upstream package; not available yet, so retry.
+      if ([int]$resp.StatusCode -ne 202) { return }
+      $lastError = 'HTTP 202 (upstream save still pending)'
     }
     catch {
       $code = $null; try { $code = [int]$_.Exception.Response.StatusCode } catch { }
-      if ($attempt -lt $MaxAttempts -and ($null -eq $code -or $code -in 202, 404, 408, 429, 500, 502, 503, 504)) {
-        Start-Sleep -Seconds ([Math]::Min(2 * $attempt, 10)); continue
-      }
-      throw "$Id $Version ($(if ($code) { "HTTP $code" } else { $_.Exception.Message }))"
+      $lastError = if ($code) { "HTTP $code" } else { $_.Exception.Message }
+      $retryable = ($null -eq $code -or $code -in 404, 408, 429, 500, 502, 503, 504)
     }
+    if (-not $retryable) { break }
+    if ($attempt -lt $MaxAttempts) { Start-Sleep -Seconds ([Math]::Min(2 * $attempt, 10)) }
   }
+  throw "$Id $Version ($lastError)"
 }
 
 function Warm-NuGet {
@@ -298,15 +309,17 @@ $results = foreach ($name in $passes.Keys) {
 }
 
 # --- cleanup + summary --------------------------------------------------------
-
-foreach ($k in $savedEnv.Keys) {
-  if ($null -eq $savedEnv[$k]) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
-  else { Set-Item "env:$k" $savedEnv[$k] }
 }
-# Always remove the token-bearing .npmrc so -KeepWorkDir never leaves a credential on disk.
-Remove-Item -LiteralPath $npmrc -Force -ErrorAction SilentlyContinue
-if (-not $KeepWorkDir) { Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue }
-else { Write-Host "`nKept work dir: $WorkDir" -ForegroundColor Yellow }
+finally {
+  # Runs even on Ctrl+C or an uncaught error, so the token file and env overrides never linger.
+  foreach ($k in $savedEnv.Keys) {
+    if ($null -eq $savedEnv[$k]) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
+    else { Set-Item "env:$k" $savedEnv[$k] }
+  }
+  Remove-Item -LiteralPath $npmrc -Force -ErrorAction SilentlyContinue
+  if (-not $KeepWorkDir) { Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue }
+  else { Write-Host "`nKept work dir: $WorkDir" -ForegroundColor Yellow }
+}
 
 $results = @($results)
 Write-Host ''

--- a/vnext/Scripts/Warm-RnwFeedCache.ps1
+++ b/vnext/Scripts/Warm-RnwFeedCache.ps1
@@ -41,9 +41,6 @@
 .PARAMETER ReactNativeVersion
   react-native version to generate against. Defaults to vnext/package.json.
 
-.PARAMETER ReactVersion
-  react version. Defaults to vnext/package.json.
-
 .PARAMETER CliVersion
   @react-native-community/cli version. Defaults to vnext/package.json.
 
@@ -72,7 +69,6 @@ param(
   [string]$Pat,
   [string]$WorkDir,
   [string]$ReactNativeVersion,
-  [string]$ReactVersion,
   [string]$CliVersion,
   [string]$CreateLibraryVersion = '0.48.9',
   [string]$TemplateVersion = '@react-native-community/template@0.84.1',
@@ -127,16 +123,19 @@ function Invoke-Checked {
 $token = Get-FeedToken -Pat $Pat
 $pkg = Get-Content (Join-Path $RepoRoot 'vnext\package.json') -Raw | ConvertFrom-Json
 $rnVersion = Get-RepoVersion -Pkg $pkg -Section 'devDependencies' -Name 'react-native' -Override $ReactNativeVersion
-$reactVersion = Get-RepoVersion -Pkg $pkg -Section 'devDependencies' -Name 'react' -Override $ReactVersion
 $cliVersion = Get-RepoVersion -Pkg $pkg -Section 'dependencies' -Name '@react-native-community/cli' -Override $CliVersion
 $isNightly = $rnVersion -match 'nightly'
 
 if (-not $WorkDir) { $WorkDir = Join-Path ([IO.Path]::GetTempPath()) "rnw-warm-$(Get-Random)" }
-New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+# Refuse a pre-existing directory: cleanup deletes $WorkDir recursively, so it must be one we created.
+if (Test-Path -LiteralPath $WorkDir) {
+  throw "WorkDir '$WorkDir' already exists. Pass a path that does not exist so cleanup only deletes what this script creates."
+}
+New-Item -ItemType Directory -Path $WorkDir | Out-Null
 
 Write-Host "Feed:          $NpmRegistry" -ForegroundColor Cyan
 Write-Host "react-native:  $rnVersion" -ForegroundColor Cyan
-Write-Host "react:         $reactVersion  cli: $cliVersion" -ForegroundColor Cyan
+Write-Host "cli:           $cliVersion" -ForegroundColor Cyan
 Write-Host "Work dir:      $WorkDir" -ForegroundColor Cyan
 
 # Point npm/npx and Yarn (classic + berry) at the feed with our token, via a
@@ -304,6 +303,8 @@ foreach ($k in $savedEnv.Keys) {
   if ($null -eq $savedEnv[$k]) { Remove-Item "env:$k" -ErrorAction SilentlyContinue }
   else { Set-Item "env:$k" $savedEnv[$k] }
 }
+# Always remove the token-bearing .npmrc so -KeepWorkDir never leaves a credential on disk.
+Remove-Item -LiteralPath $npmrc -Force -ErrorAction SilentlyContinue
 if (-not $KeepWorkDir) { Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue }
 else { Write-Host "`nKept work dir: $WorkDir" -ForegroundColor Yellow }
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
We must move our CI and Release pipelines to the new `office/ISS` ADO project and address a number of new safe supply chain related policies.

### What

#### 1. Release pipeline

`.ado/release-pipeline.yml`, `.ado/templates/publish-nuget-to-ado-feed.yml`

- **nuget.org egress under network isolation.** Added
  `settings.networkIsolationMode: Audit`. Release jobs run 1ES Network Isolation
  in `Enforce` by default, which blocks `api.nuget.org` and fails the nuget.org
  push. `Audit` runs the isolation checks in report-only mode so the push
  succeeds — the same effective behavior as the hermes-windows and
  node-api-dotnet release pipelines. The per-domain allow-list is not available
  to release jobs, so mode is the only in-pipeline lever (see Follow-ups).
- **Private NuGet feed connection.** Replaced the placeholder `endpointId`
  (`00000000-…`) for the `ms/react-native` feed with the provisioned ISS service
  connection `Nuget - ms/react-native` (`cfe2ce40-…`).
- **Publish identity.** `publish-nuget-to-ado-feed.yml` now defaults
  `azureSubscription` to `Office-Hermes-Windows-Bot` (interim identity; see
  Follow-ups).
- **Trigger branches.** CI-completion trigger now covers `main` +
  `0.81`–`0.87-stable` (dropped end-of-life `0.74`, added `0.86`/`0.87`),
  matching the CI pipeline.

Validation: a full Release run in `office/ISS` published all five targets — npm
(npmjs.com), the private and public ADO NuGet feeds, nuget.org, and PDB symbols.
The Network Isolation step reported nuget.org under the `CFSClean` policy in
report-only mode with no connections blocked.

#### 2. CI pipeline

`.ado/ci-pipeline.yml`

- **YAML-driven trigger.** Replaced `trigger: none` (trigger was configured in
  the pipeline UI) with an in-YAML `trigger` covering `main` +
  `0.81`–`0.87-stable`. Keeping the trigger in source makes it reviewable and
  versioned.
- **Weekly heartbeat schedule.** Added a Monday ~02:00 Pacific run
  (`always: true`). Azure DevOps disables long-inactive pipelines; a low-cost
  weekly run keeps the definition enabled.

Reviewer action after merge: clear "Override the YAML continuous integration
trigger from here" in the CI pipeline's Triggers UI so the YAML trigger takes
effect.

#### 3. Feed warm-up pipeline (new)

`.ado/warm-feed-cache-pipeline.yml`, `vnext/Scripts/Warm-RnwFeedCache.ps1`

Public PR builds run under network isolation and read the
`ms/react-native-public` Azure Artifacts feed **anonymously**. Anonymous reads
only return versions an authenticated identity has already saved, so first-time
transitive dependencies (for example, the `create-react-native-library`
toolchain closure) fail PR restores with 404/500. This pipeline pre-populates the
feed:

- `Warm-RnwFeedCache.ps1` — self-contained script. Warms npm by generating the
  cRNL library and app projects and running real installs against the
  authenticated feed (following the package manager's own resolution); warms
  NuGet by downloading every resolved package from the repo's
  `packages.lock.json` files through the feed's flat2 endpoint. Has skip/override
  switches and returns non-zero on any failed pass.
- `warm-feed-cache-pipeline.yml` — `office/ISS` `Office.Unofficial` scheduled
  pipeline (every 6 hours) that runs the script under an authenticated managed
  identity (interim `Office-Hermes-Windows-Bot`).

Validation: local runs against the live feed completed both npm passes and the
NuGet pass, and packages that previously failed anonymous restore resolved
afterward.

## Follow-ups

- **Return to `Enforce` (compliance).** `Audit` leaves the `CFSClean` isolation
  policy reporting nuget.org as non-compliant. Request that `api.nuget.org` and
  `www.nuget.org` be added to the `CFSClean` allow-list for this pipeline, then
  remove `settings.networkIsolationMode: Audit`.
- **Dedicated managed identity.** Replace the interim `Office-Hermes-Windows-Bot`
  with `Office-React-Native-Windows-Bot` in `publish-nuget-to-ado-feed.yml` and
  `warm-feed-cache-pipeline.yml` once provisioned with feed-push rights.
- **Register the warm-up pipeline** in `office/ISS`, confirm a PR rerun no longer
  hits anonymous feed 404/500, and revisit the 6-hour cadence after observing
  cost.

## Changelog
Should this change be included in the release notes: yes

Release/CI pipeline updates + feed warm-up

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16359)