### PR TITLE
Recreate yarn.lock when preparing new release

### DIFF
--- a/packages/@rnw-scripts/prepare-release/src/beachballBump.ts
+++ b/packages/@rnw-scripts/prepare-release/src/beachballBump.ts
@@ -47,3 +47,19 @@ export async function bumpVersions(opts: {
     {cwd: opts.cwd},
   );
 }
+
+/**
+ * Regenerate yarn.lock so it matches the versions beachball just bumped.
+ *
+ * beachball rewrites package.json/changelogs but never touches the lockfile, so
+ * without this the lockfile drifts and every downstream `yarn install
+ * --immutable` fails with YN0028. `--mode=update-lockfile` refreshes the
+ * lockfile without touching node_modules; immutable installs are on by default
+ * under CI, so disable that for this one call.
+ */
+export async function updateLockfile(opts: {cwd: string}): Promise<void> {
+  await exec('yarn install --mode=update-lockfile', {
+    cwd: opts.cwd,
+    env: {YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'},
+  });
+}

--- a/packages/@rnw-scripts/prepare-release/src/prepareRelease.ts
+++ b/packages/@rnw-scripts/prepare-release/src/prepareRelease.ts
@@ -20,7 +20,7 @@ import findRepoRoot from '@react-native-windows/find-repo-root';
 
 import {GitRepo} from './git';
 import {findPR, createPR, updatePR} from './github';
-import {hasChangeFiles, bumpVersions} from './beachballBump';
+import {hasChangeFiles, bumpVersions, updateLockfile} from './beachballBump';
 import {
   collectBumpedPackages,
   generatePRBody,
@@ -287,6 +287,11 @@ async function detectRemote(git: GitRepo, repoUrl: string): Promise<string> {
         remote: remoteName,
         cwd: repoRoot,
       });
+
+      // 10b. Refresh yarn.lock to match the bumped versions so the release
+      //      commit stays installable under `yarn install --immutable`.
+      console.log(colorize('Updating yarn.lock...', ansi.bright));
+      await updateLockfile({cwd: repoRoot});
 
       // 11. Check if beachball actually changed anything
       const status = await git.statusPorcelain();


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Automation (AI changes or Github Actions to reduce effort of manual tasks)

### Why
The `prepare-release` automation (the bot that opens the "RELEASE: Releasing N
package(s)" / Version Packages PRs) bumps package versions with beachball but
never regenerated `yarn.lock`. beachball only rewrites `package.json` and
changelog files, so the committed lockfile drifted out of sync with the bumped
versions.

Since the move to Yarn 4, CI installs with `yarn install --immutable`, which
treats any lockfile drift as a fatal error (`YN0028: The lockfile would have been
modified by this install, which is explicitly forbidden`). As a result every
release PR failed all of its validation jobs at the `yarn install (immutable)`
step. Only the Setup job passed, because it skips the immutable install on
release builds — which is why the failure looked like "everything except setup is
red."

### What
- Add an `updateLockfile()` helper to the `prepare-release` tool that runs
  `yarn install --mode=update-lockfile`. It refreshes `yarn.lock` to match the
  freshly bumped `package.json` files without touching `node_modules`. Immutable
  installs are enabled by default under CI, so the helper disables them for that
  single call (`YARN_ENABLE_IMMUTABLE_INSTALLS=false`).
- Invoke it immediately after the beachball bump and before the commit is staged,
  so the generated release commit carries a `yarn.lock` consistent with the
  version bump.
- Scoped to the PR-creating path only. The `--bump-only` path used by developer
  CI builds is left untouched, because those builds never commit the lockfile.

## Screenshots
N/A.

## Testing
- Built the affected package: `npx lage build --scope @rnw-scripts/prepare-release`
  succeeds.
- Ran the exact command the helper issues (`yarn install --mode=update-lockfile`
  with immutable installs disabled): exits 0, does not raise `YN0028`, and Yarn
  reports the link step skipped due to `mode=update-lockfile` — confirming it only
  rewrites the lockfile. On an already-consistent tree it is a no-op.
- Not yet exercised end-to-end through a real release-prep run; that happens the
  next time the bot runs against a branch that has pending change files.

## Changelog
Should this change be included in the release notes: no

This is release/build tooling, not a user-facing runtime change.
(`@rnw-scripts/prepare-release` is a private package, so no change file is
required.)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16375)