### PR TITLE
Put react-native-windows-repo under @rnw-scripts namespace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-windows-repo",
+  "name": "@rnw-scripts/react-native-windows-repo",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5253,6 +5253,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@rnw-scripts/react-native-windows-repo@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@rnw-scripts/react-native-windows-repo@workspace:."
+  dependencies:
+    "@rnw-scripts/beachball-config": "npm:0.0.0"
+    "@rnw-scripts/format-files": "npm:*"
+    "@rnw-scripts/integrate-rn": "npm:*"
+    "@rnw-scripts/just-task": "npm:*"
+    "@rnw-scripts/prepare-release": "npm:*"
+    "@rnw-scripts/promote-release": "npm:*"
+    "@rnw-scripts/stamp-version": "npm:0.0.0"
+    "@rnw-scripts/take-screenshot": "npm:*"
+    "@rnw-scripts/unbroken": "npm:*"
+    beachball: "npm:^2.20.0"
+    eslint: "npm:^8.19.0"
+    fast-glob: "npm:^3.2.11"
+    husky: "npm:^4.2.5"
+    lage: "npm:^2.7.1"
+    lodash: "npm:^4.17.15"
+    prettier: "npm:^3.6.2"
+    prettier-plugin-hermes-parser: "npm:0.21.1"
+    react: "npm:19.2.3"
+    react-native: "npm:0.85.0-nightly-20260303-c26dbe286"
+    react-native-platform-override: "workspace:*"
+    typescript: "npm:5.0.4"
+  languageName: unknown
+  linkType: soft
+
 "@rnw-scripts/sample-app-fabric@workspace:packages/sample-app-fabric":
   version: 0.0.0-use.local
   resolution: "@rnw-scripts/sample-app-fabric@workspace:packages/sample-app-fabric"
@@ -16354,34 +16382,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-windows-repo@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "react-native-windows-repo@workspace:."
-  dependencies:
-    "@rnw-scripts/beachball-config": "npm:0.0.0"
-    "@rnw-scripts/format-files": "npm:*"
-    "@rnw-scripts/integrate-rn": "npm:*"
-    "@rnw-scripts/just-task": "npm:*"
-    "@rnw-scripts/prepare-release": "npm:*"
-    "@rnw-scripts/promote-release": "npm:*"
-    "@rnw-scripts/stamp-version": "npm:0.0.0"
-    "@rnw-scripts/take-screenshot": "npm:*"
-    "@rnw-scripts/unbroken": "npm:*"
-    beachball: "npm:^2.20.0"
-    eslint: "npm:^8.19.0"
-    fast-glob: "npm:^3.2.11"
-    husky: "npm:^4.2.5"
-    lage: "npm:^2.7.1"
-    lodash: "npm:^4.17.15"
-    prettier: "npm:^3.6.2"
-    prettier-plugin-hermes-parser: "npm:0.21.1"
-    react: "npm:19.2.3"
-    react-native: "npm:0.85.0-nightly-20260303-c26dbe286"
-    react-native-platform-override: "workspace:*"
-    typescript: "npm:5.0.4"
-  languageName: unknown
-  linkType: soft
-
 "react-native-windows@npm:^0.0.0-canary.1058, react-native-windows@workspace:vnext":
   version: 0.0.0-use.local
   resolution: "react-native-windows@workspace:vnext"
@@ -17913,9 +17913,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@portal:./packages/@rnw-scripts/shims/string_decoder::locator=react-native-windows-repo%40workspace%3A.":
+"string_decoder@portal:./packages/@rnw-scripts/shims/string_decoder::locator=%40rnw-scripts%2Freact-native-windows-repo%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "string_decoder@portal:./packages/@rnw-scripts/shims/string_decoder::locator=react-native-windows-repo%40workspace%3A."
+  resolution: "string_decoder@portal:./packages/@rnw-scripts/shims/string_decoder::locator=%40rnw-scripts%2Freact-native-windows-repo%40workspace%3A."
   languageName: node
   linkType: soft
 


### PR DESCRIPTION
## Description
This PR puts the root package, react-native-windows-repo, under the @rnw-scripts namespace.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Although react-native-windows-repo is marked as a private package, with the recent rise of supply chain attacks, we should be extra careful and put it under a Microsoft owned NPM namespace.

## Testing
PR and CI should pass

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16382)