### PR TITLE
Fix ContentIsland-hosted content rendering at reduced size on scaled displays

### DIFF
--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ContentIslandComponentView.cpp
@@ -68,6 +68,24 @@ void ContentIslandComponentView::ConnectInternal() noexcept {
 
   ChildSiteLink().ActualSize({m_layoutMetrics.frame.size.width, m_layoutMetrics.frame.size.height});
 
+  // The child site reports ShouldApplyRasterizationScale = false: the host is
+  // responsible for applying the island's rasterization scale at presentation.
+  // This placement visual lives in the physical-pixel composition tree, so
+  // without a scale the hosted content lays out at DIP size, rasterizes at
+  // RasterizationScale, and presents unscaled - on a display above 100% scale,
+  // hosted islands render proportionally smaller in the top-left of their
+  // frame (observed with a WebView2-hosted island at 200%: site ActualSize
+  // 1368x728 DIPs, RasterizationScale 2.0, rendered at exactly half size).
+  // Scaling the placement visual by pointScaleFactor is the missing host-side
+  // step; at 100% scale this is Scale(1,1,1), a no-op.
+  {
+    auto placementVisual =
+        winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(Visual())
+            .as<winrt::Microsoft::UI::Composition::ContainerVisual>();
+    const float placementScale = m_layoutMetrics.pointScaleFactor;
+    placementVisual.Scale({placementScale, placementScale, 1.0f});
+  }
+
   // Issue #15557: Set initial LocalToParentTransformMatrix synchronously before Connect.
   // This fixes popup position being wrong even without scrolling.
   // Note: getClientRect() returns physical pixels, but LocalToParentTransformMatrix expects DIPs.


### PR DESCRIPTION
## Summary

Content hosted through `ContentIslandComponentView` (XAML islands via `ChildSiteLink`, e.g. a WebView2) renders at reduced size in the top-left of its frame on any display above 100% scale. At 200% it is exactly half size. The content is otherwise healthy — laid out at the right DIP size and rasterized at the right scale — it is only *presented* unscaled.

## Root cause

Measured live from a production RNW 0.83.2 new-architecture app on a 200% display, by logging the child site's state at `ConnectInternal`:

```
parentScale=1.00  rasterScale=2.00  shouldApplyRasterizationScale=false  actualSize=1368x728  pointScaleFactor=2.00
```

`ShouldApplyRasterizationScale = false` means the **host** owns applying the island's rasterization scale at presentation. But the placement `ContainerVisual` passed to `ChildSiteLink::Create` sits in RNW's physical-pixel composition tree with no scale, so island content lays out at DIP size (1368×728), rasterizes at 2×, and presents at 1× — half size on screen.

Two other candidate fixes were tried first and eliminated on device:

- Scaling `LocalToParentTransformMatrix` — visually inert; that matrix maps coordinates for input/popup placement (issue #15557), not visual presentation.
- `OverrideScale` via `IContentSite` — `ChildSiteLink` does not answer that QI.

## Fix

Scale the placement visual by `pointScaleFactor` before connecting. Content then lays out at DIP size, rasterizes at scale, and presents at scale — full-size and pixel-sharp (raster scale matches presentation scale 1:1, so no resampling blur).

At 100% display scale this is `Scale(1,1,1)` — an identity transform — so configurations already covered by CI are provably unaffected; the change only takes effect where the bug reproduces.

## Validation

Applied to the 0.83.2 package sources in a production app (WebView2-hosted maplibre basemap inside the island):

- Before: island painted exactly half-size in the top-left quadrant at 200% scale ("Invalid visual/content size" also observed via OutputDebugString from sizing churn).
- After: island fills its frame edge to edge, pixel-sharp at 200%; verified across window resizes and repeated island mounts.
- `main` carries the identical placement code at both transform sites, so the defect is live on current heads.

Happy to adjust if you'd prefer the scale applied elsewhere in the island bring-up (e.g. tracked against `DidRasterizationScaleChange` for monitor moves — the current change covers the initial connect, which is where the constant-scale case breaks).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16383)