### PR TITLE
[0.83] Put react-native-windows-repo under @rnw-scripts namespace.

### DIFF
--- a/.ado/templates/msbuild-sln.yml
+++ b/.ado/templates/msbuild-sln.yml
@@ -46,7 +46,6 @@ steps:
         /p:PreferredToolArchitecture=${{parameters.preferredToolArchitecture}}
         /p:PlatformToolset=${{parameters.platformToolset}}
         /p:PublishToolDuringBuild=true
-        /p:RestoreLockedMode=true
         /p:RestoreForceEvaluate=true
         /bl:$(BuildLogDirectory)\MsBuild.binlog
         /flp1:errorsonly;logfile=$(BuildLogDirectory)\MsBuild.err.log

--- a/.ado/templates/msbuild-sln.yml
+++ b/.ado/templates/msbuild-sln.yml
@@ -46,7 +46,7 @@ steps:
         /p:PreferredToolArchitecture=${{parameters.preferredToolArchitecture}}
         /p:PlatformToolset=${{parameters.platformToolset}}
         /p:PublishToolDuringBuild=true
-        /p:RestoreForceEvaluate=true
+        /p:RestoreLockedMode=true
         /bl:$(BuildLogDirectory)\MsBuild.binlog
         /flp1:errorsonly;logfile=$(BuildLogDirectory)\MsBuild.err.log
         /flp2:warningsonly;logfile=$(BuildLogDirectory)\MsBuild.wrn.log

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-windows-repo",
+  "name": "@rnw-scripts/react-native-windows-repo",
   "version": "0.0.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description
This PR puts the root package, react-native-windows-repo, under the @rnw-scripts namespace. Backport of #16382.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Although react-native-windows-repo is marked as a private package, with the recent rise of supply chain attacks, we should be extra careful and put it under a Microsoft owned NPM namespace.

## Testing
PR and CI should pass

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16388)