### PR TITLE
Account for 7 day feed delay

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -56,6 +56,8 @@ steps:
       retryCountOnTaskFailure: 2
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
+        # 0 = no age gate: this installs freshly built first-party packages from Verdaccio.
+        YARN_NPM_MINIMAL_AGE_GATE: 0
 
   - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
@@ -67,6 +69,7 @@ steps:
       retryCountOnTaskFailure: 2
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
+        YARN_NPM_MINIMAL_AGE_GATE: 0
 
   - ${{ if eq(parameters.useExperimentalWinUI3, true) }}:
     - template: ../templates/enable-experimental-winui3.yml

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -56,8 +56,6 @@ steps:
       retryCountOnTaskFailure: 2
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        # 0 = no age gate: this installs freshly built first-party packages from Verdaccio.
-        YARN_NPM_MINIMAL_AGE_GATE: 0
 
   - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
@@ -69,7 +67,6 @@ steps:
       retryCountOnTaskFailure: 2
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        YARN_NPM_MINIMAL_AGE_GATE: 0
 
   - ${{ if eq(parameters.useExperimentalWinUI3, true) }}:
     - template: ../templates/enable-experimental-winui3.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
+# cooldown.default-days: 8 holds lockfile bumps until a version has cleared the
+# ms/react-native-public feed's 7-day upstream quarantine (8 = 7 + 1d margin); newer
+# versions 404 in CI under network isolation. Overrides Dependabot's 3-day default.
 updates:
 # main branch - all dependency updates (minor + patch), daily
 - package-ecosystem: npm
   directory: "/"
   target-branch: "main"
+  cooldown:
+    default-days: 8
   groups:
     all-dependencies:
       patterns:
@@ -24,55 +29,12 @@ updates:
 
 # Stable branches - weekly cadence, 1 grouped PR at a time
 
-# 0.74 branch
-- package-ecosystem: npm
-  directory: "/"
-  target-branch: "0.74-stable"
-  groups:
-    all-dependencies:
-      patterns:
-        - '*'
-      update-types:
-        - 'minor'
-        - 'patch'
-  ignore:
-    # Pin react + react-native + react-test-renderer + @types/react* to the React 18.2 minor used by this branch.
-    # Bumping to 18.3 breaks TS compilation against the React 18.2 runtime.
-    - dependency-name: "react"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "react-native"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "react-test-renderer"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "@types/react"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "@types/react-dom"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-  schedule:
-    interval: weekly
-    time: "05:00"
-    timezone: "America/Los_Angeles"
-  labels:
-  - dependencies
-  versioning-strategy: lockfile-only
-  commit-message:
-    prefix: "📦 [0.74]"
-  open-pull-requests-limit: 1
-
 # 0.81 branch
 - package-ecosystem: npm
   directory: "/"
   target-branch: "0.81-stable"
+  cooldown:
+    default-days: 8
   groups:
     all-dependencies:
       patterns:
@@ -113,54 +75,12 @@ updates:
     prefix: "📦 [0.81]"
   open-pull-requests-limit: 1
 
-# 0.82 branch
-- package-ecosystem: npm
-  directory: "/"
-  target-branch: "0.82-stable"
-  groups:
-    all-dependencies:
-      patterns:
-        - '*'
-      update-types:
-        - 'minor'
-        - 'patch'
-  ignore:
-    # Pin react + react-native + react-test-renderer + @types/react* to the React 19.1 minor used by this branch.
-    - dependency-name: "react"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "react-native"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "react-test-renderer"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "@types/react"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-    - dependency-name: "@types/react-dom"
-      update-types:
-        - "version-update:semver-minor"
-        - "version-update:semver-major"
-  schedule:
-    interval: weekly
-    time: "05:00"
-    timezone: "America/Los_Angeles"
-  labels:
-  - dependencies
-  versioning-strategy: lockfile-only
-  commit-message:
-    prefix: "📦 [0.82]"
-  open-pull-requests-limit: 1
-
 # 0.83 branch
 - package-ecosystem: npm
   directory: "/"
   target-branch: "0.83-stable"
+  cooldown:
+    default-days: 8
   groups:
     all-dependencies:
       patterns:
@@ -205,6 +125,8 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   target-branch: "0.84-stable"
+  cooldown:
+    default-days: 8
   groups:
     all-dependencies:
       patterns:
@@ -243,6 +165,52 @@ updates:
   versioning-strategy: lockfile-only
   commit-message:
     prefix: "📦 [0.84]"
+  open-pull-requests-limit: 1
+
+# 0.85 branch
+- package-ecosystem: npm
+  directory: "/"
+  target-branch: "0.85-stable"
+  cooldown:
+    default-days: 8
+  groups:
+    all-dependencies:
+      patterns:
+        - '*'
+      update-types:
+        - 'minor'
+        - 'patch'
+  ignore:
+    # Pin react + react-native + react-test-renderer + @types/react* to the React 19.2 minor used by this branch.
+    - dependency-name: "react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-native"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "react-test-renderer"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "@types/react"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+    - dependency-name: "@types/react-dom"
+      update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-major"
+  schedule:
+    interval: weekly
+    time: "05:00"
+    timezone: "America/Los_Angeles"
+  labels:
+  - dependencies
+  versioning-strategy: lockfile-only
+  commit-message:
+    prefix: "📦 [0.85]"
   open-pull-requests-limit: 1
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,13 @@ yarnPath: .yarn/releases/yarn-4.13.0.cjs
 
 nodeLinker: node-modules
 
-logFilters:
-  - code: "YN0002"
-    level: "error"
+# Don't pin a version younger than the ms/react-native-public feed's 7-day upstream
+# quarantine (8 = 7 + 1d margin), so yarn.lock only holds versions the feed can serve.
+# First-party packages resolve via workspace: and are exempt; the scopes below also
+# exempt any first-party package fetched from a registry (e.g. canary during release).
+npmMinimalAgeGate: "8d"
+npmPreapprovedPackages:
+  - "react-native-windows"
+  - "@react-native-windows/*"
+  - "@rnw-scripts/*"
+  - "@office-iss/*"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,13 +4,19 @@ yarnPath: .yarn/releases/yarn-4.13.0.cjs
 
 nodeLinker: node-modules
 
+logFilters:
+  - code: "YN0002"
+    level: "error"
+
 # Don't pin a version younger than the ms/react-native-public feed's 7-day upstream
 # quarantine (8 = 7 + 1d margin), so yarn.lock only holds versions the feed can serve.
-# First-party packages resolve via workspace: and are exempt; the scopes below also
-# exempt any first-party package fetched from a registry (e.g. canary during release).
+# Exempt our first-party scopes, plus the upstream react-native family that integrate-rn
+# pins to exact nightlies (the age gate rejects even exact versions).
 npmMinimalAgeGate: "8d"
 npmPreapprovedPackages:
   - "react-native-windows"
   - "@react-native-windows/*"
   - "@rnw-scripts/*"
   - "@office-iss/*"
+  - "react-native"
+  - "@react-native/*"


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Automation (CI/pipeline and Dependabot configuration)

### Why
CI/PR builds now restore packages from the internal `ms/react-native-public` ADO
feed instead of reaching `npmjs.com` / `nuget.org` directly (supply-chain network
isolation). That feed **quarantines every upstream version for 7 days** after its
npmjs publish date. Nothing in the repo accounted for that delay, so as soon as the
lockfile pinned a version younger than 7 days, isolated builds got a **404** trying
to fetch it from the feed — e.g. `@microsoft/api-extractor@7.58.13: Package not
found`.

The fix keeps too-new versions out of the lockfile on every path that writes it.

### What

**Stop Dependabot proposing too-new versions (`.github/dependabot.yml`)**
- Add `cooldown.default-days: 8` to every npm update entry, so Dependabot never bumps
  the lockfile to a version younger than the feed's 7-day quarantine (8 = 7 + 1 day of
  margin). This overrides Dependabot's 3-day default, which is what let a ~4-day-old
  `api-extractor` into the lockfile and 404 in CI.

**Guard local / bot dependency resolves (`.yarnrc.yml`)**
- Set Yarn's `npmMinimalAgeGate: "8d"` so ad-hoc `yarn up` / prepare-release can't pin a
  version the feed can't serve yet. Pre-approve our first-party scopes and the upstream
  `react-native` family — integrate-rn deliberately pins exact nightlies, which the age
  gate would otherwise quarantine for 8 days.

**Align Dependabot with the supported branches (`.github/dependabot.yml`)**
- Match `.ado/README.md`: drop the deprecated `0.74-stable` and `0.82-stable` entries and
  add `0.85-stable` (React 19.2 pin, mirroring 0.84). `0.86`/`0.87` are left out until
  their branches exist.

## Testing
Config-only; no build impact. Confirmed Yarn parses the new `.yarnrc.yml` (the gate reads
back as 8 days) and that the `ms/react-native-public` feed withholds quarantined versions —
so the fix targets the resolve path that actually introduced the bad pin. Dependabot's
cooldown takes effect on its next scheduled run.

## Changelog
Should this change be included in the release notes: no

Dependency-update and CI-configuration hygiene; no user-facing runtime or package change.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16401)