### PR TITLE
[0.81] Skip already-published npm packages on ADO feeds

### DIFF
--- a/.ado/release-pipeline.yml
+++ b/.ado/release-pipeline.yml
@@ -245,6 +245,10 @@ extends:
             pipeline: 'CI'
             artifactName: 'NpmPackedTarballs'
             targetPath: '$(Pipeline.Workspace)/npm-feed-packages'
+          - input: pipelineArtifact
+            pipeline: 'CI'
+            artifactName: 'VersionEnvVars'
+            targetPath: '$(Pipeline.Workspace)/VersionEnvVars'
         steps:
         - template: .ado/templates/publish-npm-to-ado-feed.yml@self
           parameters:
@@ -264,6 +268,10 @@ extends:
             pipeline: 'CI'
             artifactName: 'NpmPackedTarballs'
             targetPath: '$(Pipeline.Workspace)/npm-feed-packages'
+          - input: pipelineArtifact
+            pipeline: 'CI'
+            artifactName: 'VersionEnvVars'
+            targetPath: '$(Pipeline.Workspace)/VersionEnvVars'
         steps:
         - template: .ado/templates/publish-npm-to-ado-feed.yml@self
           parameters:

--- a/.ado/scripts/npmPack.js
+++ b/.ado/scripts/npmPack.js
@@ -5,12 +5,13 @@
  * npmPack.js - Pack all non-private workspace packages to tgz files
  *
  * Usage:
- *   node npmPack.js [targetDir] [--clean] [--check-npm] [--no-pack]
+ *   node npmPack.js [targetDir] [--clean] [--check-npm] [--registry <url>] [--no-pack]
  *
  * Arguments:
  *   targetDir    - Target directory for .tgz files (default: npm-pkgs in repo root)
  *   --clean      - Clean target directory if it's not empty
- *   --check-npm  - Check each package against npmjs.com and remove already published ones
+ *   --check-npm  - Check each package against a registry and remove already published ones
+ *   --registry   - Registry to check against (default: the npm-configured registry)
  *   --no-pack    - Skip packing, only check and clean target folder
  */
 
@@ -64,7 +65,8 @@ Arguments:
 
 Options:
   --clean             Clean target directory if it's not empty
-  --check-npm         Check each package against npmjs.com and remove already published ones
+  --check-npm         Check each package against a registry and remove already published ones
+  --registry <url>    Registry to check against (default: the npm-configured registry)
   --no-pack           Skip packing, only check and clean target folder
   --no-color          Disable colored output
   --help, -h          Show this help message
@@ -74,6 +76,7 @@ Examples:
   node npmPack.js --clean
   node npmPack.js --check-npm
   node npmPack.js --no-pack --check-npm
+  node npmPack.js --no-pack --check-npm --registry https://example/npm/registry/ path/to/output
   node npmPack.js path/to/output
   node npmPack.js --clean --no-color path/to/output
 `);
@@ -209,15 +212,17 @@ function isPrivatePackage(packageJsonPath) {
 }
 
 /**
- * Check if a package version is published on npmjs.com
+ * Check if a package version is already published to the target registry
  * @param {string} packageName - Name of the package
  * @param {string} version - Version to check
+ * @param {string} [registry] - Registry to query (defaults to the npm-configured registry)
  * @returns {boolean} True if the package version is already published
  */
-function isPublishedOnNpm(packageName, version) {
+function isPublishedOnNpm(packageName, version, registry) {
+  const registryArg = registry ? ` --registry ${registry}` : '';
   try {
     // Use npm view to check if the specific version exists
-    execSync(`npm view ${packageName}@${version} version`, {
+    execSync(`npm view ${packageName}@${version} version${registryArg}`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
     });
@@ -261,9 +266,10 @@ function getPackageInfoFromTgz(tgzPath) {
 /**
  * Check and remove already published packages from target directory
  * @param {string} targetDir - Directory containing .tgz files
+ * @param {string} [registry] - Registry to query (defaults to the npm-configured registry)
  * @returns {{checked: number, removed: number}} Statistics about checked and removed packages
  */
-function checkAndRemovePublishedPackages(targetDir) {
+function checkAndRemovePublishedPackages(targetDir, registry) {
   let checkedCount = 0;
   let removedCount = 0;
 
@@ -274,7 +280,8 @@ function checkAndRemovePublishedPackages(targetDir) {
   const files = fs.readdirSync(targetDir);
   const tgzFiles = files.filter(f => f.endsWith('.tgz'));
 
-  console.log(`\n${colorize('Checking packages against npmjs.com...', colors.bright)}`);
+  const target = registry || 'the default npm registry';
+  console.log(`\n${colorize(`Checking packages against ${target}...`, colors.bright)}`);
 
   for (const tgzFile of tgzFiles) {
     const tgzPath = path.join(targetDir, tgzFile);
@@ -290,7 +297,7 @@ function checkAndRemovePublishedPackages(targetDir) {
     checkedCount++;
     console.log(`  Checking ${colorize(packageInfo.name, colors.cyan)}@${colorize(packageInfo.version, colors.dim)}...`);
 
-    if (isPublishedOnNpm(packageInfo.name, packageInfo.version)) {
+    if (isPublishedOnNpm(packageInfo.name, packageInfo.version, registry)) {
       fs.rmSync(tgzPath);
       console.log(`    ${colorize('✓', colors.green)} Already published - removed ${tgzFile}`);
       removedCount++;
@@ -361,6 +368,9 @@ function main() {
       type: 'boolean',
       default: false,
     },
+    registry: {
+      type: 'string',
+    },
   };
 
   let args;
@@ -388,6 +398,7 @@ function main() {
   const cleanFlag = args.values.clean;
   const checkNpmFlag = args.values['check-npm'];
   const noPackFlag = args.values['no-pack'];
+  const registryArg = typeof args.values.registry === 'string' ? args.values.registry : undefined;
   const targetDirArg = args.positionals[0];
 
   try {
@@ -476,7 +487,7 @@ function main() {
     let removedCount = 0;
 
     if (checkNpmFlag) {
-      const result = checkAndRemovePublishedPackages(targetDir);
+      const result = checkAndRemovePublishedPackages(targetDir, registryArg);
       checkedCount = result.checked;
       removedCount = result.removed;
 

--- a/.ado/templates/publish-npm-to-ado-feed.yml
+++ b/.ado/templates/publish-npm-to-ado-feed.yml
@@ -10,6 +10,9 @@ parameters:
   type: string
 - name: feedDisplayName
   type: string
+- name: npmPackScript
+  type: string
+  default: '$(Pipeline.Workspace)/VersionEnvVars/npmPack.js'
 
 steps:
 - task: AzureCLI@2
@@ -27,14 +30,38 @@ steps:
 
 - pwsh: |
     # The .npmrc holds only the ${NPM_FEED_TOKEN} placeholder; npm expands it from the masked env
-    # var at run time, so the raw token never lands in a file. A version already present in the feed
-    # (locally or via its npmjs upstream) returns 409, which we treat as success.
+    # var at run time, so the raw token never lands in a file. The feed registry is set as the
+    # default so the authenticated read below resolves locally published versions (an anonymous
+    # read only sees versions cached from the npmjs upstream).
     $registry = '${{ parameters.npmFeedRegistry }}'
     $key = ($registry -replace '^https?:', '')
     Set-Content -Path (Join-Path $env:USERPROFILE '.npmrc') -Encoding ascii -Value @(
       "registry=$registry"
       "${key}:_authToken=`${NPM_FEED_TOKEN}"
     )
+  displayName: Configure npm auth for ${{ parameters.feedDisplayName }}
+
+- pwsh: Get-ChildItem -Path '${{ parameters.packagesPath }}' -Filter *.tgz -Recurse | Select-Object Name, Length
+  displayName: Show npm packages before cleanup
+
+# Mirror the npmjs.com publish job: drop tarballs whose version already exists in the feed so the
+# publish step never overwrites an immutable version. NPM_CONFIG_REGISTRY points the check at this
+# ADO feed (authenticated via the .npmrc token) so it sees locally published versions, not just the
+# ones cached from the npmjs upstream. Set via env, not --registry, so an older npmPack.js bundled
+# in the CI artifact still honors it.
+- script: node "${{ parameters.npmPackScript }}" --no-pack --check-npm --no-color "${{ parameters.packagesPath }}"
+  displayName: Remove already published packages
+  env:
+    NPM_CONFIG_REGISTRY: ${{ parameters.npmFeedRegistry }}
+    NPM_FEED_TOKEN: $(AdoNpmFeedToken)
+
+- pwsh: Get-ChildItem -Path '${{ parameters.packagesPath }}' -Filter *.tgz -Recurse | Select-Object Name, Length
+  displayName: Show npm packages after cleanup
+
+- pwsh: |
+    # A version already present in the feed (locally or via its npmjs upstream) returns 409, which
+    # we treat as success as a safety net in case one slips past the cleanup step above.
+    $registry = '${{ parameters.npmFeedRegistry }}'
     $tgzs = @(Get-ChildItem -Path '${{ parameters.packagesPath }}' -Filter *.tgz -Recurse)
     Write-Host "Publishing $($tgzs.Count) package(s) to ${{ parameters.feedDisplayName }}"
     $failed = @()


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The Release pipeline's two npm→ADO-feed jobs (`PushNpmPublicAdo`, `PushNpmPrivateAdo`)
`npm publish` every packed tarball and only tolerate an HTTP 409 as "already there." That
isn't reliable, so a release fails whenever a package's version is already on the feed —
which is the normal case, since not every workspace package gets a new version on each
build. The npmjs.com publish job already avoids this by removing already-published
packages first; this brings the ADO feed jobs in line with it.

### What

**Remove already-published packages before the ADO feed publish (`publish-npm-to-ado-feed.yml`)**
- Both ADO npm jobs now run the same `npmPack.js --check-npm` cleanup the npmjs.com job
  uses, dropping any tarball whose version is already on the feed so the publish step never
  tries to overwrite an immutable version. Adds before/after "show packages" steps for
  visibility.
- The check runs **authenticated against the target feed** (registry via
  `NPM_CONFIG_REGISTRY`, auth via the `.npmrc` token), so it sees versions published
  locally to the feed — not just the ones cached from the npmjs upstream, which is all an
  anonymous read resolves.

**Give those jobs the pack script (`release-pipeline.yml`)**
- Added the `VersionEnvVars` artifact (which bundles `npmPack.js`) to both ADO npm jobs so
  the cleanup step can find the script.

**Let the cleanup target a specific registry (`npmPack.js`)**
- Added a `--registry` option so the shared pack/check script can be pointed at a feed
  instead of only the npm-configured default. The pipeline targets the feed via
  `NPM_CONFIG_REGISTRY` (kept env-based so an older `npmPack.js` bundled in a prior CI
  artifact still honors it).

## Testing
Exercised through the Release pipeline's npm→ADO feed publish jobs; the cleanup step runs
and the publish step only sees new versions.

## Changelog
Should this change be included in the release notes: no

Release-pipeline-only change; no user-facing runtime or package behavior change.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16406)