### PR TITLE
[0.81] Fix e2e x86 flakiness

### DIFF
--- a/change/@react-native-windows-automation-channel-3a71601c-04a0-4e14-aef2-6204fb0755db.json
+++ b/change/@react-native-windows-automation-channel-3a71601c-04a0-4e14-aef2-6204fb0755db.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Try fixing the e2e x86 test flakiness",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation-channel/src/automationChannel.ts
+++ b/packages/@react-native-windows/automation-channel/src/automationChannel.ts
@@ -120,10 +120,14 @@ export class AutomationClient {
     }
 
     switch (response.type) {
-      // The server only ever sends responses; ignore stray request/notification
-      // frames rather than throwing out of the socket handler.
+      // The server only ever sends responses; a request/notification frame means
+      // the stream is out of sync, so fail all in-flight requests rather than
+      // silently ignore it (invoke has no timeout).
       case RpcStatusType.request:
       case RpcStatusType.notification:
+        this.failAllPendingRequests(
+          new Error('Unexpected JSON-RPC message from server'),
+        );
         return;
 
       case RpcStatusType.invalid: {

--- a/packages/@react-native-windows/automation-channel/src/automationChannel.ts
+++ b/packages/@react-native-windows/automation-channel/src/automationChannel.ts
@@ -85,13 +85,16 @@ export class AutomationClient {
       const messageBuffer = this.receiveBuffer.subarray(4, totalLength);
       this.receiveBuffer = this.receiveBuffer.subarray(totalLength);
 
-      // A single bad message must not tear down the receive loop.
+      // One bad frame can't be tied to a specific request, so fail every
+      // in-flight request rather than let any hang forever (invoke has no timeout).
       try {
         this.onMessage(messageBuffer);
       } catch (err) {
-        console.error(
-          'Unexpected error handling automation-channel message: ' +
-            (err instanceof Error ? err.message : String(err)),
+        this.failAllPendingRequests(
+          new Error(
+            'Unexpected error handling automation-channel message: ' +
+              (err instanceof Error ? err.message : String(err)),
+          ),
         );
       }
     }
@@ -110,7 +113,9 @@ export class AutomationClient {
   private onMessage(message: Buffer) {
     const response = jsonrpc.parseJsonRpcString(message.toString('utf8'));
     if (Array.isArray(response)) {
-      console.error('Ignoring unexpected JSON-RPC batch response');
+      this.failAllPendingRequests(
+        new Error('Unexpected JSON-RPC batch response'),
+      );
       return;
     }
 
@@ -156,13 +161,28 @@ export class AutomationClient {
   }
 
   private rejectPendingRequest(id: any, err: Error) {
-    const pendingReq =
-      id === undefined ? undefined : this.pendingRequests.get(id);
+    if (id === undefined) {
+      // No id to attribute the failure to; fail every in-flight request so none
+      // hang (invoke has no timeout).
+      this.failAllPendingRequests(err);
+      return;
+    }
+
+    const pendingReq = this.pendingRequests.get(id);
     if (pendingReq) {
       this.pendingRequests.delete(id);
       pendingReq(null, err);
     } else {
+      // Recoverable id, but already settled (stale/duplicate) — ignore.
       console.error(err.message);
+    }
+  }
+
+  private failAllPendingRequests(err: Error) {
+    const pending = Array.from(this.pendingRequests.values());
+    this.pendingRequests.clear();
+    for (const req of pending) {
+      req(null, err);
     }
   }
 }

--- a/packages/@react-native-windows/automation-channel/src/automationChannel.ts
+++ b/packages/@react-native-windows/automation-channel/src/automationChannel.ts
@@ -154,10 +154,21 @@ export class AutomationClient {
       }
 
       case RpcStatusType.error: {
-        const pendingReq = this.pendingRequests.get(response.payload.id);
+        const id = response.payload.id;
+        const pendingReq =
+          id === null ? undefined : this.pendingRequests.get(id);
         if (pendingReq) {
-          this.pendingRequests.delete(response.payload.id);
+          this.pendingRequests.delete(id);
           pendingReq({type: 'error', ...response.payload.error}, null);
+        } else if (id === null) {
+          // A null id means the server couldn't attribute the error to a
+          // request (e.g. a parse error on our stream); fail all so none hang.
+          this.failAllPendingRequests(
+            new Error(
+              'JSON-RPC error with null id: ' +
+                JSON.stringify(response.payload.error),
+            ),
+          );
         }
         return;
       }
@@ -165,7 +176,7 @@ export class AutomationClient {
   }
 
   private rejectPendingRequest(id: any, err: Error) {
-    if (id === undefined) {
+    if (id === undefined || id === null) {
       // No id to attribute the failure to; fail every in-flight request so none
       // hang (invoke has no timeout).
       this.failAllPendingRequests(err);

--- a/packages/@react-native-windows/automation-channel/src/automationChannel.ts
+++ b/packages/@react-native-windows/automation-channel/src/automationChannel.ts
@@ -176,9 +176,9 @@ export class AutomationClient {
   }
 
   private rejectPendingRequest(id: any, err: Error) {
-    if (id === undefined || id === null) {
-      // No id to attribute the failure to; fail every in-flight request so none
-      // hang (invoke has no timeout).
+    // This client only issues numeric ids, so a non-numeric id can't match a
+    // pending request; treat it as unattributable and fail all (invoke has no timeout).
+    if (typeof id !== 'number') {
       this.failAllPendingRequests(err);
       return;
     }
@@ -188,7 +188,7 @@ export class AutomationClient {
       this.pendingRequests.delete(id);
       pendingReq(null, err);
     } else {
-      // Recoverable id, but already settled (stale/duplicate) — ignore.
+      // Valid numeric id, but already settled (stale/duplicate) — ignore.
       console.error(err.message);
     }
   }

--- a/packages/@react-native-windows/automation-channel/src/automationChannel.ts
+++ b/packages/@react-native-windows/automation-channel/src/automationChannel.ts
@@ -71,20 +71,28 @@ export class AutomationClient {
 
   private onData(chunk: Buffer) {
     this.receiveBuffer = Buffer.concat([this.receiveBuffer, chunk]);
-    if (this.receiveBuffer.length >= 4) {
+
+    // Localhost TCP can coalesce responses into one chunk, so drain every
+    // complete frame and advance past it; stopping after one leaves later
+    // responses stuck behind it and wedges the channel.
+    while (this.receiveBuffer.length >= 4) {
       const messageLength = this.receiveBuffer.readUInt32LE();
       const totalLength = messageLength + 4;
+      if (this.receiveBuffer.length < totalLength) {
+        break;
+      }
 
-      if (this.receiveBuffer.length >= totalLength) {
-        const messageBuffer = this.receiveBuffer.slice(4, totalLength);
+      const messageBuffer = this.receiveBuffer.subarray(4, totalLength);
+      this.receiveBuffer = this.receiveBuffer.subarray(totalLength);
 
-        if (totalLength < this.receiveBuffer.length) {
-          this.receiveBuffer = Buffer.from(this.receiveBuffer, totalLength);
-        } else {
-          this.receiveBuffer = Buffer.alloc(0);
-        }
-
+      // A single bad message must not tear down the receive loop.
+      try {
         this.onMessage(messageBuffer);
+      } catch (err) {
+        console.error(
+          'Unexpected error handling automation-channel message: ' +
+            (err instanceof Error ? err.message : String(err)),
+        );
       }
     }
   }
@@ -102,41 +110,59 @@ export class AutomationClient {
   private onMessage(message: Buffer) {
     const response = jsonrpc.parseJsonRpcString(message.toString('utf8'));
     if (Array.isArray(response)) {
-      throw new Error('Expected single message');
+      console.error('Ignoring unexpected JSON-RPC batch response');
+      return;
     }
 
     switch (response.type) {
+      // The server only ever sends responses; ignore stray request/notification
+      // frames rather than throwing out of the socket handler.
       case RpcStatusType.request:
-        throw new Error('Received JSON-RPC request instead of response');
       case RpcStatusType.notification:
-        throw new Error('Unexpected JSON-RPC notification');
-      case RpcStatusType.invalid:
-        throw new Error(
-          'Invalid JSON-RPC2 response: ' +
-            JSON.stringify(response.payload, null, 2),
+        return;
+
+      case RpcStatusType.invalid: {
+        // jsonrpc-lite keeps the raw response under `data`; use its id to reject
+        // the matching request so its caller fails fast instead of hanging.
+        const rawId = (response.payload as any)?.data?.id;
+        this.rejectPendingRequest(
+          rawId,
+          new Error(
+            'Invalid JSON-RPC2 response: ' +
+              JSON.stringify(response.payload, null, 2),
+          ),
         );
+        return;
+      }
 
       case RpcStatusType.success: {
         const pendingReq = this.pendingRequests.get(response.payload.id);
-        if (!pendingReq) {
-          throw new Error('Could not find pending request from response ID');
+        if (pendingReq) {
+          this.pendingRequests.delete(response.payload.id);
+          pendingReq({type: 'success', result: response.payload.result}, null);
         }
-
-        this.pendingRequests.delete(response.payload.id);
-        pendingReq({type: 'success', result: response.payload.result}, null);
-        break;
+        return;
       }
 
       case RpcStatusType.error: {
         const pendingReq = this.pendingRequests.get(response.payload.id);
-        if (!pendingReq) {
-          throw new Error('Could not find pending request from response ID');
+        if (pendingReq) {
+          this.pendingRequests.delete(response.payload.id);
+          pendingReq({type: 'error', ...response.payload.error}, null);
         }
-
-        this.pendingRequests.delete(response.payload.id);
-        pendingReq({type: 'error', ...response.payload.error}, null);
-        break;
+        return;
       }
+    }
+  }
+
+  private rejectPendingRequest(id: any, err: Error) {
+    const pendingReq =
+      id === undefined ? undefined : this.pendingRequests.get(id);
+    if (pendingReq) {
+      this.pendingRequests.delete(id);
+      pendingReq(null, err);
+    } else {
+      console.error(err.message);
     }
   }
 }

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.cpp
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.cpp
@@ -89,8 +89,7 @@ IAsyncOperation<IJsonValue> CommandHandler::Invoke(const winrt::hstring &methodN
 
   // Falling through without co_return would yield a null result, which serializes
   // into a malformed response; surface a proper error instead.
-  throw winrt::hresult_invalid_argument(
-      L"No automation-channel handler registered for method '" + methodName + L"'");
+  throw winrt::hresult_invalid_argument(L"No automation-channel handler registered for method '" + methodName + L"'");
 }
 
 } // namespace winrt::AutomationChannel::implementation

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.cpp
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.cpp
@@ -86,6 +86,11 @@ IAsyncOperation<IJsonValue> CommandHandler::Invoke(const winrt::hstring &methodN
     auto result = co_await asyncOperation->second(params);
     co_return result;
   }
+
+  // Falling through without co_return would yield a null result, which serializes
+  // into a malformed response; surface a proper error instead.
+  throw winrt::hresult_invalid_argument(
+      L"No automation-channel handler registered for method '" + methodName + L"'");
 }
 
 } // namespace winrt::AutomationChannel::implementation

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.cpp
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.cpp
@@ -87,8 +87,7 @@ IAsyncOperation<IJsonValue> CommandHandler::Invoke(const winrt::hstring &methodN
     co_return result;
   }
 
-  // Falling through without co_return would yield a null result, which serializes
-  // into a malformed response; surface a proper error instead.
+  // Unknown methods surface as JSON-RPC MethodNotFound in the request processor; this guards direct callers.
   throw winrt::hresult_invalid_argument(L"No automation-channel handler registered for method '" + methodName + L"'");
 }
 

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.idl
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CommandHandler.idl
@@ -19,6 +19,8 @@ namespace AutomationChannel {
         CommandHandler BindOperation(String methodName, SyncOperation operation);
         CommandHandler BindAsyncOperation(String methodName, AsyncOperation operation);
 
+        Boolean IsMethodRegistered(String methodName);
+
         // May throw on delegate error
         Windows.Foundation.IAsyncOperation<Windows.Data.Json.IJsonValue> Invoke(String methodName, Windows.Data.Json.JsonValue params);
     };

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/JsonRpcRequestProcessor.cpp
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/JsonRpcRequestProcessor.cpp
@@ -29,7 +29,13 @@ winrt::fire_and_forget JsonRpcRequestProcessor::HandleRequest(
   winrt::hstring errorMessage;
 
   try {
-    auto result = co_await handler.Invoke(message.GetNamedString(L"method"), message.GetNamedValue(L"params"));
+    auto method = message.GetNamedString(L"method");
+    if (!handler.IsMethodRegistered(method)) {
+      co_await EmitError(
+          JsonRpcErrorCode::MethodNotFound, L"Method not found: " + method, message.GetNamedValue(L"id"), output);
+      co_return;
+    }
+    auto result = co_await handler.Invoke(method, message.GetNamedValue(L"params"));
     co_await EmitResult(result, message.GetNamedValue(L"id"), output);
     co_return;
   } catch (const winrt::hresult_error &ex) {

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/JsonRpcRequestProcessor.cpp
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/JsonRpcRequestProcessor.cpp
@@ -70,6 +70,11 @@ IAsyncAction JsonRpcRequestProcessor::EmitError(
 
 IAsyncAction JsonRpcRequestProcessor::EmitResult(IJsonValue result, JsonValue id, IOutputStream output) noexcept {
   JsonObject res;
+  // A null result must still serialize as "result": null. SetNamedValue with a
+  // null value drops the key, producing a response the client rejects as invalid.
+  if (!result) {
+    result = JsonValue::CreateNullValue();
+  }
   res.SetNamedValue(L"result", result);
   co_await EmitResponse(res, id, output);
 }

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/JsonRpcRequestProcessor.cpp
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/JsonRpcRequestProcessor.cpp
@@ -68,10 +68,14 @@ IAsyncAction JsonRpcRequestProcessor::EmitError(
     winrt::hstring message,
     JsonValue id,
     IOutputStream output) noexcept {
-  JsonObject err;
-  err.SetNamedValue(L"code", JsonValue::CreateNumberValue(static_cast<int32_t>(code)));
-  err.SetNamedValue(L"message", JsonValue::CreateStringValue(message));
-  co_await EmitResponse(err, id, output);
+  JsonObject error;
+  error.SetNamedValue(L"code", JsonValue::CreateNumberValue(static_cast<int32_t>(code)));
+  error.SetNamedValue(L"message", JsonValue::CreateStringValue(message));
+
+  // JSON-RPC 2.0 requires code/message under an "error" member; at top level the client rejects it as invalid.
+  JsonObject res;
+  res.SetNamedValue(L"error", error);
+  co_await EmitResponse(res, id, output);
 }
 
 IAsyncAction JsonRpcRequestProcessor::EmitResult(IJsonValue result, JsonValue id, IOutputStream output) noexcept {


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
On the x86 Hermes end-to-end leg, the `LegacyTextHitTestTest` suite failed all 15
tests — each hitting the 70 s timeout (~18 min total) with an opaque
`Invalid JSON-RPC2 response` and no crash — which intermittently hard-blocked
unrelated PRs from merging. Root cause: one automation-channel command returned a
null result, which serialized into a malformed JSON-RPC response, and a latent
framing bug in the client then wedged the whole session so every later request timed
out. These changes harden the channel so a null or malformed response fails a single
test cleanly instead of cascading across the suite.

### What

**Serialize command results safely (`JsonRpcRequestProcessor.cpp`)**
- A command that returns nothing produced a null WinRT value that `Stringify()`
  drops, so the app sent a response with no `result` and no `error` — which the
  client rejects as invalid. A null result now serializes as `"result": null`, a
  valid success.

**Harden the client receive loop (`automationChannel.ts`)**
- Drain every framed response in the buffer (localhost TCP coalesces them) and
  advance past each one; the old code processed only the first frame and could
  re-parse a stale frame forever. A malformed or unmatched response now fails just
  its own request instead of throwing out of the socket handler and wedging the whole
  session. When a frame can't be tied to a request — no recoverable id, or a stray
  request/notification from a response-only server — every in-flight request is failed
  rather than left to hang.

**Return well-formed JSON-RPC errors (`CommandHandler.*`, `JsonRpcRequestProcessor.cpp`)**
- An unregistered method used to fall through to a null result; the request
  processor now checks registration and returns `MethodNotFound` (`-32601`). Error
  responses also wrap `code`/`message` under an `error` member — they were emitted at
  the top level, which the client rejects as invalid — so callers get a structured
  error instead of a generic `Invalid JSON-RPC2` rejection.

## Testing
Validated the client locally (package build + lint, plus a fake-socket harness
covering malformed, coalesced, and split frames); the native changes and the x86
Hermes e2e leg are exercised in CI.

## Changelog
Should this change be included in the release notes: no

Hardening for the internal e2e automation channel; no user-facing runtime or API
behavior change. (The `@react-native-windows/automation-channel` package still gets a
patch entry from the change file.)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/16407)